### PR TITLE
Fix description of the vacuum_assign_compaction_segno function

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -446,7 +446,7 @@ vacuum(VacuumStmt *vacstmt, Oid relid, bool do_toast,
 /*
  * Assigns the compaction segment information.
  *
- * The segment to compact is returned in *compact_segno, and
+ * The segments to compact are returned in **compactNowList, and
  * the segment to move rows to, is returned in *insert_segno.
  */
 static bool


### PR DESCRIPTION
The function has no compact_segno argument. It returns list of segments to compact, but not one segment.