### PR TITLE
Explain node summary

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -281,6 +281,9 @@ int			gp_hashagg_groups_per_bucket = 5;
 /* Analyzing aid */
 int			gp_motion_slice_noop = 0;
 
+/* Greenplum Database EXPLAIN Feature GUCs */
+bool		gp_enable_explain_node_summary = FALSE;
+
 /* Greenplum Database Experimental Feature GUCs */
 int			gp_distinct_grouping_sets_threshold = 32;
 bool		gp_enable_explain_rows_out = FALSE;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -892,6 +892,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
+		{"gp_enable_explain_node_summary", PGC_USERSET, CLIENT_CONN_OTHER,
+			gettext_noop("Dump CdbExplain_NodeSummary for every node in EXPLAIN ANALYZE."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&gp_enable_explain_node_summary,
+		false,
+		NULL, NULL, NULL
+	},
+
+	{
 		{"gp_enable_sort_limit", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable LIMIT operation to be performed while sorting."),
 			gettext_noop("Sort more efficiently when plan requires the first <n> rows at most.")

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -754,6 +754,12 @@ extern bool gp_enable_explain_rows_out;
  */
 extern bool gp_enable_explain_allstat;
 
+/* May Greenplum dump node summary from CdbExplain_NodeSummary
+ * during EXPLAIN ANALYZE?
+ *
+ */
+extern bool gp_enable_explain_node_summary;
+
 /* May Greenplum restrict ORDER BY sorts to the first N rows if the ORDER BY
  * is wrapped by a LIMIT clause (where N=OFFSET+LIMIT)?
  *

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -174,6 +174,7 @@
 		"gp_enable_exchange_default_partition",
 		"gp_enable_explain_rows_out",
 		"gp_enable_explain_allstat",
+		"gp_enable_explain_node_summary",
 		"gp_enable_fast_sri",
 		"gp_enable_global_deadlock_detector",
 		"gp_enable_gpperfmon",

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -349,6 +349,50 @@ explain analyze SELECT * FROM explaintest;
 (8 rows)
 
 set gp_enable_explain_rows_out=DEFAULT;
+-- Test explain node summary.
+set gp_enable_explain_node_summary=on;
+explain analyze SELECT * FROM explaintest;
+                                                                                                               QUERY PLAN                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=10 width=4) (actual time=0.476..0.484 rows=10 loops=1)
+   Node Summary:                  vmax       vsum       vcnt       imax
+     ntuples:                       10         10          1         -1
+     execmemused:                    0          0          0          0
+     workmemused:                    0          0          0          0
+     workmemwanted:                  0          0          0          0
+     totalWorkfileCreated:           0          0          0          0
+     peakMemBalance:              5336       5336          1         -1
+     totalPartTableScanned:          0          0          0          0
+     segindex0: -1
+     ninst: 1
+     StatInsts:
+       (segN) pstype starttime counter firsttuple startup total ntuples nloops execmemused workmemused workmemwanted workfileCreated firststart peakMemBalance numPartScanned sortMethod sortSpaceType sortSpaceUsed bnotes enotes
+       (seg-1) 241 0.00 0.00 0.00 10.00 1.00 0 0 0 0 0 0 5336.00 0 0 0 0 0 0 0
+   ->  Seq Scan on explaintest  (cost=0.00..431.00 rows=4 width=4) (actual time=0.017..0.018 rows=5 loops=1)
+         Node Summary:                  vmax       vsum       vcnt       imax
+           ntuples:                        5         10          3          0
+           execmemused:                    0          0          0          0
+           workmemused:                    0          0          0          0
+           workmemwanted:                  0          0          0          0
+           totalWorkfileCreated:           0          0          0          0
+           peakMemBalance:             15872      47616          3          0
+           totalPartTableScanned:          0          0          0          0
+           segindex0: 0
+           ninst: 3
+           StatInsts:
+             (segN) pstype starttime counter firsttuple startup total ntuples nloops execmemused workmemused workmemwanted workfileCreated firststart peakMemBalance numPartScanned sortMethod sortSpaceType sortSpaceUsed bnotes enotes
+             (seg0) 211 0.00 0.00 0.00 5.00 1.00 0 0 0 0 0 0 15872.00 0 0 0 0 0 0 0
+             (seg1) 211 0.00 0.00 0.00 1.00 1.00 0 0 0 0 0 0 15872.00 0 0 0 0 0 0 0
+             (seg2) 211 0.00 0.00 0.00 4.00 1.00 0 0 0 0 0 0 15872.00 0 0 0 0 0 0 0
+ Planning time: 6.834 ms
+   (slice0)    Executor memory: 27K bytes.
+   (slice1)    Executor memory: 25K bytes avg x 3 workers, 25K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 0.900 ms
+(36 rows)
+
+set gp_enable_explain_node_summary=DEFAULT;
 --
 -- Test output of EXPLAIN ANALYZE for Bitmap index scan's actual rows.
 --

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -380,6 +380,50 @@ explain analyze SELECT * FROM explaintest;
 (8 rows)
 
 set gp_enable_explain_rows_out=DEFAULT;
+-- Test explain node summary.
+set gp_enable_explain_node_summary=on;
+explain analyze SELECT * FROM explaintest;
+                                                                                                               QUERY PLAN                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=10 width=4) (actual time=0.476..0.484 rows=10 loops=1)
+   Node Summary:                  vmax       vsum       vcnt       imax
+     ntuples:                       10         10          1         -1
+     execmemused:                    0          0          0          0
+     workmemused:                    0          0          0          0
+     workmemwanted:                  0          0          0          0
+     totalWorkfileCreated:           0          0          0          0
+     peakMemBalance:              5336       5336          1         -1
+     totalPartTableScanned:          0          0          0          0
+     segindex0: -1
+     ninst: 1
+     StatInsts:
+       (segN) pstype starttime counter firsttuple startup total ntuples nloops execmemused workmemused workmemwanted workfileCreated firststart peakMemBalance numPartScanned sortMethod sortSpaceType sortSpaceUsed bnotes enotes
+       (seg-1) 241 0.00 0.00 0.00 10.00 1.00 0 0 0 0 0 0 5336.00 0 0 0 0 0 0 0
+   ->  Seq Scan on explaintest  (cost=0.00..431.00 rows=4 width=4) (actual time=0.017..0.018 rows=5 loops=1)
+         Node Summary:                  vmax       vsum       vcnt       imax
+           ntuples:                        5         10          3          0
+           execmemused:                    0          0          0          0
+           workmemused:                    0          0          0          0
+           workmemwanted:                  0          0          0          0
+           totalWorkfileCreated:           0          0          0          0
+           peakMemBalance:             15872      47616          3          0
+           totalPartTableScanned:          0          0          0          0
+           segindex0: 0
+           ninst: 3
+           StatInsts:
+             (segN) pstype starttime counter firsttuple startup total ntuples nloops execmemused workmemused workmemwanted workfileCreated firststart peakMemBalance numPartScanned sortMethod sortSpaceType sortSpaceUsed bnotes enotes
+             (seg0) 211 0.00 0.00 0.00 5.00 1.00 0 0 0 0 0 0 15872.00 0 0 0 0 0 0 0
+             (seg1) 211 0.00 0.00 0.00 1.00 1.00 0 0 0 0 0 0 15872.00 0 0 0 0 0 0 0
+             (seg2) 211 0.00 0.00 0.00 4.00 1.00 0 0 0 0 0 0 15872.00 0 0 0 0 0 0 0
+ Planning time: 6.834 ms
+   (slice0)    Executor memory: 27K bytes.
+   (slice1)    Executor memory: 25K bytes avg x 3 workers, 25K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 0.900 ms
+(36 rows)
+
+set gp_enable_explain_node_summary=DEFAULT;
 --
 -- Test output of EXPLAIN ANALYZE for Bitmap index scan's actual rows.
 --

--- a/src/test/regress/sql/gp_explain.sql
+++ b/src/test/regress/sql/gp_explain.sql
@@ -161,6 +161,11 @@ set gp_enable_explain_rows_out=on;
 explain analyze SELECT * FROM explaintest;
 set gp_enable_explain_rows_out=DEFAULT;
 
+-- Test explain node summary.
+set gp_enable_explain_node_summary=on;
+explain analyze SELECT * FROM explaintest;
+set gp_enable_explain_node_summary=DEFAULT;
+
 --
 -- Test output of EXPLAIN ANALYZE for Bitmap index scan's actual rows.
 --


### PR DESCRIPTION
Dumps CdbExplain_NodeSummary struct in EXPLAIN ANALYZE

`set gp_enable_explain_node_summary=on;`

`drop table if exists tt; create table tt (a int, b int) distributed randomly;`

`explain (analyze,verbose) insert into tt select * from generate_series(1,1000)a,generate_series(1,1000)b;`

`explain (analyze,verbose) select * from tt where a > b;`

```
                                                                                                               QUERY PLAN                                                                                                                
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=33.612..78.159 rows=1000 loops=1)
   Output: a, b
   Node Summary:                  vmax       vsum       vcnt       imax
     ntuples:                     1000       1000          1         -1
     execmemused:                    0          0          0          0
     workmemused:                    0          0          0          0
     workmemwanted:                  0          0          0          0
     totalWorkfileCreated:           0          0          0          0
     peakMemBalance:             44592      44592          1         -1
     totalPartTableScanned:          0          0          0          0
     segindex0: -1
     ninst: 1
     StatInsts:
       (segN) pstype starttime counter firsttuple startup total ntuples nloops execmemused workmemused workmemwanted workfileCreated firststart peakMemBalance numPartScanned sortMethod sortSpaceType sortSpaceUsed bnotes enotes
       (seg-1) 241 0.00 0.03 0.08 1000.00 1.00 0 0 0 0 0 0 44592.00 0 0 0 0 0 0 0
   ->  Seq Scan on public.tt  (cost=0.00..431.00 rows=1 width=8) (actual time=2.512..77.640 rows=353 loops=1)
         Output: a, b
         Filter: (tt.a = 100)
         Node Summary:                  vmax       vsum       vcnt       imax
           ntuples:                      353       1000          3          0
           execmemused:                    0          0          0          0
           workmemused:                    0          0          0          0
           workmemwanted:                  0          0          0          0
           totalWorkfileCreated:           0          0          0          0
           peakMemBalance:             19072      57216          3          0
           totalPartTableScanned:          0          0          0          0
           segindex0: 0
           ninst: 3
           StatInsts:
             (segN) pstype starttime counter firsttuple startup total ntuples nloops execmemused workmemused workmemwanted workfileCreated firststart peakMemBalance numPartScanned sortMethod sortSpaceType sortSpaceUsed bnotes enotes
             (seg0) 211 0.00 0.00 0.08 353.00 1.00 0 0 0 0 0 0 19072.00 0 0 0 0 0 0 0
             (seg1) 211 0.00 0.00 0.03 330.00 1.00 0 0 0 0 0 0 19072.00 0 0 0 0 0 0 0
             (seg2) 211 0.00 0.00 0.05 317.00 1.00 0 0 0 0 0 0 19072.00 0 0 0 0 0 0 0
 Planning time: 4.514 ms
   (slice0)    Executor memory: 119K bytes.
   (slice1)    Executor memory: 27K bytes avg x 3 workers, 27K bytes max (seg0).
 Memory used:  128000kB
 Optimizer: Pivotal Optimizer (GPORCA)
 Execution time: 78.584 ms
(39 rows)
```


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
