### PR TITLE
Convert datatype cast functions for "soft" error handling

### DIFF
--- a/contrib/hstore/hstore.h
+++ b/contrib/hstore/hstore.h
@@ -6,6 +6,7 @@
 
 #include "fmgr.h"
 #include "utils/array.h"
+#include "nodes/nodes.h"
 
 
 /*
@@ -171,7 +172,9 @@ typedef struct
 extern int	hstoreUniquePairs(Pairs *a, int32 l, int32 *buflen);
 extern HStore *hstorePairs(Pairs *pairs, int32 pcount, int32 buflen);
 
+extern bool hstoreCheckKeyLenSafe(size_t len, size_t *result, Node *escontext);
 extern size_t hstoreCheckKeyLen(size_t len);
+extern bool hstoreCheckValLenSafe(size_t len, size_t *result, Node *escontext);
 extern size_t hstoreCheckValLen(size_t len);
 
 extern int	hstoreFindKey(HStore *hs, int *lowbound, char *key, int keylen);

--- a/src/backend/utils/adt/bool.c
+++ b/src/backend/utils/adt/bool.c
@@ -148,7 +148,7 @@ boolin(PG_FUNCTION_ARGS)
 	if (parse_bool_with_len(str, len, &result))
 		PG_RETURN_BOOL(result);
 
-	ereport(ERROR,
+	PG_ERETURN(fcinfo->context,
 			(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
 		   errmsg("invalid input syntax for type boolean: \"%s\"", in_str)));
 

--- a/src/backend/utils/adt/char.c
+++ b/src/backend/utils/adt/char.c
@@ -164,7 +164,7 @@ i4tochar(PG_FUNCTION_ARGS)
 	int32		arg1 = PG_GETARG_INT32(0);
 
 	if (arg1 < SCHAR_MIN || arg1 > SCHAR_MAX)
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("\"char\" out of range")));
 

--- a/src/backend/utils/adt/date.c
+++ b/src/backend/utils/adt/date.c
@@ -48,8 +48,8 @@ static void AdjustTimeForTypmod(TimeADT *time, int32 typmod);
 
 
 /* common code for timetypmodin and timetztypmodin */
-static int32
-anytime_typmodin(bool istz, ArrayType *ta)
+static bool
+anytime_typmodin_safe(bool istz, ArrayType *ta, int32 *result, Node *escontext)
 {
 	int32		typmod;
 	int32	   *tl;
@@ -62,12 +62,12 @@ anytime_typmodin(bool istz, ArrayType *ta)
 	 * shouldn't allow wrong number of modifiers for TIME
 	 */
 	if (n != 1)
-		ereport(ERROR,
+		ereturn(escontext, false,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("invalid type modifier")));
 
 	if (*tl < 0)
-		ereport(ERROR,
+		ereturn(escontext, false,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("TIME(%d)%s precision must not be negative",
 						*tl, (istz ? " WITH TIME ZONE" : ""))));
@@ -83,7 +83,16 @@ anytime_typmodin(bool istz, ArrayType *ta)
 	else
 		typmod = *tl;
 
-	return typmod;
+	*result = typmod;
+	return true;
+}
+
+static int32
+anytime_typmodin(bool istz, ArrayType *ta)
+{
+	int32 result;
+	(void) anytime_typmodin_safe(istz, ta, &result, NULL);
+	return result;
 }
 
 /* common code for timetypmodout and timetztypmodout */
@@ -126,9 +135,9 @@ date_in(PG_FUNCTION_ARGS)
 	dterr = ParseDateTime(str, workbuf, sizeof(workbuf),
 						  field, ftype, MAXDATEFIELDS, &nf);
 	if (dterr == 0)
-		dterr = DecodeDateTime(field, ftype, nf, &dtype, tm, &fsec, &tzp);
+		PG_SAFE_CALL(DecodeDateTimeSafe, (field, ftype, nf, &dtype, tm, &fsec, &tzp, &dterr, fcinfo->context));
 	if (dterr != 0)
-		DateTimeParseError(dterr, str, "date");
+		PG_SAFE_CALL(DateTimeParseErrorSafe, (dterr, str, "date", fcinfo->context));
 
 	switch (dtype)
 	{
@@ -136,7 +145,7 @@ date_in(PG_FUNCTION_ARGS)
 			break;
 
 		case DTK_CURRENT:
-			ereport(ERROR,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 			  errmsg("date/time value \"current\" is no longer supported")));
 
@@ -156,12 +165,13 @@ date_in(PG_FUNCTION_ARGS)
 			PG_RETURN_DATEADT(date);
 
 		default:
-			DateTimeParseError(DTERR_BAD_FORMAT, str, "date");
+			PG_SAFE_CALL(DateTimeParseErrorSafe, (DTERR_BAD_FORMAT, str, "date", fcinfo->context));
+			PG_RETURN_NULL();
 			break;
 	}
 
 	if (!IS_VALID_JULIAN(tm->tm_year, tm->tm_mon, tm->tm_mday))
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("date out of range: \"%s\"", str)));
 
@@ -211,7 +221,7 @@ date_recv(PG_FUNCTION_ARGS)
 		 /* ok */ ;
 	else if (result < -POSTGRES_EPOCH_JDATE ||
 			 result >= JULIAN_MAX - POSTGRES_EPOCH_JDATE)
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("date out of range")));
 
@@ -253,13 +263,13 @@ make_date(PG_FUNCTION_ARGS)
 	dterr = ValidateDate(DTK_DATE_M, false, false, false, &tm);
 
 	if (dterr != 0)
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_FIELD_OVERFLOW),
 				 errmsg("date field value out of range: %d-%02d-%02d",
 						tm.tm_year, tm.tm_mon, tm.tm_mday)));
 
 	if (!IS_VALID_JULIAN(tm.tm_year, tm.tm_mon, tm.tm_mday))
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("date out of range: %d-%02d-%02d",
 						tm.tm_year, tm.tm_mon, tm.tm_mday)));
@@ -412,7 +422,7 @@ date_mi(PG_FUNCTION_ARGS)
 	DateADT		dateVal2 = PG_GETARG_DATEADT(1);
 
 	if (DATE_NOT_FINITE(dateVal1) || DATE_NOT_FINITE(dateVal2))
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("cannot subtract infinite dates")));
 
@@ -452,9 +462,8 @@ date_mii(PG_FUNCTION_ARGS)
  * Internal routines for promoting date to timestamp and timestamp with
  * time zone
  */
-
-static Timestamp
-date2timestamp(DateADT dateVal)
+static bool
+date2timestamp_safe(DateADT dateVal, Timestamp *res, Node *escontext)
 {
 	Timestamp	result;
 
@@ -469,7 +478,7 @@ date2timestamp(DateADT dateVal)
 		result = dateVal * USECS_PER_DAY;
 		/* Date's range is wider than timestamp's, so check for overflow */
 		if (result / USECS_PER_DAY != dateVal)
-			ereport(ERROR,
+			ereturn(escontext, false,
 					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 					 errmsg("date out of range for timestamp")));
 #else
@@ -478,11 +487,20 @@ date2timestamp(DateADT dateVal)
 #endif
 	}
 
+	*res = result;
+	return true;
+}
+
+static Timestamp
+date2timestamp(DateADT dateVal)
+{
+	Timestamp result;
+	(void) date2timestamp_safe(dateVal, &result, NULL);
 	return result;
 }
 
-static TimestampTz
-date2timestamptz(DateADT dateVal)
+static bool
+date2timestamptz_safe(DateADT dateVal, TimestampTz *res, Node *escontext)
 {
 	TimestampTz result;
 	struct pg_tm tt,
@@ -506,7 +524,7 @@ date2timestamptz(DateADT dateVal)
 		result = dateVal * USECS_PER_DAY + tz * USECS_PER_SEC;
 		/* Date's range is wider than timestamp's, so check for overflow */
 		if ((result - tz * USECS_PER_SEC) / USECS_PER_DAY != dateVal)
-			ereport(ERROR,
+			ereturn(escontext, false,
 					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 					 errmsg("date out of range for timestamp")));
 #else
@@ -514,6 +532,15 @@ date2timestamptz(DateADT dateVal)
 #endif
 	}
 
+	*res = result;
+	return true;
+}
+
+static TimestampTz
+date2timestamptz(DateADT dateVal)
+{
+	TimestampTz result;
+	(void) date2timestamptz_safe(dateVal, &result, NULL);
 	return result;
 }
 
@@ -562,7 +589,7 @@ date_eq_timestamp(PG_FUNCTION_ARGS)
 	Timestamp	dt2 = PG_GETARG_TIMESTAMP(1);
 	Timestamp	dt1;
 
-	dt1 = date2timestamp(dateVal);
+	PG_SAFE_CALL(date2timestamp_safe, (dateVal, &dt1, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamp_cmp_internal(dt1, dt2) == 0);
 }
@@ -574,7 +601,7 @@ date_ne_timestamp(PG_FUNCTION_ARGS)
 	Timestamp	dt2 = PG_GETARG_TIMESTAMP(1);
 	Timestamp	dt1;
 
-	dt1 = date2timestamp(dateVal);
+	PG_SAFE_CALL(date2timestamp_safe, (dateVal, &dt1, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamp_cmp_internal(dt1, dt2) != 0);
 }
@@ -586,7 +613,7 @@ date_lt_timestamp(PG_FUNCTION_ARGS)
 	Timestamp	dt2 = PG_GETARG_TIMESTAMP(1);
 	Timestamp	dt1;
 
-	dt1 = date2timestamp(dateVal);
+	PG_SAFE_CALL(date2timestamp_safe, (dateVal, &dt1, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamp_cmp_internal(dt1, dt2) < 0);
 }
@@ -598,7 +625,7 @@ date_gt_timestamp(PG_FUNCTION_ARGS)
 	Timestamp	dt2 = PG_GETARG_TIMESTAMP(1);
 	Timestamp	dt1;
 
-	dt1 = date2timestamp(dateVal);
+	PG_SAFE_CALL(date2timestamp_safe, (dateVal, &dt1, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamp_cmp_internal(dt1, dt2) > 0);
 }
@@ -610,7 +637,7 @@ date_le_timestamp(PG_FUNCTION_ARGS)
 	Timestamp	dt2 = PG_GETARG_TIMESTAMP(1);
 	Timestamp	dt1;
 
-	dt1 = date2timestamp(dateVal);
+	PG_SAFE_CALL(date2timestamp_safe, (dateVal, &dt1, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamp_cmp_internal(dt1, dt2) <= 0);
 }
@@ -622,7 +649,7 @@ date_ge_timestamp(PG_FUNCTION_ARGS)
 	Timestamp	dt2 = PG_GETARG_TIMESTAMP(1);
 	Timestamp	dt1;
 
-	dt1 = date2timestamp(dateVal);
+	PG_SAFE_CALL(date2timestamp_safe, (dateVal, &dt1, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamp_cmp_internal(dt1, dt2) >= 0);
 }
@@ -634,7 +661,7 @@ date_cmp_timestamp(PG_FUNCTION_ARGS)
 	Timestamp	dt2 = PG_GETARG_TIMESTAMP(1);
 	Timestamp	dt1;
 
-	dt1 = date2timestamp(dateVal);
+	PG_SAFE_CALL(date2timestamp_safe, (dateVal, &dt1, fcinfo->context));
 
 	PG_RETURN_INT32(timestamp_cmp_internal(dt1, dt2));
 }
@@ -646,7 +673,7 @@ date_eq_timestamptz(PG_FUNCTION_ARGS)
 	TimestampTz dt2 = PG_GETARG_TIMESTAMPTZ(1);
 	TimestampTz dt1;
 
-	dt1 = date2timestamptz(dateVal);
+	PG_SAFE_CALL(date2timestamptz_safe, (dateVal, &dt1, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamptz_cmp_internal(dt1, dt2) == 0);
 }
@@ -658,7 +685,7 @@ date_ne_timestamptz(PG_FUNCTION_ARGS)
 	TimestampTz dt2 = PG_GETARG_TIMESTAMPTZ(1);
 	TimestampTz dt1;
 
-	dt1 = date2timestamptz(dateVal);
+	PG_SAFE_CALL(date2timestamptz_safe, (dateVal, &dt1, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamptz_cmp_internal(dt1, dt2) != 0);
 }
@@ -670,7 +697,7 @@ date_lt_timestamptz(PG_FUNCTION_ARGS)
 	TimestampTz dt2 = PG_GETARG_TIMESTAMPTZ(1);
 	TimestampTz dt1;
 
-	dt1 = date2timestamptz(dateVal);
+	PG_SAFE_CALL(date2timestamptz_safe, (dateVal, &dt1, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamptz_cmp_internal(dt1, dt2) < 0);
 }
@@ -682,7 +709,7 @@ date_gt_timestamptz(PG_FUNCTION_ARGS)
 	TimestampTz dt2 = PG_GETARG_TIMESTAMPTZ(1);
 	TimestampTz dt1;
 
-	dt1 = date2timestamptz(dateVal);
+	PG_SAFE_CALL(date2timestamptz_safe, (dateVal, &dt1, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamptz_cmp_internal(dt1, dt2) > 0);
 }
@@ -694,7 +721,7 @@ date_le_timestamptz(PG_FUNCTION_ARGS)
 	TimestampTz dt2 = PG_GETARG_TIMESTAMPTZ(1);
 	TimestampTz dt1;
 
-	dt1 = date2timestamptz(dateVal);
+	PG_SAFE_CALL(date2timestamptz_safe, (dateVal, &dt1, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamptz_cmp_internal(dt1, dt2) <= 0);
 }
@@ -706,7 +733,7 @@ date_ge_timestamptz(PG_FUNCTION_ARGS)
 	TimestampTz dt2 = PG_GETARG_TIMESTAMPTZ(1);
 	TimestampTz dt1;
 
-	dt1 = date2timestamptz(dateVal);
+	PG_SAFE_CALL(date2timestamptz_safe, (dateVal, &dt1, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamptz_cmp_internal(dt1, dt2) >= 0);
 }
@@ -718,7 +745,7 @@ date_cmp_timestamptz(PG_FUNCTION_ARGS)
 	TimestampTz dt2 = PG_GETARG_TIMESTAMPTZ(1);
 	TimestampTz dt1;
 
-	dt1 = date2timestamptz(dateVal);
+	PG_SAFE_CALL(date2timestamptz_safe, (dateVal, &dt1, fcinfo->context));
 
 	PG_RETURN_INT32(timestamptz_cmp_internal(dt1, dt2));
 }
@@ -730,7 +757,7 @@ timestamp_eq_date(PG_FUNCTION_ARGS)
 	DateADT		dateVal = PG_GETARG_DATEADT(1);
 	Timestamp	dt2;
 
-	dt2 = date2timestamp(dateVal);
+	PG_SAFE_CALL(date2timestamp_safe, (dateVal, &dt2, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamp_cmp_internal(dt1, dt2) == 0);
 }
@@ -742,7 +769,7 @@ timestamp_ne_date(PG_FUNCTION_ARGS)
 	DateADT		dateVal = PG_GETARG_DATEADT(1);
 	Timestamp	dt2;
 
-	dt2 = date2timestamp(dateVal);
+	PG_SAFE_CALL(date2timestamp_safe, (dateVal, &dt2, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamp_cmp_internal(dt1, dt2) != 0);
 }
@@ -754,7 +781,7 @@ timestamp_lt_date(PG_FUNCTION_ARGS)
 	DateADT		dateVal = PG_GETARG_DATEADT(1);
 	Timestamp	dt2;
 
-	dt2 = date2timestamp(dateVal);
+	PG_SAFE_CALL(date2timestamp_safe, (dateVal, &dt2, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamp_cmp_internal(dt1, dt2) < 0);
 }
@@ -766,7 +793,7 @@ timestamp_gt_date(PG_FUNCTION_ARGS)
 	DateADT		dateVal = PG_GETARG_DATEADT(1);
 	Timestamp	dt2;
 
-	dt2 = date2timestamp(dateVal);
+	PG_SAFE_CALL(date2timestamp_safe, (dateVal, &dt2, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamp_cmp_internal(dt1, dt2) > 0);
 }
@@ -778,7 +805,7 @@ timestamp_le_date(PG_FUNCTION_ARGS)
 	DateADT		dateVal = PG_GETARG_DATEADT(1);
 	Timestamp	dt2;
 
-	dt2 = date2timestamp(dateVal);
+	PG_SAFE_CALL(date2timestamp_safe, (dateVal, &dt2, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamp_cmp_internal(dt1, dt2) <= 0);
 }
@@ -790,7 +817,7 @@ timestamp_ge_date(PG_FUNCTION_ARGS)
 	DateADT		dateVal = PG_GETARG_DATEADT(1);
 	Timestamp	dt2;
 
-	dt2 = date2timestamp(dateVal);
+	PG_SAFE_CALL(date2timestamp_safe, (dateVal, &dt2, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamp_cmp_internal(dt1, dt2) >= 0);
 }
@@ -802,7 +829,7 @@ timestamp_cmp_date(PG_FUNCTION_ARGS)
 	DateADT		dateVal = PG_GETARG_DATEADT(1);
 	Timestamp	dt2;
 
-	dt2 = date2timestamp(dateVal);
+	PG_SAFE_CALL(date2timestamp_safe, (dateVal, &dt2, fcinfo->context));
 
 	PG_RETURN_INT32(timestamp_cmp_internal(dt1, dt2));
 }
@@ -814,7 +841,7 @@ timestamptz_eq_date(PG_FUNCTION_ARGS)
 	DateADT		dateVal = PG_GETARG_DATEADT(1);
 	TimestampTz dt2;
 
-	dt2 = date2timestamptz(dateVal);
+	PG_SAFE_CALL(date2timestamptz_safe, (dateVal, &dt2, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamptz_cmp_internal(dt1, dt2) == 0);
 }
@@ -826,7 +853,7 @@ timestamptz_ne_date(PG_FUNCTION_ARGS)
 	DateADT		dateVal = PG_GETARG_DATEADT(1);
 	TimestampTz dt2;
 
-	dt2 = date2timestamptz(dateVal);
+	PG_SAFE_CALL(date2timestamptz_safe, (dateVal, &dt2, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamptz_cmp_internal(dt1, dt2) != 0);
 }
@@ -838,7 +865,7 @@ timestamptz_lt_date(PG_FUNCTION_ARGS)
 	DateADT		dateVal = PG_GETARG_DATEADT(1);
 	TimestampTz dt2;
 
-	dt2 = date2timestamptz(dateVal);
+	PG_SAFE_CALL(date2timestamptz_safe, (dateVal, &dt2, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamptz_cmp_internal(dt1, dt2) < 0);
 }
@@ -850,7 +877,7 @@ timestamptz_gt_date(PG_FUNCTION_ARGS)
 	DateADT		dateVal = PG_GETARG_DATEADT(1);
 	TimestampTz dt2;
 
-	dt2 = date2timestamptz(dateVal);
+	PG_SAFE_CALL(date2timestamptz_safe, (dateVal, &dt2, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamptz_cmp_internal(dt1, dt2) > 0);
 }
@@ -862,7 +889,7 @@ timestamptz_le_date(PG_FUNCTION_ARGS)
 	DateADT		dateVal = PG_GETARG_DATEADT(1);
 	TimestampTz dt2;
 
-	dt2 = date2timestamptz(dateVal);
+	PG_SAFE_CALL(date2timestamptz_safe, (dateVal, &dt2, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamptz_cmp_internal(dt1, dt2) <= 0);
 }
@@ -874,7 +901,7 @@ timestamptz_ge_date(PG_FUNCTION_ARGS)
 	DateADT		dateVal = PG_GETARG_DATEADT(1);
 	TimestampTz dt2;
 
-	dt2 = date2timestamptz(dateVal);
+	PG_SAFE_CALL(date2timestamptz_safe, (dateVal, &dt2, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamptz_cmp_internal(dt1, dt2) >= 0);
 }
@@ -886,7 +913,7 @@ timestamptz_cmp_date(PG_FUNCTION_ARGS)
 	DateADT		dateVal = PG_GETARG_DATEADT(1);
 	TimestampTz dt2;
 
-	dt2 = date2timestamptz(dateVal);
+	PG_SAFE_CALL(date2timestamptz_safe, (dateVal, &dt2, fcinfo->context));
 
 	PG_RETURN_INT32(timestamptz_cmp_internal(dt1, dt2));
 }
@@ -905,7 +932,7 @@ date_pl_interval(PG_FUNCTION_ARGS)
 	Interval   *span = PG_GETARG_INTERVAL_P(1);
 	Timestamp	dateStamp;
 
-	dateStamp = date2timestamp(dateVal);
+	PG_SAFE_CALL(date2timestamp_safe, (dateVal, &dateStamp, fcinfo->context));
 
 	return DirectFunctionCall2(timestamp_pl_interval,
 							   TimestampGetDatum(dateStamp),
@@ -925,7 +952,7 @@ date_mi_interval(PG_FUNCTION_ARGS)
 	Interval   *span = PG_GETARG_INTERVAL_P(1);
 	Timestamp	dateStamp;
 
-	dateStamp = date2timestamp(dateVal);
+	PG_SAFE_CALL(date2timestamp_safe, (dateVal, &dateStamp, fcinfo->context));
 
 	return DirectFunctionCall2(timestamp_mi_interval,
 							   TimestampGetDatum(dateStamp),
@@ -941,7 +968,7 @@ date_timestamp(PG_FUNCTION_ARGS)
 	DateADT		dateVal = PG_GETARG_DATEADT(0);
 	Timestamp	result;
 
-	result = date2timestamp(dateVal);
+	PG_SAFE_CALL(date2timestamp_safe, (dateVal, &result, fcinfo->context));
 
 	PG_RETURN_TIMESTAMP(result);
 }
@@ -965,7 +992,7 @@ timestamp_date(PG_FUNCTION_ARGS)
 	else
 	{
 		if (timestamp2tm(timestamp, NULL, tm, &fsec, NULL, NULL) != 0)
-			ereport(ERROR,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 					 errmsg("timestamp out of range")));
 
@@ -985,7 +1012,7 @@ date_timestamptz(PG_FUNCTION_ARGS)
 	DateADT		dateVal = PG_GETARG_DATEADT(0);
 	TimestampTz result;
 
-	result = date2timestamptz(dateVal);
+	PG_SAFE_CALL(date2timestamptz_safe, (dateVal, &result, fcinfo->context));
 
 	PG_RETURN_TIMESTAMP(result);
 }
@@ -1011,7 +1038,7 @@ timestamptz_date(PG_FUNCTION_ARGS)
 	else
 	{
 		if (timestamp2tm(timestamp, &tz, tm, &fsec, NULL, NULL) != 0)
-			ereport(ERROR,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 					 errmsg("timestamp out of range")));
 
@@ -1037,7 +1064,7 @@ abstime_date(PG_FUNCTION_ARGS)
 	switch (abstime)
 	{
 		case INVALID_ABSTIME:
-			ereport(ERROR,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				   errmsg("cannot convert reserved abstime value to date")));
 			result = 0;			/* keep compiler quiet */
@@ -1089,9 +1116,9 @@ time_in(PG_FUNCTION_ARGS)
 	dterr = ParseDateTime(str, workbuf, sizeof(workbuf),
 						  field, ftype, MAXDATEFIELDS, &nf);
 	if (dterr == 0)
-		dterr = DecodeTimeOnly(field, ftype, nf, &dtype, tm, &fsec, &tz);
+		PG_SAFE_CALL(DecodeTimeOnlySafe, (field, ftype, nf, &dtype, tm, &fsec, &tz, &dterr, fcinfo->context));
 	if (dterr != 0)
-		DateTimeParseError(dterr, str, "time");
+		PG_SAFE_CALL(DateTimeParseErrorSafe, (dterr, str, "time", fcinfo->context));
 
 	tm2time(tm, fsec, &result);
 	AdjustTimeForTypmod(&result, typmod);
@@ -1191,14 +1218,14 @@ time_recv(PG_FUNCTION_ARGS)
 	result = pq_getmsgint64(buf);
 
 	if (result < INT64CONST(0) || result > USECS_PER_DAY)
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("time out of range")));
 #else
 	result = pq_getmsgfloat8(buf);
 
 	if (result < 0 || result > (double) SECS_PER_DAY)
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("time out of range")));
 #endif
@@ -1231,7 +1258,12 @@ timetypmodin(PG_FUNCTION_ARGS)
 {
 	ArrayType  *ta = PG_GETARG_ARRAYTYPE_P(0);
 
-	PG_RETURN_INT32(anytime_typmodin(false, ta));
+	int32 typmod;
+
+	if (!anytime_typmodin_safe(false, ta, &typmod, fcinfo->context))
+		PG_RETURN_NULL();
+
+	PG_RETURN_INT32(typmod);
 }
 
 Datum
@@ -1259,7 +1291,7 @@ make_time(PG_FUNCTION_ARGS)
 		tm_hour > HOURS_PER_DAY ||
 	/* test for > 24:00:00 */
 		(tm_hour == HOURS_PER_DAY && (tm_min > 0 || sec > 0)))
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_FIELD_OVERFLOW),
 				 errmsg("time field value out of range: %d:%02d:%02g",
 						tm_hour, tm_min, sec)));
@@ -1611,7 +1643,7 @@ timestamp_time(PG_FUNCTION_ARGS)
 		PG_RETURN_NULL();
 
 	if (timestamp2tm(timestamp, NULL, tm, &fsec, NULL, NULL) != 0)
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("timestamp out of range")));
 
@@ -1647,7 +1679,7 @@ timestamptz_time(PG_FUNCTION_ARGS)
 		PG_RETURN_NULL();
 
 	if (timestamp2tm(timestamp, &tz, tm, &fsec, NULL, NULL) != 0)
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("timestamp out of range")));
 
@@ -1676,7 +1708,7 @@ datetime_timestamp(PG_FUNCTION_ARGS)
 	TimeADT		time = PG_GETARG_TIMEADT(1);
 	Timestamp	result;
 
-	result = date2timestamp(date);
+	PG_SAFE_CALL(date2timestamp_safe, (date, &result, fcinfo->context));
 	if (!TIMESTAMP_NOT_FINITE(result))
 		result += time;
 
@@ -1961,7 +1993,7 @@ time_part(PG_FUNCTION_ARGS)
 			case DTK_MILLENNIUM:
 			case DTK_ISOYEAR:
 			default:
-				ereport(ERROR,
+				PG_ERETURN(fcinfo->context,
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						 errmsg("\"time\" units \"%s\" not recognized",
 								lowunits)));
@@ -1978,7 +2010,7 @@ time_part(PG_FUNCTION_ARGS)
 	}
 	else
 	{
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("\"time\" units \"%s\" not recognized",
 						lowunits)));
@@ -2034,9 +2066,9 @@ timetz_in(PG_FUNCTION_ARGS)
 	dterr = ParseDateTime(str, workbuf, sizeof(workbuf),
 						  field, ftype, MAXDATEFIELDS, &nf);
 	if (dterr == 0)
-		dterr = DecodeTimeOnly(field, ftype, nf, &dtype, tm, &fsec, &tz);
+		PG_SAFE_CALL(DecodeTimeOnlySafe, (field, ftype, nf, &dtype, tm, &fsec, &tz, &dterr, fcinfo->context));
 	if (dterr != 0)
-		DateTimeParseError(dterr, str, "time with time zone");
+		PG_SAFE_CALL(DateTimeParseErrorSafe, (dterr, str, "time with time zone", fcinfo->context));
 
 	result = (TimeTzADT *) palloc(sizeof(TimeTzADT));
 	tm2timetz(tm, fsec, tz, result);
@@ -2083,14 +2115,14 @@ timetz_recv(PG_FUNCTION_ARGS)
 	result->time = pq_getmsgint64(buf);
 
 	if (result->time < INT64CONST(0) || result->time > USECS_PER_DAY)
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("time out of range")));
 #else
 	result->time = pq_getmsgfloat8(buf);
 
 	if (result->time < 0 || result->time > (double) SECS_PER_DAY)
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("time out of range")));
 #endif
@@ -2099,7 +2131,7 @@ timetz_recv(PG_FUNCTION_ARGS)
 
 	/* Check for sane GMT displacement; see notes in datatype/timestamp.h */
 	if (result->zone <= -TZDISP_LIMIT || result->zone >= TZDISP_LIMIT)
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_INVALID_TIME_ZONE_DISPLACEMENT_VALUE),
 				 errmsg("time zone displacement out of range")));
 
@@ -2132,7 +2164,12 @@ timetztypmodin(PG_FUNCTION_ARGS)
 {
 	ArrayType  *ta = PG_GETARG_ARRAYTYPE_P(0);
 
-	PG_RETURN_INT32(anytime_typmodin(true, ta));
+	int32 typmod;
+
+	if (!anytime_typmodin_safe(false, ta, &typmod, fcinfo->context))
+		PG_RETURN_NULL();
+
+	PG_RETURN_INT32(typmod);
 }
 
 Datum
@@ -2593,7 +2630,7 @@ timestamptz_timetz(PG_FUNCTION_ARGS)
 		PG_RETURN_NULL();
 
 	if (timestamp2tm(timestamp, &tz, tm, &fsec, NULL, NULL) != 0)
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("timestamp out of range")));
 
@@ -2723,7 +2760,7 @@ timetz_part(PG_FUNCTION_ARGS)
 			case DTK_CENTURY:
 			case DTK_MILLENNIUM:
 			default:
-				ereport(ERROR,
+				PG_ERETURN(fcinfo->context,
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				errmsg("\"time with time zone\" units \"%s\" not recognized",
 					   lowunits)));
@@ -2740,7 +2777,7 @@ timetz_part(PG_FUNCTION_ARGS)
 	}
 	else
 	{
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("\"time with time zone\" units \"%s\" not recognized",
 						lowunits)));
@@ -2782,7 +2819,7 @@ timetz_zone(PG_FUNCTION_ARGS)
 										   strlen(tzname),
 										   false);
 
-	type = DecodeTimezoneAbbrev(0, lowzone, &val, &tzp);
+	PG_SAFE_CALL(DecodeTimezoneAbbrevSafe, (0, lowzone, &val, &tzp, &type, fcinfo->context));
 
 	if (type == TZ || type == DTZ)
 	{
@@ -2813,7 +2850,7 @@ timetz_zone(PG_FUNCTION_ARGS)
 		}
 		else
 		{
-			ereport(ERROR,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("time zone \"%s\" not recognized", tzname)));
 			tz = 0;				/* keep compiler quiet */
@@ -2853,7 +2890,7 @@ timetz_izone(PG_FUNCTION_ARGS)
 	int			tz;
 
 	if (zone->month != 0 || zone->day != 0)
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 		  errmsg("interval time zone \"%s\" must not include months or days",
 				 DatumGetCString(DirectFunctionCall1(interval_out,

--- a/src/backend/utils/adt/datetime.c
+++ b/src/backend/utils/adt/datetime.c
@@ -69,6 +69,7 @@ static bool DetermineTimeZoneAbbrevOffsetInternal(pg_time_t t,
 									  const char *abbr, pg_tz *tzp,
 									  int *offset, int *isdst);
 static pg_tz *FetchDynamicTimeZone(TimeZoneAbbrevTable *tbl, const datetkn *tp);
+static bool FetchDynamicTimeZoneSafe(TimeZoneAbbrevTable *tbl, const datetkn *tp, pg_tz **result, Node *escontext);
 
 
 const int	day_tab[2][13] =
@@ -801,6 +802,15 @@ int
 DecodeDateTime(char **field, int *ftype, int nf,
 			   int *dtype, struct pg_tm * tm, fsec_t *fsec, int *tzp)
 {
+	int result;
+	(void) DecodeDateTimeSafe(field, ftype, nf, dtype, tm, fsec, tzp, &result, NULL);
+	return result;
+}
+
+bool
+DecodeDateTimeSafe(char **field, int *ftype, int nf,
+			   int *dtype, struct pg_tm * tm, fsec_t *fsec, int *tzp, int *result, Node *escontext)
+{
 	int			fmask = 0,
 				tmask,
 				type;
@@ -849,21 +859,27 @@ DecodeDateTime(char **field, int *ftype, int nf,
 					char	   *cp;
 					int			val;
 
-					if (tzp == NULL)
-						return DTERR_BAD_FORMAT;
+					if (tzp == NULL) {
+						*result = DTERR_BAD_FORMAT;
+						return true;
+					}
 
 					errno = 0;
 					val = strtoint(field[i], &cp, 10);
-					if (errno == ERANGE || val < 0)
-						return DTERR_FIELD_OVERFLOW;
+					if (errno == ERANGE || val < 0) {
+						*result = DTERR_FIELD_OVERFLOW;
+						return true;
+					}
 
 					j2date(val, &tm->tm_year, &tm->tm_mon, &tm->tm_mday);
 					isjulian = TRUE;
 
 					/* Get the time zone from the end of the string */
 					dterr = DecodeTimezone(cp, tzp);
-					if (dterr)
-						return dterr;
+					if (dterr) {
+						*result = dterr;
+						return true;
+					}
 
 					tmask = DTK_DATE_M | DTK_TIME_M | DTK_M(TZ);
 					ptype = 0;
@@ -885,8 +901,10 @@ DecodeDateTime(char **field, int *ftype, int nf,
 						  (DTK_M(MONTH) | DTK_M(DAY))))
 				{
 					/* No time zone accepted? Then quit... */
-					if (tzp == NULL)
-						return DTERR_BAD_FORMAT;
+					if (tzp == NULL) {
+						*result = DTERR_BAD_FORMAT;
+						return true;
+					}
 
 					if (isdigit((unsigned char) *field[i]) || ptype != 0)
 					{
@@ -895,8 +913,10 @@ DecodeDateTime(char **field, int *ftype, int nf,
 						if (ptype != 0)
 						{
 							/* Sanity check; should not fail this test */
-							if (ptype != DTK_TIME)
-								return DTERR_BAD_FORMAT;
+							if (ptype != DTK_TIME) {
+								*result = DTERR_BAD_FORMAT;
+								return true;
+							}
 							ptype = 0;
 						}
 
@@ -905,16 +925,22 @@ DecodeDateTime(char **field, int *ftype, int nf,
 						 * field? Then we are in trouble with a date and time
 						 * already...
 						 */
-						if ((fmask & DTK_TIME_M) == DTK_TIME_M)
-							return DTERR_BAD_FORMAT;
+						if ((fmask & DTK_TIME_M) == DTK_TIME_M) {
+							*result = DTERR_BAD_FORMAT;
+							return true;
+						}
 
-						if ((cp = strchr(field[i], '-')) == NULL)
-							return DTERR_BAD_FORMAT;
+						if ((cp = strchr(field[i], '-')) == NULL) {
+							*result = DTERR_BAD_FORMAT;
+							return true;
+						}
 
 						/* Get the time zone from the end of the string */
 						dterr = DecodeTimezone(cp, tzp);
-						if (dterr)
-							return dterr;
+						if (dterr) {
+							*result = dterr;
+							return true;
+						}
 						*cp = '\0';
 
 						/*
@@ -925,8 +951,10 @@ DecodeDateTime(char **field, int *ftype, int nf,
 												  fmask,
 												  &tmask, tm,
 												  fsec, &is2digits);
-						if (dterr < 0)
-							return dterr;
+						if (dterr < 0) {
+							*result = dterr;
+							return true;
+						}
 
 						/*
 						 * modify tmask after returning from
@@ -944,7 +972,7 @@ DecodeDateTime(char **field, int *ftype, int nf,
 							 * ereport'ing directly, but then there is no way
 							 * to report the bad time zone name.
 							 */
-							ereport(ERROR,
+							ereturn(escontext, false,
 									(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 									 errmsg("time zone \"%s\" not recognized",
 											field[i])));
@@ -957,8 +985,10 @@ DecodeDateTime(char **field, int *ftype, int nf,
 				{
 					dterr = DecodeDate(field[i], fmask,
 									   &tmask, &is2digits, tm);
-					if (dterr)
-						return dterr;
+					if (dterr) {
+						*result = dterr;
+						return true;
+					}
 				}
 				break;
 
@@ -970,14 +1000,18 @@ DecodeDateTime(char **field, int *ftype, int nf,
 				if (ptype != 0)
 				{
 					/* Sanity check; should not fail this test */
-					if (ptype != DTK_TIME)
-						return DTERR_BAD_FORMAT;
+					if (ptype != DTK_TIME) {
+						*result = DTERR_BAD_FORMAT;
+						return true;
+					}
 					ptype = 0;
 				}
 				dterr = DecodeTime(field[i], fmask, INTERVAL_FULL_RANGE,
 								   &tmask, tm, fsec);
-				if (dterr)
-					return dterr;
+				if (dterr) {
+					*result = dterr;
+					return true;
+				}
 
 				/*
 				 * Check upper limit on hours; other limits checked in
@@ -986,20 +1020,26 @@ DecodeDateTime(char **field, int *ftype, int nf,
 				/* test for > 24:00:00 */
 				if (tm->tm_hour > HOURS_PER_DAY ||
 					(tm->tm_hour == HOURS_PER_DAY &&
-					 (tm->tm_min > 0 || tm->tm_sec > 0 || *fsec > 0)))
-					return DTERR_FIELD_OVERFLOW;
+					 (tm->tm_min > 0 || tm->tm_sec > 0 || *fsec > 0))) {
+					*result = DTERR_FIELD_OVERFLOW;
+					return true;
+				}
 				break;
 
 			case DTK_TZ:
 				{
 					int			tz;
 
-					if (tzp == NULL)
-						return DTERR_BAD_FORMAT;
+					if (tzp == NULL) {
+						*result = DTERR_BAD_FORMAT;
+						return true;
+					}
 
 					dterr = DecodeTimezone(field[i], &tz);
-					if (dterr)
-						return dterr;
+					if (dterr) {
+						*result = dterr;
+						return true;
+					}
 					*tzp = tz;
 					tmask = DTK_M(TZ);
 				}
@@ -1018,8 +1058,10 @@ DecodeDateTime(char **field, int *ftype, int nf,
 
 					errno = 0;
 					val = strtoint(field[i], &cp, 10);
-					if (errno == ERANGE)
-						return DTERR_FIELD_OVERFLOW;
+					if (errno == ERANGE) {
+						*result = DTERR_FIELD_OVERFLOW;
+						return true;
+					}
 
 					/*
 					 * only a few kinds are allowed to have an embedded
@@ -1033,11 +1075,14 @@ DecodeDateTime(char **field, int *ftype, int nf,
 							case DTK_SECOND:
 								break;
 							default:
-								return DTERR_BAD_FORMAT;
+								*result = DTERR_BAD_FORMAT;
+								return true;
 								break;
 						}
-					else if (*cp != '\0')
-						return DTERR_BAD_FORMAT;
+					else if (*cp != '\0') {
+						*result = DTERR_BAD_FORMAT;
+						return true;
+					}
 
 					switch (ptype)
 					{
@@ -1086,8 +1131,10 @@ DecodeDateTime(char **field, int *ftype, int nf,
 							if (*cp == '.')
 							{
 								dterr = ParseFractionalSecond(cp, fsec);
-								if (dterr)
-									return dterr;
+								if (dterr) {
+									*result = dterr;
+									return true;
+								}
 								tmask = DTK_ALL_SECS_M;
 							}
 							break;
@@ -1095,14 +1142,18 @@ DecodeDateTime(char **field, int *ftype, int nf,
 						case DTK_TZ:
 							tmask = DTK_M(TZ);
 							dterr = DecodeTimezone(field[i], tzp);
-							if (dterr)
-								return dterr;
+							if (dterr) {
+								*result = dterr;
+								return true;
+							}
 							break;
 
 						case DTK_JULIAN:
 							/* previous field was a label for "julian date" */
-							if (val < 0)
-								return DTERR_FIELD_OVERFLOW;
+							if (val < 0) {
+								*result = DTERR_FIELD_OVERFLOW;
+								return true;
+							}
 							tmask = DTK_DATE_M;
 							j2date(val, &tm->tm_year, &tm->tm_mon, &tm->tm_mday);
 							isjulian = TRUE;
@@ -1114,8 +1165,10 @@ DecodeDateTime(char **field, int *ftype, int nf,
 
 								errno = 0;
 								time = strtod(cp, &cp);
-								if (*cp != '\0' || errno != 0)
-									return DTERR_BAD_FORMAT;
+								if (*cp != '\0' || errno != 0) {
+									*result = DTERR_BAD_FORMAT;
+									return true;
+								}
 
 #ifdef HAVE_INT64_TIMESTAMP
 								time *= USECS_PER_DAY;
@@ -1135,14 +1188,19 @@ DecodeDateTime(char **field, int *ftype, int nf,
 													  (fmask | DTK_DATE_M),
 													  &tmask, tm,
 													  fsec, &is2digits);
-							if (dterr < 0)
-								return dterr;
-							if (tmask != DTK_TIME_M)
-								return DTERR_BAD_FORMAT;
+							if (dterr < 0) {
+								*result = dterr;
+								return true;
+							}
+							if (tmask != DTK_TIME_M) {
+								*result = DTERR_BAD_FORMAT;
+								return true;
+							}
 							break;
 
 						default:
-							return DTERR_BAD_FORMAT;
+							*result = DTERR_BAD_FORMAT;
+							return true;
 							break;
 					}
 
@@ -1165,8 +1223,10 @@ DecodeDateTime(char **field, int *ftype, int nf,
 					{
 						dterr = DecodeDate(field[i], fmask,
 										   &tmask, &is2digits, tm);
-						if (dterr)
-							return dterr;
+						if (dterr) {
+							*result = dterr;
+							return true;
+						}
 					}
 					/* embedded decimal and several digits before? */
 					else if (cp != NULL && flen - strlen(cp) > 2)
@@ -1179,8 +1239,10 @@ DecodeDateTime(char **field, int *ftype, int nf,
 						dterr = DecodeNumberField(flen, field[i], fmask,
 												  &tmask, tm,
 												  fsec, &is2digits);
-						if (dterr < 0)
-							return dterr;
+						if (dterr < 0) {
+							*result = dterr;
+							return true;
+						}
 					}
 
 					/*
@@ -1198,8 +1260,10 @@ DecodeDateTime(char **field, int *ftype, int nf,
 						dterr = DecodeNumberField(flen, field[i], fmask,
 												  &tmask, tm,
 												  fsec, &is2digits);
-						if (dterr < 0)
-							return dterr;
+						if (dterr < 0) {
+							*result = dterr;
+							return true;
+						}
 					}
 					/* otherwise it is a single date/time field... */
 					else
@@ -1208,8 +1272,10 @@ DecodeDateTime(char **field, int *ftype, int nf,
 											 haveTextMonth, fmask,
 											 &tmask, tm,
 											 fsec, &is2digits);
-						if (dterr)
-							return dterr;
+						if (dterr) {
+							*result = dterr;
+							return true;
+						}
 					}
 				}
 				break;
@@ -1217,7 +1283,7 @@ DecodeDateTime(char **field, int *ftype, int nf,
 			case DTK_STRING:
 			case DTK_SPECIAL:
 				/* timezone abbrevs take precedence over built-in tokens */
-				type = DecodeTimezoneAbbrev(i, field[i], &val, &valtz);
+				safe_call(DecodeTimezoneAbbrevSafe, (i, field[i], &val, &valtz, &type, escontext));
 				if (type == UNKNOWN_FIELD)
 					type = DecodeSpecial(i, field[i], &val);
 				if (type == IGNORE_DTF)
@@ -1230,11 +1296,12 @@ DecodeDateTime(char **field, int *ftype, int nf,
 						switch (val)
 						{
 							case DTK_CURRENT:
-								ereport(ERROR,
+								ereturn(escontext, false,
 									 (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 									  errmsg("date/time value \"current\" is no longer supported")));
 
-								return DTERR_BAD_FORMAT;
+								*result = DTERR_BAD_FORMAT;
+								return true;
 								break;
 
 							case DTK_NOW:
@@ -1309,8 +1376,10 @@ DecodeDateTime(char **field, int *ftype, int nf,
 						 */
 						tmask |= DTK_M(DTZ);
 						tm->tm_isdst = 1;
-						if (tzp == NULL)
-							return DTERR_BAD_FORMAT;
+						if (tzp == NULL) {
+							*result = DTERR_BAD_FORMAT;
+							return true;
+						}
 						*tzp -= val;
 						break;
 
@@ -1322,22 +1391,28 @@ DecodeDateTime(char **field, int *ftype, int nf,
 						 */
 						tmask |= DTK_M(TZ);
 						tm->tm_isdst = 1;
-						if (tzp == NULL)
-							return DTERR_BAD_FORMAT;
+						if (tzp == NULL) {
+							*result = DTERR_BAD_FORMAT;
+							return true;
+						}
 						*tzp = -val;
 						break;
 
 					case TZ:
 						tm->tm_isdst = 0;
-						if (tzp == NULL)
-							return DTERR_BAD_FORMAT;
+						if (tzp == NULL) {
+							*result = DTERR_BAD_FORMAT;
+							return true;
+						}
 						*tzp = -val;
 						break;
 
 					case DYNTZ:
 						tmask |= DTK_M(TZ);
-						if (tzp == NULL)
-							return DTERR_BAD_FORMAT;
+						if (tzp == NULL) {
+							*result = DTERR_BAD_FORMAT;
+							return true;
+						}
 						/* we'll determine the actual offset later */
 						abbrevTz = valtz;
 						abbrev = field[i];
@@ -1369,8 +1444,10 @@ DecodeDateTime(char **field, int *ftype, int nf,
 						tmask = 0;
 
 						/* No preceding date? Then quit... */
-						if ((fmask & DTK_DATE_M) != DTK_DATE_M)
-							return DTERR_BAD_FORMAT;
+						if ((fmask & DTK_DATE_M) != DTK_DATE_M) {
+							*result = DTERR_BAD_FORMAT;
+							return true;
+						}
 
 						/***
 						 * We will need one of the following fields:
@@ -1381,8 +1458,10 @@ DecodeDateTime(char **field, int *ftype, int nf,
 						if (i >= nf - 1 ||
 							(ftype[i + 1] != DTK_NUMBER &&
 							 ftype[i + 1] != DTK_TIME &&
-							 ftype[i + 1] != DTK_DATE))
-							return DTERR_BAD_FORMAT;
+							 ftype[i + 1] != DTK_DATE)) {
+							*result = DTERR_BAD_FORMAT;
+							return true;
+						}
 
 						ptype = val;
 						break;
@@ -1394,34 +1473,44 @@ DecodeDateTime(char **field, int *ftype, int nf,
 						 * if it is an all-alpha timezone name.
 						 */
 						namedTz = pg_tzset(field[i]);
-						if (!namedTz)
-							return DTERR_BAD_FORMAT;
+						if (!namedTz) {
+							*result = DTERR_BAD_FORMAT;
+							return true;
+						}
 						/* we'll apply the zone setting below */
 						tmask = DTK_M(TZ);
 						break;
 
 					default:
-						return DTERR_BAD_FORMAT;
+						*result = DTERR_BAD_FORMAT;
+						return true;
 				}
 				break;
 
 			default:
-				return DTERR_BAD_FORMAT;
+				*result = DTERR_BAD_FORMAT;
+				return true;
 		}
 
-		if (tmask & fmask)
-			return DTERR_BAD_FORMAT;
+		if (tmask & fmask) {
+			*result = DTERR_BAD_FORMAT;
+			return true;
+		}
 		fmask |= tmask;
 	}							/* end loop over fields */
 
 	/* do final checking/adjustment of Y/M/D fields */
 	dterr = ValidateDate(fmask, isjulian, is2digits, bc, tm);
-	if (dterr)
-		return dterr;
+	if (dterr) {
+		*result = dterr;
+		return true;
+	}
 
 	/* handle AM/PM */
-	if (mer != HR24 && tm->tm_hour > HOURS_PER_DAY / 2)
-		return DTERR_FIELD_OVERFLOW;
+	if (mer != HR24 && tm->tm_hour > HOURS_PER_DAY / 2) {
+		*result = DTERR_FIELD_OVERFLOW;
+		return true;
+	}
 	if (mer == AM && tm->tm_hour == HOURS_PER_DAY / 2)
 		tm->tm_hour = 0;
 	else if (mer == PM && tm->tm_hour != HOURS_PER_DAY / 2)
@@ -1432,9 +1521,12 @@ DecodeDateTime(char **field, int *ftype, int nf,
 	{
 		if ((fmask & DTK_DATE_M) != DTK_DATE_M)
 		{
-			if ((fmask & DTK_TIME_M) == DTK_TIME_M)
-				return 1;
-			return DTERR_BAD_FORMAT;
+			if ((fmask & DTK_TIME_M) == DTK_TIME_M) {
+				*result = 1;
+				return true;
+			}
+			*result = DTERR_BAD_FORMAT;
+			return true;
 		}
 
 		/*
@@ -1444,8 +1536,10 @@ DecodeDateTime(char **field, int *ftype, int nf,
 		if (namedTz != NULL)
 		{
 			/* daylight savings time modifier disallowed with full TZ */
-			if (fmask & DTK_M(DTZMOD))
-				return DTERR_BAD_FORMAT;
+			if (fmask & DTK_M(DTZMOD)) {
+				*result = DTERR_BAD_FORMAT;
+				return true;
+			}
 
 			*tzp = DetermineTimeZoneOffset(tm, namedTz);
 		}
@@ -1457,8 +1551,10 @@ DecodeDateTime(char **field, int *ftype, int nf,
 		if (abbrevTz != NULL)
 		{
 			/* daylight savings time modifier disallowed with dynamic TZ */
-			if (fmask & DTK_M(DTZMOD))
-				return DTERR_BAD_FORMAT;
+			if (fmask & DTK_M(DTZMOD)) {
+				*result = DTERR_BAD_FORMAT;
+				return true;
+			}
 
 			*tzp = DetermineTimeZoneAbbrevOffset(tm, abbrev, abbrevTz);
 		}
@@ -1470,14 +1566,17 @@ DecodeDateTime(char **field, int *ftype, int nf,
 			 * daylight savings time modifier but no standard timezone? then
 			 * error
 			 */
-			if (fmask & DTK_M(DTZMOD))
-				return DTERR_BAD_FORMAT;
+			if (fmask & DTK_M(DTZMOD)) {
+				*result = DTERR_BAD_FORMAT;
+				return true;
+			}
 
 			*tzp = DetermineTimeZoneOffset(tm, session_timezone);
 		}
 	}
 
-	return 0;
+	*result = 0;
+	return true;
 }
 
 
@@ -1696,6 +1795,15 @@ int
 DetermineTimeZoneAbbrevOffsetTS(TimestampTz ts, const char *abbr,
 								pg_tz *tzp, int *isdst)
 {
+	int result;
+	(void) DetermineTimeZoneAbbrevOffsetTSSafe(ts, abbr, tzp, isdst, &result, NULL);
+	return result;
+}
+
+bool
+DetermineTimeZoneAbbrevOffsetTSSafe(TimestampTz ts, const char *abbr,
+								pg_tz *tzp, int *isdst, int *result, Node *escontext)
+{
 	pg_time_t	t = timestamptz_to_time_t(ts);
 	int			zone_offset;
 	int			abbr_offset;
@@ -1707,20 +1815,23 @@ DetermineTimeZoneAbbrevOffsetTS(TimestampTz ts, const char *abbr,
 	 * If the abbrev matches anything in the zone data, this is pretty easy.
 	 */
 	if (DetermineTimeZoneAbbrevOffsetInternal(t, abbr, tzp,
-											  &abbr_offset, isdst))
-		return abbr_offset;
+											  &abbr_offset, isdst)) {
+		*result = abbr_offset;
+		return true;
+	}
 
 	/*
 	 * Else, break down the timestamp so we can use DetermineTimeZoneOffset.
 	 */
 	if (timestamp2tm(ts, &tz, &tm, &fsec, NULL, tzp) != 0)
-		ereport(ERROR,
+		ereturn(escontext, false,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("timestamp out of range")));
 
 	zone_offset = DetermineTimeZoneOffset(&tm, tzp);
 	*isdst = tm.tm_isdst;
-	return zone_offset;
+	*result = zone_offset;
+	return true;
 }
 
 
@@ -1773,6 +1884,15 @@ int
 DecodeTimeOnly(char **field, int *ftype, int nf,
 			   int *dtype, struct pg_tm * tm, fsec_t *fsec, int *tzp)
 {
+	int result;
+	(void) DecodeTimeOnlySafe(field, ftype, nf, dtype, tm, fsec, tzp, &result, NULL);
+	return result;
+}
+
+bool
+DecodeTimeOnlySafe(char **field, int *ftype, int nf,
+			   int *dtype, struct pg_tm * tm, fsec_t *fsec, int *tzp, int *result, Node *escontext)
+{
 	int			fmask = 0,
 				tmask,
 				type;
@@ -1810,8 +1930,10 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 				 * Time zone not allowed? Then should not accept dates or time
 				 * zones no matter what else!
 				 */
-				if (tzp == NULL)
-					return DTERR_BAD_FORMAT;
+				if (tzp == NULL) {
+					*result = DTERR_BAD_FORMAT;
+					return true;
+				}
 
 				/* Under limited circumstances, we will accept a date... */
 				if (i == 0 && nf >= 2 &&
@@ -1819,8 +1941,10 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 				{
 					dterr = DecodeDate(field[i], fmask,
 									   &tmask, &is2digits, tm);
-					if (dterr)
-						return dterr;
+					if (dterr) {
+						*result = dterr;
+						return true;
+					}
 				}
 				/* otherwise, this is a time and/or time zone */
 				else
@@ -1833,19 +1957,25 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 						 * Starts with a digit but we already have a time
 						 * field? Then we are in trouble with time already...
 						 */
-						if ((fmask & DTK_TIME_M) == DTK_TIME_M)
-							return DTERR_BAD_FORMAT;
+						if ((fmask & DTK_TIME_M) == DTK_TIME_M) {
+							*result = DTERR_BAD_FORMAT;
+					return true;
+				}
 
 						/*
 						 * Should not get here and fail. Sanity check only...
 						 */
-						if ((cp = strchr(field[i], '-')) == NULL)
-							return DTERR_BAD_FORMAT;
+						if ((cp = strchr(field[i], '-')) == NULL) {
+							*result = DTERR_BAD_FORMAT;
+					return true;
+				}
 
 						/* Get the time zone from the end of the string */
 						dterr = DecodeTimezone(cp, tzp);
-						if (dterr)
-							return dterr;
+						if (dterr) {
+							*result = dterr;
+					return true;
+				}
 						*cp = '\0';
 
 						/*
@@ -1856,8 +1986,10 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 												  (fmask | DTK_DATE_M),
 												  &tmask, tm,
 												  fsec, &is2digits);
-						if (dterr < 0)
-							return dterr;
+						if (dterr < 0) {
+							*result = dterr;
+					return true;
+				}
 						ftype[i] = dterr;
 
 						tmask |= DTK_M(TZ);
@@ -1872,7 +2004,7 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 							 * ereport'ing directly, but then there is no way
 							 * to report the bad time zone name.
 							 */
-							ereport(ERROR,
+							ereturn(escontext, false,
 									(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 									 errmsg("time zone \"%s\" not recognized",
 											field[i])));
@@ -1888,20 +2020,26 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 				dterr = DecodeTime(field[i], (fmask | DTK_DATE_M),
 								   INTERVAL_FULL_RANGE,
 								   &tmask, tm, fsec);
-				if (dterr)
-					return dterr;
+				if (dterr) {
+					*result = dterr;
+					return true;
+				}
 				break;
 
 			case DTK_TZ:
 				{
 					int			tz;
 
-					if (tzp == NULL)
-						return DTERR_BAD_FORMAT;
+					if (tzp == NULL) {
+						*result = DTERR_BAD_FORMAT;
+						return true;
+					}
 
 					dterr = DecodeTimezone(field[i], &tz);
-					if (dterr)
-						return dterr;
+					if (dterr) {
+						*result = dterr;
+						return true;
+					}
 					*tzp = tz;
 					tmask = DTK_M(TZ);
 				}
@@ -1925,16 +2063,20 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 						case DTK_YEAR:
 						case DTK_MONTH:
 						case DTK_DAY:
-							if (tzp == NULL)
-								return DTERR_BAD_FORMAT;
+							if (tzp == NULL) {
+								*result = DTERR_BAD_FORMAT;
+								return true;
+							}
 						default:
 							break;
 					}
 
 					errno = 0;
 					val = strtoint(field[i], &cp, 10);
-					if (errno == ERANGE)
-						return DTERR_FIELD_OVERFLOW;
+					if (errno == ERANGE) {
+						*result = DTERR_FIELD_OVERFLOW;
+						return true;
+					}
 
 					/*
 					 * only a few kinds are allowed to have an embedded
@@ -1948,11 +2090,14 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 							case DTK_SECOND:
 								break;
 							default:
-								return DTERR_BAD_FORMAT;
+								*result = DTERR_BAD_FORMAT;
+								return true;
 								break;
 						}
-					else if (*cp != '\0')
-						return DTERR_BAD_FORMAT;
+					else if (*cp != '\0') {
+						*result = DTERR_BAD_FORMAT;
+						return true;
+					}
 
 					switch (ptype)
 					{
@@ -2001,8 +2146,10 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 							if (*cp == '.')
 							{
 								dterr = ParseFractionalSecond(cp, fsec);
-								if (dterr)
-									return dterr;
+								if (dterr) {
+									*result = dterr;
+									return true;
+								}
 								tmask = DTK_ALL_SECS_M;
 							}
 							break;
@@ -2010,14 +2157,18 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 						case DTK_TZ:
 							tmask = DTK_M(TZ);
 							dterr = DecodeTimezone(field[i], tzp);
-							if (dterr)
-								return dterr;
+							if (dterr) {
+								*result = dterr;
+								return true;
+							}
 							break;
 
 						case DTK_JULIAN:
 							/* previous field was a label for "julian date" */
-							if (val < 0)
-								return DTERR_FIELD_OVERFLOW;
+							if (val < 0) {
+								*result = DTERR_FIELD_OVERFLOW;
+								return true;
+							}
 							tmask = DTK_DATE_M;
 							j2date(val, &tm->tm_year, &tm->tm_mon, &tm->tm_mday);
 							isjulian = TRUE;
@@ -2028,8 +2179,10 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 
 								errno = 0;
 								time = strtod(cp, &cp);
-								if (*cp != '\0' || errno != 0)
-									return DTERR_BAD_FORMAT;
+								if (*cp != '\0' || errno != 0) {
+									*result = DTERR_BAD_FORMAT;
+									return true;
+								}
 
 #ifdef HAVE_INT64_TIMESTAMP
 								time *= USECS_PER_DAY;
@@ -2049,16 +2202,21 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 													  (fmask | DTK_DATE_M),
 													  &tmask, tm,
 													  fsec, &is2digits);
-							if (dterr < 0)
-								return dterr;
+							if (dterr < 0) {
+								*result = dterr;
+								return true;
+							}
 							ftype[i] = dterr;
 
-							if (tmask != DTK_TIME_M)
-								return DTERR_BAD_FORMAT;
+							if (tmask != DTK_TIME_M) {
+								*result = DTERR_BAD_FORMAT;
+								return true;
+							}
 							break;
 
 						default:
-							return DTERR_BAD_FORMAT;
+							*result = DTERR_BAD_FORMAT;
+							return true;
 							break;
 					}
 
@@ -2084,8 +2242,10 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 						{
 							dterr = DecodeDate(field[i], fmask,
 											   &tmask, &is2digits, tm);
-							if (dterr)
-								return dterr;
+							if (dterr) {
+								*result = dterr;
+								return true;
+							}
 						}
 						/* embedded decimal and several digits before? */
 						else if (flen - strlen(cp) > 2)
@@ -2099,12 +2259,16 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 													  (fmask | DTK_DATE_M),
 													  &tmask, tm,
 													  fsec, &is2digits);
-							if (dterr < 0)
-								return dterr;
+							if (dterr < 0) {
+								*result = dterr;
+								return true;
+							}
 							ftype[i] = dterr;
 						}
-						else
-							return DTERR_BAD_FORMAT;
+						else {
+							*result = DTERR_BAD_FORMAT;
+							return true;
+						}
 					}
 					else if (flen > 4)
 					{
@@ -2112,8 +2276,10 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 												  (fmask | DTK_DATE_M),
 												  &tmask, tm,
 												  fsec, &is2digits);
-						if (dterr < 0)
-							return dterr;
+						if (dterr < 0) {
+							*result = dterr;
+							return true;
+						}
 						ftype[i] = dterr;
 					}
 					/* otherwise it is a single date/time field... */
@@ -2124,8 +2290,10 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 											 (fmask | DTK_DATE_M),
 											 &tmask, tm,
 											 fsec, &is2digits);
-						if (dterr)
-							return dterr;
+						if (dterr) {
+							*result = dterr;
+							return true;
+						}
 					}
 				}
 				break;
@@ -2133,7 +2301,7 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 			case DTK_STRING:
 			case DTK_SPECIAL:
 				/* timezone abbrevs take precedence over built-in tokens */
-				type = DecodeTimezoneAbbrev(i, field[i], &val, &valtz);
+				safe_call(DecodeTimezoneAbbrevSafe, (i, field[i], &val, &valtz, &type, escontext));
 				if (type == UNKNOWN_FIELD)
 					type = DecodeSpecial(i, field[i], &val);
 				if (type == IGNORE_DTF)
@@ -2146,10 +2314,11 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 						switch (val)
 						{
 							case DTK_CURRENT:
-								ereport(ERROR,
+								ereturn(escontext, false,
 									 (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 									  errmsg("date/time value \"current\" is no longer supported")));
-								return DTERR_BAD_FORMAT;
+								*result = DTERR_BAD_FORMAT;
+								return true;
 								break;
 
 							case DTK_NOW:
@@ -2168,7 +2337,8 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 								break;
 
 							default:
-								return DTERR_BAD_FORMAT;
+								*result = DTERR_BAD_FORMAT;
+								return true;
 						}
 
 						break;
@@ -2181,8 +2351,10 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 						 */
 						tmask |= DTK_M(DTZ);
 						tm->tm_isdst = 1;
-						if (tzp == NULL)
-							return DTERR_BAD_FORMAT;
+						if (tzp == NULL) {
+							*result = DTERR_BAD_FORMAT;
+							return true;
+						}
 						*tzp -= val;
 						break;
 
@@ -2194,24 +2366,30 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 						 */
 						tmask |= DTK_M(TZ);
 						tm->tm_isdst = 1;
-						if (tzp == NULL)
-							return DTERR_BAD_FORMAT;
+						if (tzp == NULL) {
+							*result = DTERR_BAD_FORMAT;
+							return true;
+						}
 						*tzp = -val;
 						ftype[i] = DTK_TZ;
 						break;
 
 					case TZ:
 						tm->tm_isdst = 0;
-						if (tzp == NULL)
-							return DTERR_BAD_FORMAT;
+						if (tzp == NULL) {
+							*result = DTERR_BAD_FORMAT;
+							return true;
+						}
 						*tzp = -val;
 						ftype[i] = DTK_TZ;
 						break;
 
 					case DYNTZ:
 						tmask |= DTK_M(TZ);
-						if (tzp == NULL)
-							return DTERR_BAD_FORMAT;
+						if (tzp == NULL) {
+							*result = DTERR_BAD_FORMAT;
+							return true;
+						}
 						/* we'll determine the actual offset later */
 						abbrevTz = valtz;
 						abbrev = field[i];
@@ -2243,8 +2421,10 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 						if (i >= nf - 1 ||
 							(ftype[i + 1] != DTK_NUMBER &&
 							 ftype[i + 1] != DTK_TIME &&
-							 ftype[i + 1] != DTK_DATE))
-							return DTERR_BAD_FORMAT;
+							 ftype[i + 1] != DTK_DATE)) {
+							*result = DTERR_BAD_FORMAT;
+							return true;
+						}
 
 						ptype = val;
 						break;
@@ -2256,34 +2436,44 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 						 * if it is an all-alpha timezone name.
 						 */
 						namedTz = pg_tzset(field[i]);
-						if (!namedTz)
-							return DTERR_BAD_FORMAT;
+						if (!namedTz) {
+							*result = DTERR_BAD_FORMAT;
+							return true;
+						}
 						/* we'll apply the zone setting below */
 						tmask = DTK_M(TZ);
 						break;
 
 					default:
-						return DTERR_BAD_FORMAT;
+						*result = DTERR_BAD_FORMAT;
+						return true;
 				}
 				break;
 
 			default:
-				return DTERR_BAD_FORMAT;
+				*result = DTERR_BAD_FORMAT;
+				return true;
 		}
 
-		if (tmask & fmask)
-			return DTERR_BAD_FORMAT;
+		if (tmask & fmask) {
+			*result = DTERR_BAD_FORMAT;
+			return true;
+		}
 		fmask |= tmask;
 	}							/* end loop over fields */
 
 	/* do final checking/adjustment of Y/M/D fields */
 	dterr = ValidateDate(fmask, isjulian, is2digits, bc, tm);
-	if (dterr)
-		return dterr;
+	if (dterr) {
+		*result = dterr;
+		return true;
+	}
 
 	/* handle AM/PM */
-	if (mer != HR24 && tm->tm_hour > HOURS_PER_DAY / 2)
-		return DTERR_FIELD_OVERFLOW;
+	if (mer != HR24 && tm->tm_hour > HOURS_PER_DAY / 2) {
+		*result = DTERR_FIELD_OVERFLOW;
+		return true;
+	}
 	if (mer == AM && tm->tm_hour == HOURS_PER_DAY / 2)
 		tm->tm_hour = 0;
 	else if (mer == PM && tm->tm_hour != HOURS_PER_DAY / 2)
@@ -2303,11 +2493,15 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 #else
 		*fsec < 0 || *fsec > 1
 #endif
-		)
-		return DTERR_FIELD_OVERFLOW;
+		) {
+		*result = DTERR_FIELD_OVERFLOW;
+		return true;
+	}
 
-	if ((fmask & DTK_TIME_M) != DTK_TIME_M)
-		return DTERR_BAD_FORMAT;
+	if ((fmask & DTK_TIME_M) != DTK_TIME_M ) {
+		*result = DTERR_BAD_FORMAT;
+		return true;
+	}
 
 	/*
 	 * If we had a full timezone spec, compute the offset (we could not do it
@@ -2318,8 +2512,10 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 		long int	gmtoff;
 
 		/* daylight savings time modifier disallowed with full TZ */
-		if (fmask & DTK_M(DTZMOD))
-			return DTERR_BAD_FORMAT;
+		if (fmask & DTK_M(DTZMOD)) {
+			*result = DTERR_BAD_FORMAT;
+			return true;
+		}
 
 		/* if non-DST zone, we do not need to know the date */
 		if (pg_get_timezone_offset(namedTz, &gmtoff))
@@ -2329,8 +2525,10 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 		else
 		{
 			/* a date has to be specified */
-			if ((fmask & DTK_DATE_M) != DTK_DATE_M)
-				return DTERR_BAD_FORMAT;
+			if ((fmask & DTK_DATE_M) != DTK_DATE_M) {
+				*result = DTERR_BAD_FORMAT;
+				return true;
+			}
 			*tzp = DetermineTimeZoneOffset(tm, namedTz);
 		}
 	}
@@ -2346,16 +2544,20 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 		/*
 		 * daylight savings time modifier but no standard timezone? then error
 		 */
-		if (fmask & DTK_M(DTZMOD))
-			return DTERR_BAD_FORMAT;
+		if (fmask & DTK_M(DTZMOD)) {
+			*result = DTERR_BAD_FORMAT;
+			return true;
+		}
 
 		if ((fmask & DTK_DATE_M) == 0)
 			GetCurrentDateTime(tmp);
 		else
 		{
 			/* a date has to be specified */
-			if ((fmask & DTK_DATE_M) != DTK_DATE_M)
-				return DTERR_BAD_FORMAT;
+			if ((fmask & DTK_DATE_M) != DTK_DATE_M) {
+				*result = DTERR_BAD_FORMAT;
+				return true;
+			}
 			tmp->tm_year = tm->tm_year;
 			tmp->tm_mon = tm->tm_mon;
 			tmp->tm_mday = tm->tm_mday;
@@ -2376,16 +2578,20 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 		/*
 		 * daylight savings time modifier but no standard timezone? then error
 		 */
-		if (fmask & DTK_M(DTZMOD))
-			return DTERR_BAD_FORMAT;
+		if (fmask & DTK_M(DTZMOD)) {
+			*result = DTERR_BAD_FORMAT;
+			return true;
+		}
 
 		if ((fmask & DTK_DATE_M) == 0)
 			GetCurrentDateTime(tmp);
 		else
 		{
 			/* a date has to be specified */
-			if ((fmask & DTK_DATE_M) != DTK_DATE_M)
-				return DTERR_BAD_FORMAT;
+			if ((fmask & DTK_DATE_M) != DTK_DATE_M) {
+				*result = DTERR_BAD_FORMAT;
+				return true;
+			}
 			tmp->tm_year = tm->tm_year;
 			tmp->tm_mon = tm->tm_mon;
 			tmp->tm_mday = tm->tm_mday;
@@ -2397,7 +2603,8 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 		tm->tm_isdst = tmp->tm_isdst;
 	}
 
-	return 0;
+	*result = 0;
+	return true;
 }
 
 /* DecodeDate()
@@ -3071,6 +3278,15 @@ int
 DecodeTimezoneAbbrev(int field, char *lowtoken,
 					 int *offset, pg_tz **tz)
 {
+	int result = 0;
+	(void) DecodeTimezoneAbbrevSafe(field, lowtoken, offset, tz, &result, NULL);
+	return result;
+}
+
+bool
+DecodeTimezoneAbbrevSafe(int field, char *lowtoken,
+					 int *offset, pg_tz **tz, int *result, Node *escontext)
+{
 	int			type;
 	const datetkn *tp;
 
@@ -3097,7 +3313,7 @@ DecodeTimezoneAbbrev(int field, char *lowtoken,
 		if (type == DYNTZ)
 		{
 			*offset = 0;
-			*tz = FetchDynamicTimeZone(zoneabbrevtbl, tp);
+			safe_call(FetchDynamicTimeZoneSafe, (zoneabbrevtbl, tp, tz, escontext));
 		}
 		else
 		{
@@ -3106,7 +3322,8 @@ DecodeTimezoneAbbrev(int field, char *lowtoken,
 		}
 	}
 
-	return type;
+	*result = type;
+	return true;
 }
 
 
@@ -3869,37 +4086,43 @@ DecodeUnits(int field, char *lowtoken, int *val)
 void
 DateTimeParseError(int dterr, const char *str, const char *datatype)
 {
+	(void) DateTimeParseErrorSafe(dterr, str, datatype, NULL);
+}
+
+bool
+DateTimeParseErrorSafe(int dterr, const char *str, const char *datatype, Node *escontext)
+{
 	switch (dterr)
 	{
 		case DTERR_FIELD_OVERFLOW:
-			ereport(ERROR,
+			ereturn(escontext, false,
 					(errcode(ERRCODE_DATETIME_FIELD_OVERFLOW),
 					 errmsg("date/time field value out of range: \"%s\"",
 							str)));
 			break;
 		case DTERR_MD_FIELD_OVERFLOW:
 			/* <nanny>same as above, but add hint about DateStyle</nanny> */
-			ereport(ERROR,
+			ereturn(escontext, false,
 					(errcode(ERRCODE_DATETIME_FIELD_OVERFLOW),
 					 errmsg("date/time field value out of range: \"%s\"",
 							str),
 			errhint("Perhaps you need a different \"datestyle\" setting.")));
 			break;
 		case DTERR_INTERVAL_OVERFLOW:
-			ereport(ERROR,
+			ereturn(escontext, false,
 					(errcode(ERRCODE_INTERVAL_FIELD_OVERFLOW),
 					 errmsg("interval field value out of range: \"%s\"",
 							str)));
 			break;
 		case DTERR_TZDISP_OVERFLOW:
-			ereport(ERROR,
+			ereturn(escontext, false,
 					(errcode(ERRCODE_INVALID_TIME_ZONE_DISPLACEMENT_VALUE),
 					 errmsg("time zone displacement out of range: \"%s\"",
 							str)));
 			break;
 		case DTERR_BAD_FORMAT:
 		default:
-			ereport(ERROR,
+			ereturn(escontext, false,
 					(errcode(ERRCODE_INVALID_DATETIME_FORMAT),
 					 errmsg("invalid input syntax for type %s: \"%s\"",
 							datatype, str)));
@@ -4717,6 +4940,14 @@ InstallTimeZoneAbbrevs(TimeZoneAbbrevTable *tbl)
 static pg_tz *
 FetchDynamicTimeZone(TimeZoneAbbrevTable *tbl, const datetkn *tp)
 {
+	pg_tz *result;
+	FetchDynamicTimeZoneSafe(tbl, tp, &result, NULL);
+	return result;
+}
+
+static bool
+FetchDynamicTimeZoneSafe(TimeZoneAbbrevTable *tbl, const datetkn *tp, pg_tz **result, Node *escontext)
+{
 	DynamicZoneAbbrev *dtza;
 
 	/* Just some sanity checks to prevent indexing off into nowhere */
@@ -4735,14 +4966,15 @@ FetchDynamicTimeZone(TimeZoneAbbrevTable *tbl, const datetkn *tp)
 		 * then there is no way to report the bad time zone name.
 		 */
 		if (dtza->tz == NULL)
-			ereport(ERROR,
+			ereturn(escontext, false,
 					(errcode(ERRCODE_CONFIG_FILE_ERROR),
 					 errmsg("time zone \"%s\" not recognized",
 							dtza->zone),
 					 errdetail("This time zone name appears in the configuration file for time zone abbreviation \"%s\".",
 							   tp->token)));
 	}
-	return dtza->tz;
+	*result = dtza->tz;
+	return true;
 }
 
 
@@ -4828,13 +5060,20 @@ pg_timezone_abbrevs(PG_FUNCTION_ARGS)
 				pg_tz	   *tzp;
 				TimestampTz now;
 				int			isdst;
+				int 		ngmtoffset;
 
-				tzp = FetchDynamicTimeZone(zoneabbrevtbl, tp);
+				if (!FetchDynamicTimeZoneSafe(zoneabbrevtbl, tp, &tzp, fcinfo->context))
+					PG_RETURN_NULL();
 				now = GetCurrentTransactionStartTimestamp();
-				gmtoffset = -DetermineTimeZoneAbbrevOffsetTS(now,
-															 tp->token,
-															 tzp,
-															 &isdst);
+				if (!DetermineTimeZoneAbbrevOffsetTSSafe(now,
+														 tp->token,
+														 tzp,
+														 &isdst, 
+														 &ngmtoffset, 
+														 fcinfo->context))
+					PG_RETURN_NULL();
+				gmtoffset = -ngmtoffset;
+
 				is_dst = (bool) isdst;
 				break;
 			}

--- a/src/backend/utils/adt/float.c
+++ b/src/backend/utils/adt/float.c
@@ -194,7 +194,7 @@ float4in(PG_FUNCTION_ARGS)
 	 * strtod() on different platforms.
 	 */
 	if (*num == '\0')
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
 				 errmsg("invalid input syntax for type real: \"%s\"",
 						orig_num)));
@@ -262,13 +262,13 @@ float4in(PG_FUNCTION_ARGS)
 			 * to see if the result is zero or huge.
 			 */
 			if (val == 0.0 || val >= HUGE_VAL || val <= -HUGE_VAL)
-				ereturn(fcinfo->context, 0,
+				PG_ERETURN(fcinfo->context,
 						(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 						 errmsg("\"%s\" is out of range for type real",
 								orig_num)));
 		}
 		else
-			ereturn(fcinfo->context, 0,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
 					 errmsg("invalid input syntax for type real: \"%s\"",
 							orig_num)));
@@ -292,7 +292,7 @@ float4in(PG_FUNCTION_ARGS)
 
 	/* if there is any junk left at the end of the string, bail out */
 	if (*endptr != '\0')
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
 				 errmsg("invalid input syntax for type real: \"%s\"",
 						orig_num)));
@@ -301,7 +301,7 @@ float4in(PG_FUNCTION_ARGS)
 	 * if we get here, we have a legal double, still need to check to see if
 	 * it's a legal float4
 	 */
-	CHECKFLOATVAL((float4) val, isinf(val), val == 0);
+	PG_CHECKFLOATVAL_SAFE((float4) val, isinf(val), val == 0);
 
 	PG_RETURN_FLOAT4((float4) val);
 }
@@ -394,7 +394,7 @@ float8in(PG_FUNCTION_ARGS)
 	 * strtod() on different platforms.
 	 */
 	if (*num == '\0')
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
 			 errmsg("invalid input syntax for type double precision: \"%s\"",
 					orig_num)));
@@ -462,13 +462,13 @@ float8in(PG_FUNCTION_ARGS)
 			 * to see if the result is zero or huge.
 			 */
 			if (val == 0.0 || val >= HUGE_VAL || val <= -HUGE_VAL)
-				ereturn(fcinfo->context, 0,
+				PG_ERETURN(fcinfo->context,
 						(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				   errmsg("\"%s\" is out of range for type double precision",
 						  orig_num)));
 		}
 		else
-			ereturn(fcinfo->context, 0,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
 			 errmsg("invalid input syntax for type double precision: \"%s\"",
 					orig_num)));
@@ -492,7 +492,7 @@ float8in(PG_FUNCTION_ARGS)
 
 	/* if there is any junk left at the end of the string, bail out */
 	if (*endptr != '\0')
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
 			 errmsg("invalid input syntax for type double precision: \"%s\"",
 					orig_num)));
@@ -520,7 +520,7 @@ float8in(PG_FUNCTION_ARGS)
 		 pg_strncasecmp(num, "+Infinity", 9) != 0 && pg_strncasecmp(num, "+Inf", 4) != 0 )
 		literal_inf = false;
 
-	CHECKFLOATVAL((double) val, literal_inf, !(val > 0 || val < 0));
+	PG_CHECKFLOATVAL_SAFE((double) val, literal_inf, !(val > 0 || val < 0));
 
 	PG_RETURN_FLOAT8((double) val);
 }
@@ -751,7 +751,7 @@ float4pl(PG_FUNCTION_ARGS)
 	 * different, e.g. on x86, '1e-45'::float4 == '2e-45'::float4 ==
 	 * 1.4013e-45.
 	 */
-	CHECKFLOATVAL(result, isinf(arg1) || isinf(arg2), true);
+	PG_CHECKFLOATVAL_SAFE(result, isinf(arg1) || isinf(arg2), true);
 	PG_RETURN_FLOAT4(result);
 }
 
@@ -763,7 +763,7 @@ float4mi(PG_FUNCTION_ARGS)
 	float4		result;
 
 	result = arg1 - arg2;
-	CHECKFLOATVAL(result, isinf(arg1) || isinf(arg2), true);
+	PG_CHECKFLOATVAL_SAFE(result, isinf(arg1) || isinf(arg2), true);
 	PG_RETURN_FLOAT4(result);
 }
 
@@ -775,8 +775,8 @@ float4mul(PG_FUNCTION_ARGS)
 	float4		result;
 
 	result = arg1 * arg2;
-	CHECKFLOATVAL(result, isinf(arg1) || isinf(arg2),
-				  arg1 == 0 || arg2 == 0);
+	PG_CHECKFLOATVAL_SAFE(result, isinf(arg1) || isinf(arg2),
+				  		  arg1 == 0 || arg2 == 0);
 	PG_RETURN_FLOAT4(result);
 }
 
@@ -788,13 +788,13 @@ float4div(PG_FUNCTION_ARGS)
 	float4		result;
 
 	if (arg2 == 0.0)
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DIVISION_BY_ZERO),
 				 errmsg("division by zero")));
 
 	result = arg1 / arg2;
 
-	CHECKFLOATVAL(result, isinf(arg1) || isinf(arg2), arg1 == 0);
+	PG_CHECKFLOATVAL_SAFE(result, isinf(arg1) || isinf(arg2), arg1 == 0);
 	PG_RETURN_FLOAT4(result);
 }
 
@@ -813,7 +813,7 @@ float8pl(PG_FUNCTION_ARGS)
 
 	result = arg1 + arg2;
 
-	CHECKFLOATVAL(result, isinf(arg1) || isinf(arg2), true);
+	PG_CHECKFLOATVAL_SAFE(result, isinf(arg1) || isinf(arg2), true);
 	PG_RETURN_FLOAT8(result);
 }
 
@@ -826,7 +826,7 @@ float8mi(PG_FUNCTION_ARGS)
 
 	result = arg1 - arg2;
 
-	CHECKFLOATVAL(result, isinf(arg1) || isinf(arg2), true);
+	PG_CHECKFLOATVAL_SAFE(result, isinf(arg1) || isinf(arg2), true);
 	PG_RETURN_FLOAT8(result);
 }
 
@@ -839,8 +839,8 @@ float8mul(PG_FUNCTION_ARGS)
 
 	result = arg1 * arg2;
 
-	CHECKFLOATVAL(result, isinf(arg1) || isinf(arg2),
-				  arg1 == 0 || arg2 == 0);
+	PG_CHECKFLOATVAL_SAFE(result, isinf(arg1) || isinf(arg2),
+				  		  arg1 == 0 || arg2 == 0);
 	PG_RETURN_FLOAT8(result);
 }
 
@@ -852,13 +852,13 @@ float8div(PG_FUNCTION_ARGS)
 	float8		result;
 
 	if (arg2 == 0.0)
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DIVISION_BY_ZERO),
 				 errmsg("division by zero")));
 
 	result = arg1 / arg2;
 
-	CHECKFLOATVAL(result, isinf(arg1) || isinf(arg2), arg1 == 0);
+	PG_CHECKFLOATVAL_SAFE(result, isinf(arg1) || isinf(arg2), arg1 == 0);
 	PG_RETURN_FLOAT8(result);
 }
 
@@ -1144,7 +1144,7 @@ dtof(PG_FUNCTION_ARGS)
 {
 	float8		num = PG_GETARG_FLOAT8(0);
 
-	CHECKFLOATVAL((float4) num, isinf(num), num == 0);
+	PG_CHECKFLOATVAL_SAFE((float4) num, isinf(num), num == 0);
 
 	PG_RETURN_FLOAT4((float4) num);
 }
@@ -1167,7 +1167,7 @@ dtoi4(PG_FUNCTION_ARGS)
 
 	/* Range check */
 	if (isnan(num) || !FLOAT8_FITS_IN_INT32(num))
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("integer out of range")));
 
@@ -1192,7 +1192,7 @@ dtoi2(PG_FUNCTION_ARGS)
 
 	/* Range check */
 	if (isnan(num) || !FLOAT8_FITS_IN_INT16(num))
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("smallint out of range")));
 
@@ -1241,7 +1241,7 @@ ftoi4(PG_FUNCTION_ARGS)
 
 	/* Range check */
 	if (isnan(num) || !FLOAT4_FITS_IN_INT32(num))
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("integer out of range")));
 
@@ -1266,7 +1266,7 @@ ftoi2(PG_FUNCTION_ARGS)
 
 	/* Range check */
 	if (isnan(num) || !FLOAT4_FITS_IN_INT16(num))
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("smallint out of range")));
 
@@ -2647,7 +2647,7 @@ float48pl(PG_FUNCTION_ARGS)
 	float8		result;
 
 	result = arg1 + arg2;
-	CHECKFLOATVAL(result, isinf(arg1) || isinf(arg2), true);
+	PG_CHECKFLOATVAL_SAFE(result, isinf(arg1) || isinf(arg2), true);
 	PG_RETURN_FLOAT8(result);
 }
 
@@ -2659,7 +2659,7 @@ float48mi(PG_FUNCTION_ARGS)
 	float8		result;
 
 	result = arg1 - arg2;
-	CHECKFLOATVAL(result, isinf(arg1) || isinf(arg2), true);
+	PG_CHECKFLOATVAL_SAFE(result, isinf(arg1) || isinf(arg2), true);
 	PG_RETURN_FLOAT8(result);
 }
 
@@ -2671,7 +2671,7 @@ float48mul(PG_FUNCTION_ARGS)
 	float8		result;
 
 	result = arg1 * arg2;
-	CHECKFLOATVAL(result, isinf(arg1) || isinf(arg2),
+	PG_CHECKFLOATVAL_SAFE(result, isinf(arg1) || isinf(arg2),
 				  arg1 == 0 || arg2 == 0);
 	PG_RETURN_FLOAT8(result);
 }
@@ -2684,12 +2684,12 @@ float48div(PG_FUNCTION_ARGS)
 	float8		result;
 
 	if (arg2 == 0.0)
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DIVISION_BY_ZERO),
 				 errmsg("division by zero")));
 
 	result = arg1 / arg2;
-	CHECKFLOATVAL(result, isinf(arg1) || isinf(arg2), arg1 == 0);
+	PG_CHECKFLOATVAL_SAFE(result, isinf(arg1) || isinf(arg2), arg1 == 0);
 	PG_RETURN_FLOAT8(result);
 }
 
@@ -2708,7 +2708,7 @@ float84pl(PG_FUNCTION_ARGS)
 
 	result = arg1 + arg2;
 
-	CHECKFLOATVAL(result, isinf(arg1) || isinf(arg2), true);
+	PG_CHECKFLOATVAL_SAFE(result, isinf(arg1) || isinf(arg2), true);
 	PG_RETURN_FLOAT8(result);
 }
 
@@ -2721,7 +2721,7 @@ float84mi(PG_FUNCTION_ARGS)
 
 	result = arg1 - arg2;
 
-	CHECKFLOATVAL(result, isinf(arg1) || isinf(arg2), true);
+	PG_CHECKFLOATVAL_SAFE(result, isinf(arg1) || isinf(arg2), true);
 	PG_RETURN_FLOAT8(result);
 }
 
@@ -2734,8 +2734,8 @@ float84mul(PG_FUNCTION_ARGS)
 
 	result = arg1 * arg2;
 
-	CHECKFLOATVAL(result, isinf(arg1) || isinf(arg2),
-				  arg1 == 0 || arg2 == 0);
+	PG_CHECKFLOATVAL_SAFE(result, isinf(arg1) || isinf(arg2),
+						  arg1 == 0 || arg2 == 0);
 	PG_RETURN_FLOAT8(result);
 }
 
@@ -2747,13 +2747,13 @@ float84div(PG_FUNCTION_ARGS)
 	float8		result;
 
 	if (arg2 == 0.0)
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DIVISION_BY_ZERO),
 				 errmsg("division by zero")));
 
 	result = arg1 / arg2;
 
-	CHECKFLOATVAL(result, isinf(arg1) || isinf(arg2), arg1 == 0);
+	PG_CHECKFLOATVAL_SAFE(result, isinf(arg1) || isinf(arg2), arg1 == 0);
 	PG_RETURN_FLOAT8(result);
 }
 

--- a/src/backend/utils/adt/int.c
+++ b/src/backend/utils/adt/int.c
@@ -62,7 +62,10 @@ int2in(PG_FUNCTION_ARGS)
 {
 	char	   *num = PG_GETARG_CSTRING(0);
 
-	PG_RETURN_INT16(pg_atoi_safe(num, sizeof(int16), '\0', fcinfo->context));
+	int32 result;
+	PG_SAFE_CALL(pg_atoi_safe, (num, sizeof(int16), '\0', &result, fcinfo->context));
+
+	PG_RETURN_INT16(result);
 }
 
 /*
@@ -157,7 +160,7 @@ int2vectorin(PG_FUNCTION_ARGS)
 	while (*intString && isspace((unsigned char) *intString))
 		intString++;
 	if (*intString)
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("int2vector has too many elements")));
 
@@ -232,13 +235,13 @@ int2vectorrecv(PG_FUNCTION_ARGS)
 		ARR_HASNULL(result) ||
 		ARR_ELEMTYPE(result) != INT2OID ||
 		ARR_LBOUND(result)[0] != 0)
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_INVALID_BINARY_REPRESENTATION),
 				 errmsg("invalid int2vector data")));
 
 	/* check length for consistency with int2vectorin() */
 	if (ARR_DIMS(result)[0] > FUNC_MAX_ARGS)
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("oidvector has too many elements")));
 
@@ -282,7 +285,10 @@ int4in(PG_FUNCTION_ARGS)
 {
 	char	   *num = PG_GETARG_CSTRING(0);
 
-	PG_RETURN_INT32(pg_atoi_safe(num, sizeof(int32), '\0', fcinfo->context));
+	int32 result;
+	PG_SAFE_CALL(pg_atoi_safe, (num, sizeof(int32), '\0', &result, fcinfo->context));
+
+	PG_RETURN_INT32(result);
 }
 
 /*
@@ -344,7 +350,7 @@ i4toi2(PG_FUNCTION_ARGS)
 	int32		arg1 = PG_GETARG_INT32(0);
 
 	if (arg1 < SHRT_MIN || arg1 > SHRT_MAX)
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("smallint out of range")));
 
@@ -618,7 +624,7 @@ int4um(PG_FUNCTION_ARGS)
 	result = -arg;
 	/* overflow check (needed for INT_MIN) */
 	if (arg != 0 && SAMESIGN(result, arg))
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("integer out of range")));
 	PG_RETURN_INT32(result);
@@ -647,7 +653,7 @@ int4pl(PG_FUNCTION_ARGS)
 	 * better be that sign too.
 	 */
 	if (SAMESIGN(arg1, arg2) && !SAMESIGN(result, arg1))
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("integer out of range")));
 	PG_RETURN_INT32(result);
@@ -668,7 +674,7 @@ int4mi(PG_FUNCTION_ARGS)
 	 * result should be of the same sign as the first input.
 	 */
 	if (!SAMESIGN(arg1, arg2) && !SAMESIGN(result, arg1))
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("integer out of range")));
 	PG_RETURN_INT32(result);
@@ -699,7 +705,7 @@ int4mul(PG_FUNCTION_ARGS)
 		arg2 != 0 &&
 		((arg2 == -1 && arg1 < 0 && result < 0) ||
 		 result / arg2 != arg1))
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("integer out of range")));
 	PG_RETURN_INT32(result);
@@ -714,7 +720,7 @@ int4div(PG_FUNCTION_ARGS)
 
 	if (arg2 == 0)
 	{
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DIVISION_BY_ZERO),
 				 errmsg("division by zero")));
 		/* ensure compiler realizes we mustn't reach the division (gcc bug) */
@@ -732,7 +738,7 @@ int4div(PG_FUNCTION_ARGS)
 		result = -arg1;
 		/* overflow check (needed for INT_MIN) */
 		if (arg1 != 0 && SAMESIGN(result, arg1))
-			ereturn(fcinfo->context, 0,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 					 errmsg("integer out of range")));
 		PG_RETURN_INT32(result);
@@ -754,7 +760,7 @@ int4inc(PG_FUNCTION_ARGS)
 	result = arg + 1;
 	/* Overflow check */
 	if (arg > 0 && result < 0)
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("integer out of range")));
 
@@ -770,7 +776,7 @@ int2um(PG_FUNCTION_ARGS)
 	result = -arg;
 	/* overflow check (needed for SHRT_MIN) */
 	if (arg != 0 && SAMESIGN(result, arg))
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("smallint out of range")));
 	PG_RETURN_INT16(result);
@@ -799,7 +805,7 @@ int2pl(PG_FUNCTION_ARGS)
 	 * better be that sign too.
 	 */
 	if (SAMESIGN(arg1, arg2) && !SAMESIGN(result, arg1))
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("smallint out of range")));
 	PG_RETURN_INT16(result);
@@ -820,7 +826,7 @@ int2mi(PG_FUNCTION_ARGS)
 	 * result should be of the same sign as the first input.
 	 */
 	if (!SAMESIGN(arg1, arg2) && !SAMESIGN(result, arg1))
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("smallint out of range")));
 	PG_RETURN_INT16(result);
@@ -840,7 +846,7 @@ int2mul(PG_FUNCTION_ARGS)
 	result32 = (int32) arg1 *(int32) arg2;
 
 	if (result32 < SHRT_MIN || result32 > SHRT_MAX)
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("smallint out of range")));
 
@@ -856,7 +862,7 @@ int2div(PG_FUNCTION_ARGS)
 
 	if (arg2 == 0)
 	{
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DIVISION_BY_ZERO),
 				 errmsg("division by zero")));
 		/* ensure compiler realizes we mustn't reach the division (gcc bug) */
@@ -874,7 +880,7 @@ int2div(PG_FUNCTION_ARGS)
 		result = -arg1;
 		/* overflow check (needed for SHRT_MIN) */
 		if (arg1 != 0 && SAMESIGN(result, arg1))
-			ereturn(fcinfo->context, 0,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 					 errmsg("smallint out of range")));
 		PG_RETURN_INT16(result);
@@ -902,7 +908,7 @@ int24pl(PG_FUNCTION_ARGS)
 	 * better be that sign too.
 	 */
 	if (SAMESIGN(arg1, arg2) && !SAMESIGN(result, arg1))
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("integer out of range")));
 	PG_RETURN_INT32(result);
@@ -923,7 +929,7 @@ int24mi(PG_FUNCTION_ARGS)
 	 * result should be of the same sign as the first input.
 	 */
 	if (!SAMESIGN(arg1, arg2) && !SAMESIGN(result, arg1))
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("integer out of range")));
 	PG_RETURN_INT32(result);
@@ -950,7 +956,7 @@ int24mul(PG_FUNCTION_ARGS)
 	 */
 	if (!(arg2 >= (int32) SHRT_MIN && arg2 <= (int32) SHRT_MAX) &&
 		result / arg2 != arg1)
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("integer out of range")));
 	PG_RETURN_INT32(result);
@@ -964,7 +970,7 @@ int24div(PG_FUNCTION_ARGS)
 
 	if (arg2 == 0)
 	{
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DIVISION_BY_ZERO),
 				 errmsg("division by zero")));
 		/* ensure compiler realizes we mustn't reach the division (gcc bug) */
@@ -990,7 +996,7 @@ int42pl(PG_FUNCTION_ARGS)
 	 * better be that sign too.
 	 */
 	if (SAMESIGN(arg1, arg2) && !SAMESIGN(result, arg1))
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("integer out of range")));
 	PG_RETURN_INT32(result);
@@ -1011,7 +1017,7 @@ int42mi(PG_FUNCTION_ARGS)
 	 * result should be of the same sign as the first input.
 	 */
 	if (!SAMESIGN(arg1, arg2) && !SAMESIGN(result, arg1))
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("integer out of range")));
 	PG_RETURN_INT32(result);
@@ -1038,7 +1044,7 @@ int42mul(PG_FUNCTION_ARGS)
 	 */
 	if (!(arg1 >= (int32) SHRT_MIN && arg1 <= (int32) SHRT_MAX) &&
 		result / arg1 != arg2)
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("integer out of range")));
 	PG_RETURN_INT32(result);
@@ -1053,7 +1059,7 @@ int42div(PG_FUNCTION_ARGS)
 
 	if (arg2 == 0)
 	{
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DIVISION_BY_ZERO),
 				 errmsg("division by zero")));
 		/* ensure compiler realizes we mustn't reach the division (gcc bug) */
@@ -1071,7 +1077,7 @@ int42div(PG_FUNCTION_ARGS)
 		result = -arg1;
 		/* overflow check (needed for INT_MIN) */
 		if (arg1 != 0 && SAMESIGN(result, arg1))
-			ereturn(fcinfo->context, 0,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 					 errmsg("integer out of range")));
 		PG_RETURN_INT32(result);
@@ -1092,7 +1098,7 @@ int4mod(PG_FUNCTION_ARGS)
 
 	if (arg2 == 0)
 	{
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DIVISION_BY_ZERO),
 				 errmsg("division by zero")));
 		/* ensure compiler realizes we mustn't reach the division (gcc bug) */
@@ -1120,7 +1126,7 @@ int2mod(PG_FUNCTION_ARGS)
 
 	if (arg2 == 0)
 	{
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DIVISION_BY_ZERO),
 				 errmsg("division by zero")));
 		/* ensure compiler realizes we mustn't reach the division (gcc bug) */
@@ -1154,7 +1160,7 @@ int4abs(PG_FUNCTION_ARGS)
 	result = (arg1 < 0) ? -arg1 : arg1;
 	/* overflow check (needed for INT_MIN) */
 	if (result < 0)
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("integer out of range")));
 	PG_RETURN_INT32(result);
@@ -1169,7 +1175,7 @@ int2abs(PG_FUNCTION_ARGS)
 	result = (arg1 < 0) ? -arg1 : arg1;
 	/* overflow check (needed for SHRT_MIN) */
 	if (result < 0)
-		ereturn(fcinfo->context, 0,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("smallint out of range")));
 	PG_RETURN_INT16(result);

--- a/src/backend/utils/adt/network.c
+++ b/src/backend/utils/adt/network.c
@@ -600,7 +600,7 @@ network_show(PG_FUNCTION_ARGS)
 
 	if (inet_net_ntop(ip_family(ip), ip_addr(ip), ip_maxbits(ip),
 					  tmp, sizeof(tmp)) == NULL)
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_INVALID_BINARY_REPRESENTATION),
 				 errmsg("could not format inet value: %m")));
 

--- a/src/backend/utils/adt/timestamp.c
+++ b/src/backend/utils/adt/timestamp.c
@@ -70,22 +70,14 @@ typedef struct
 
 static TimeOffset time2t(const int hour, const int min, const int sec, const fsec_t fsec);
 static Timestamp dt2local(Timestamp dt, int timezone);
-// static void AdjustTimestampForTypmod(Timestamp *time, int32 typmod);
 static bool AdjustTimestampForTypmodSafe(Timestamp *time, int32 typmod, Node *escontext);
-// static void AdjustIntervalForTypmod(Interval *interval, int32 typmod);
 static bool AdjustIntervalForTypmodSafe(Interval *interval, int32 typmod, Node *escontext);
 static TimestampTz timestamp2timestamptz(Timestamp timestamp);
 static bool timestamp2timestamptz_safe(Timestamp timestamp, Timestamp *result, Node *escontext);
-// static inline Timestamp timestamp_offset_internal(Timestamp timestamp,
-// 						Interval *span);
 static inline bool timestamp_offset_internal_safe(Timestamp timestamp,
 						Interval *span, Timestamp *result, Node* escontext);
-// static inline Timestamp timestamp_offset_multiple(Timestamp base, Interval *unit,
-// 						int64 mul);
 static inline bool timestamp_offset_multiple_safe(Timestamp base, Interval *unit,
 						int64 mul, Timestamp *result, Node *escontext);
-// static inline TimestampTz timestamptz_offset_internal(TimestampTz timestamp,
-// 							Interval *span);
 static inline bool timestamptz_offset_internal_safe(TimestampTz timestamp,
 							Interval *span, TimestampTz *result, Node *escontext);
 static inline TimestampTz timestamptz_offset_multiple(TimestampTz base,

--- a/src/backend/utils/adt/timestamp.c
+++ b/src/backend/utils/adt/timestamp.c
@@ -70,25 +70,47 @@ typedef struct
 
 static TimeOffset time2t(const int hour, const int min, const int sec, const fsec_t fsec);
 static Timestamp dt2local(Timestamp dt, int timezone);
-static void AdjustTimestampForTypmod(Timestamp *time, int32 typmod);
-static void AdjustIntervalForTypmod(Interval *interval, int32 typmod);
+// static void AdjustTimestampForTypmod(Timestamp *time, int32 typmod);
+static bool AdjustTimestampForTypmodSafe(Timestamp *time, int32 typmod, Node *escontext);
+// static void AdjustIntervalForTypmod(Interval *interval, int32 typmod);
+static bool AdjustIntervalForTypmodSafe(Interval *interval, int32 typmod, Node *escontext);
 static TimestampTz timestamp2timestamptz(Timestamp timestamp);
-static inline Timestamp timestamp_offset_internal(Timestamp timestamp,
-						Interval *span);
-static inline Timestamp timestamp_offset_multiple(Timestamp base, Interval *unit,
-						int64 mul);
-static inline TimestampTz timestamptz_offset_internal(TimestampTz timestamp,
-							Interval *span);
+static bool timestamp2timestamptz_safe(Timestamp timestamp, Timestamp *result, Node *escontext);
+// static inline Timestamp timestamp_offset_internal(Timestamp timestamp,
+// 						Interval *span);
+static inline bool timestamp_offset_internal_safe(Timestamp timestamp,
+						Interval *span, Timestamp *result, Node* escontext);
+// static inline Timestamp timestamp_offset_multiple(Timestamp base, Interval *unit,
+// 						int64 mul);
+static inline bool timestamp_offset_multiple_safe(Timestamp base, Interval *unit,
+						int64 mul, Timestamp *result, Node *escontext);
+// static inline TimestampTz timestamptz_offset_internal(TimestampTz timestamp,
+// 							Interval *span);
+static inline bool timestamptz_offset_internal_safe(TimestampTz timestamp,
+							Interval *span, TimestampTz *result, Node *escontext);
 static inline TimestampTz timestamptz_offset_multiple(TimestampTz base,
 							Interval *unit, int64 mul);
+static inline bool timestamptz_offset_multiple_safe(TimestampTz base,
+							Interval *unit, int64 mul, TimestampTz *result, Node *escontext);
 /* Handy for comparisons. */
 static const Interval	IntervalZero = {0, 0, 0};
 
 
 
 /* common code for timestamptypmodin and timestamptztypmodin */
+static bool
+anytimestamp_typmodin_safe(bool istz, ArrayType *ta, int32 *result, Node *escontext);
+
 static int32
 anytimestamp_typmodin(bool istz, ArrayType *ta)
+{
+	int32 result;
+	(void) anytimestamp_typmodin_safe(istz, ta, &result, NULL);
+	return result;
+}
+
+static bool
+anytimestamp_typmodin_safe(bool istz, ArrayType *ta, int32 *result, Node *escontext)
 {
 	int32		typmod;
 	int32	   *tl;
@@ -101,12 +123,12 @@ anytimestamp_typmodin(bool istz, ArrayType *ta)
 	 * shouldn't allow wrong number of modifiers for TIMESTAMP
 	 */
 	if (n != 1)
-		ereport(ERROR,
+		ereturn(escontext, false,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("invalid type modifier")));
 
 	if (*tl < 0)
-		ereport(ERROR,
+		ereturn(escontext, false,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("TIMESTAMP(%d)%s precision must not be negative",
 						*tl, (istz ? " WITH TIME ZONE" : ""))));
@@ -122,7 +144,8 @@ anytimestamp_typmodin(bool istz, ArrayType *ta)
 	else
 		typmod = *tl;
 
-	return typmod;
+	*result = typmod;
+	return true;
 }
 
 /* common code for timestamptypmodout and timestamptztypmodout */
@@ -169,15 +192,15 @@ timestamp_in(PG_FUNCTION_ARGS)
 	dterr = ParseDateTime(str, workbuf, sizeof(workbuf),
 						  field, ftype, MAXDATEFIELDS, &nf);
 	if (dterr == 0)
-		dterr = DecodeDateTime(field, ftype, nf, &dtype, tm, &fsec, &tz);
+		PG_SAFE_CALL(DecodeDateTimeSafe, (field, ftype, nf, &dtype, tm, &fsec, &tz, &dterr, fcinfo->context));
 	if (dterr != 0)
-		DateTimeParseError(dterr, str, "timestamp");
+		PG_SAFE_CALL(DateTimeParseErrorSafe, (dterr, str, "timestamp", fcinfo->context));
 
 	switch (dtype)
 	{
 		case DTK_DATE:
 			if (tm2timestamp(tm, fsec, NULL, &result) != 0)
-				ereport(ERROR,
+				PG_ERETURN(fcinfo->context,
 						(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 						 errmsg("timestamp out of range: \"%s\"", str)));
 			break;
@@ -195,7 +218,7 @@ timestamp_in(PG_FUNCTION_ARGS)
 			break;
 
 		case DTK_INVALID:
-			ereport(ERROR,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 			  errmsg("date/time value \"%s\" is no longer supported", str)));
 
@@ -208,7 +231,7 @@ timestamp_in(PG_FUNCTION_ARGS)
 			TIMESTAMP_NOEND(result);
 	}
 
-	AdjustTimestampForTypmod(&result, typmod);
+	PG_SAFE_CALL(AdjustTimestampForTypmodSafe, (&result, typmod, fcinfo->context));
 
 	PG_RETURN_TIMESTAMP(result);
 }
@@ -231,7 +254,7 @@ timestamp_out(PG_FUNCTION_ARGS)
 	else if (timestamp2tm(timestamp, NULL, tm, &fsec, NULL, NULL) == 0)
 		EncodeDateTime(tm, fsec, false, 0, NULL, DateStyle, buf);
 	else
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("timestamp out of range")));
 
@@ -265,7 +288,7 @@ timestamp_recv(PG_FUNCTION_ARGS)
 	timestamp = (Timestamp) pq_getmsgfloat8(buf);
 
 	if (isnan(timestamp))
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("timestamp cannot be NaN")));
 #endif
@@ -274,11 +297,11 @@ timestamp_recv(PG_FUNCTION_ARGS)
 	if (TIMESTAMP_NOT_FINITE(timestamp))
 		 /* ok */ ;
 	else if (timestamp2tm(timestamp, NULL, tm, &fsec, NULL, NULL) != 0)
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("timestamp out of range")));
 
-	AdjustTimestampForTypmod(&timestamp, typmod);
+	PG_SAFE_CALL(AdjustTimestampForTypmodSafe, (&timestamp, typmod, fcinfo->context));
 
 	PG_RETURN_TIMESTAMP(timestamp);
 }
@@ -306,7 +329,11 @@ timestamptypmodin(PG_FUNCTION_ARGS)
 {
 	ArrayType  *ta = PG_GETARG_ARRAYTYPE_P(0);
 
-	PG_RETURN_INT32(anytimestamp_typmodin(false, ta));
+	int32 typmod = 0;
+	if (!anytimestamp_typmodin_safe(false, ta, &typmod, fcinfo->context))
+		PG_RETURN_NULL();
+
+	PG_RETURN_INT32(typmod);
 }
 
 Datum
@@ -324,9 +351,22 @@ timestamptypmodout(PG_FUNCTION_ARGS)
  *		interval_bound(timestamp, interval, int, timestamp)
  *		returns timestamp
  */
+static bool
+timestamp_interval_bound_common_safe(Timestamp val, Interval *width,
+								int32 shift, Timestamp reg, Timestamp *result, Node *escontext);
+
 static Timestamp
 timestamp_interval_bound_common(Timestamp val, Interval *width,
 								int32 shift, Timestamp reg)
+{
+	Timestamp result;
+	(void) timestamp_interval_bound_common_safe(val, width, shift, reg, &result, NULL);
+	return result;
+}
+
+static bool
+timestamp_interval_bound_common_safe(Timestamp val, Interval *width,
+								int32 shift, Timestamp reg, Timestamp *result, Node *escontext)
 {
 	int64		index = 0;
 	float8		quo = 0.0;
@@ -337,16 +377,18 @@ timestamp_interval_bound_common(Timestamp val, Interval *width,
 
 	/* Insist on positive, interval width. */
 	if (interval_cmp_internal(width, &IntervalZero) <= 0)
-		ereport(ERROR,
+		ereturn(escontext, false,
 				(errcode(ERRCODE_INVALID_INTERVAL_WIDTH),
 				 errmsg("width of time interval not positive")));
 
 	/* Just return non-finite timestamp. */
-	if (TIMESTAMP_NOT_FINITE(val))
-		return val;
+	if (TIMESTAMP_NOT_FINITE(val)) {
+		*result = val;
+		return true;
+	}
 
 	if (TIMESTAMP_NOT_FINITE(reg))
-		ereport(ERROR,
+		ereturn(escontext, false,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("bound for registration is not finite")));
 
@@ -364,10 +406,12 @@ timestamp_interval_bound_common(Timestamp val, Interval *width,
 	for (safety = 64; ; safety--)
 	{
 		if (safety <= 0)
-			elog(ERROR, "interval_bound failed to converge");
+			ereturn(escontext, false,
+						(errcode(ERRCODE_DATA_EXCEPTION),
+						 errmsg("interval_bound failed to converge")));
 
-		low = timestamp_offset_multiple(reg, width, index);
-		high = timestamp_offset_multiple(low, width, 1);
+		safe_call(timestamp_offset_multiple_safe, (reg, width, index, &low, escontext));
+		safe_call(timestamp_offset_multiple_safe, (low, width, 1, &high, escontext));
 
 		Assert(high > low);
 
@@ -405,9 +449,10 @@ timestamp_interval_bound_common(Timestamp val, Interval *width,
 
 	/* If necessary, shift the interval. */
 	if (shift)
-		low = timestamp_offset_multiple(reg, width, index + shift);
+		safe_call(timestamp_offset_multiple_safe, (reg, width, index + shift, &low, escontext));
 
-	return low;
+	*result = low;
+	return true;
 }
 
 /*
@@ -420,10 +465,12 @@ timestamp_interval_bound(PG_FUNCTION_ARGS)
 	Interval   *width = PG_GETARG_INTERVAL_P(1);
 	int32		shift = 0;
 	Timestamp	reg = SetEpochTimestamp();
+	Timestamp	result;
 
-	PG_RETURN_TIMESTAMP(
-			timestamp_interval_bound_common(
-				val, width, shift, reg));
+	PG_SAFE_CALL(timestamp_interval_bound_common_safe, (
+				val, width, shift, reg, &result, fcinfo->context));
+
+	PG_RETURN_TIMESTAMP(result);
 }
 
 /*
@@ -436,6 +483,7 @@ timestamp_interval_bound_shift(PG_FUNCTION_ARGS)
 	Interval   *width;
 	int32		shift = 0;
 	Timestamp	reg;
+	Timestamp	result;
 
 	/* NULL, if either of the first two arguments is NULL. */
 	if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
@@ -450,9 +498,8 @@ timestamp_interval_bound_shift(PG_FUNCTION_ARGS)
 
 	reg = SetEpochTimestamp();
 
-	PG_RETURN_TIMESTAMP(
-			timestamp_interval_bound_common(
-				val, width, shift, reg));
+	PG_SAFE_CALL(timestamp_interval_bound_common_safe, (
+				val, width, shift, reg, &result, fcinfo->context));
 }
 
 /*
@@ -465,6 +512,7 @@ timestamp_interval_bound_shift_reg(PG_FUNCTION_ARGS)
 	Interval   *width;
 	int32		shift = 0;
 	Timestamp	reg;
+	Timestamp	result;
 
 	/* NULL, if either of the first two arguments is NULL. */
 	if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
@@ -483,9 +531,8 @@ timestamp_interval_bound_shift_reg(PG_FUNCTION_ARGS)
 	else
 		reg = SetEpochTimestamp();
 
-	PG_RETURN_TIMESTAMP(
-			timestamp_interval_bound_common(
-				val, width, shift, reg));
+	PG_SAFE_CALL(timestamp_interval_bound_common_safe, (
+				val, width, shift, reg, &result, fcinfo->context));
 }
 
 /*
@@ -495,29 +542,44 @@ timestamp_interval_bound_shift_reg(PG_FUNCTION_ARGS)
  *		interval_bound(timestamptz, interval, int, timestamptz)
  *		returns timestamptz
  */
+static bool
+timestamptz_interval_bound_common_safe(TimestampTz val, Interval *width,
+								  int32 shift, TimestampTz reg, TimestampTz *result, Node *escontext);
+
 static TimestampTz
 timestamptz_interval_bound_common(TimestampTz val, Interval *width,
 								  int32 shift, TimestampTz reg)
+{
+	TimestampTz result;
+	(void) timestamptz_interval_bound_common_safe(val, width, shift, reg, &result, NULL);
+	return result;
+}
+
+static bool
+timestamptz_interval_bound_common_safe(TimestampTz val, Interval *width,
+								  int32 shift, TimestampTz reg, TimestampTz *result, Node *escontext)
 {
 	int64		index = 0;
 	float8		quo = 0.0;
 	Interval	span;
 	TimestampTz	low;
-	TimestampTz	high;
+	TimestampTz	high = 0;
 	int			safety;
 
 	/* Insist on positive, interval width. */
 	if (interval_cmp_internal(width, &IntervalZero) <= 0)
-		ereport(ERROR,
+		ereturn(escontext, false,
 				(errcode(ERRCODE_INVALID_INTERVAL_WIDTH),
 				 errmsg("width of time interval not positive")));
 
 	/* Just return non-finite timestamp. */
-	if (TIMESTAMP_NOT_FINITE(val))
-		return val;
+	if (TIMESTAMP_NOT_FINITE(val)){
+		*result = val;
+		return true;
+	}
 
 	if (TIMESTAMP_NOT_FINITE(reg))
-		ereport(ERROR,
+		ereturn(escontext, false,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("bound for registration is not finite")));
 
@@ -535,10 +597,12 @@ timestamptz_interval_bound_common(TimestampTz val, Interval *width,
 	for (safety = 64; ; safety--)
 	{
 		if (safety <= 0)
-			elog(ERROR, "interval_bound failed to converge");
+			ereturn(escontext, false,
+						(errcode(ERRCODE_DATA_EXCEPTION),
+						 errmsg("interval_bound failed to converge")));
 
-		low = timestamptz_offset_multiple(reg, width, index);
-		high = timestamptz_offset_multiple(low, width, 1);
+		safe_call(timestamptz_offset_multiple_safe, (reg, width, index, &low, escontext));
+		safe_call(timestamptz_offset_multiple_safe, (low, width, 1, &high, escontext));
 
 		Assert(high > low);
 
@@ -576,9 +640,10 @@ timestamptz_interval_bound_common(TimestampTz val, Interval *width,
 
 	/* If necessary, shift the interval. */
 	if (shift)
-		low = timestamptz_offset_multiple(reg, width, index + shift);
+		safe_call(timestamptz_offset_multiple_safe, (reg, width, index + shift, &low, escontext));
 
-	return low;
+	*result = low;
+	return true;
 }
 
 /*
@@ -591,10 +656,12 @@ timestamptz_interval_bound(PG_FUNCTION_ARGS)
 	Interval   *width = PG_GETARG_INTERVAL_P(1);
 	int32		shift = 0;
 	TimestampTz	reg = SetEpochTimestamp();
+	TimestampTz result;
 
-	PG_RETURN_TIMESTAMPTZ(
-			timestamptz_interval_bound_common(
-				val, width, shift, reg));
+	PG_SAFE_CALL(timestamptz_interval_bound_common_safe, (
+				val, width, shift, reg, &result, fcinfo->context));
+
+	PG_RETURN_TIMESTAMPTZ(result);
 
 }
 
@@ -608,6 +675,7 @@ timestamptz_interval_bound_shift(PG_FUNCTION_ARGS)
 	Interval   *width;
 	int32		shift = 0;
 	TimestampTz	reg;
+	TimestampTz result;
 
 	/* NULL, if either of the first two arguments is NULL. */
 	if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
@@ -622,9 +690,10 @@ timestamptz_interval_bound_shift(PG_FUNCTION_ARGS)
 
 	reg = SetEpochTimestamp();
 
-	PG_RETURN_TIMESTAMPTZ(
-			timestamptz_interval_bound_common(
-				val, width, shift, reg));
+	PG_SAFE_CALL(timestamptz_interval_bound_common_safe, (
+				val, width, shift, reg, &result, fcinfo->context));
+
+	PG_RETURN_TIMESTAMPTZ(result);
 }
 
 /*
@@ -637,6 +706,7 @@ timestamptz_interval_bound_shift_reg(PG_FUNCTION_ARGS)
 	Interval   *width;
 	int32		shift = 0;
 	TimestampTz	reg;
+	TimestampTz result;
 
 	/* NULL, if either of the first two arguments is NULL. */
 	if (PG_ARGISNULL(0) || PG_ARGISNULL(1))
@@ -655,9 +725,10 @@ timestamptz_interval_bound_shift_reg(PG_FUNCTION_ARGS)
 	else
 		reg = SetEpochTimestamp();
 
-	PG_RETURN_TIMESTAMPTZ(
-			timestamptz_interval_bound_common(
-				val, width, shift, reg));
+	PG_SAFE_CALL(timestamptz_interval_bound_common_safe, (
+				val, width, shift, reg, &result, fcinfo->context));
+
+	PG_RETURN_TIMESTAMPTZ(result);
 }
 
 /* timestamp_transform()
@@ -684,13 +755,19 @@ timestamp_scale(PG_FUNCTION_ARGS)
 
 	result = timestamp;
 
-	AdjustTimestampForTypmod(&result, typmod);
+	PG_SAFE_CALL(AdjustTimestampForTypmodSafe, (&result, typmod, fcinfo->context));
 
 	PG_RETURN_TIMESTAMP(result);
 }
 
 static void
 AdjustTimestampForTypmod(Timestamp *time, int32 typmod)
+{
+	(void) AdjustTimestampForTypmodSafe(time, typmod, NULL);
+}
+
+static bool
+AdjustTimestampForTypmodSafe(Timestamp *time, int32 typmod, Node *escontext)
 {
 #ifdef HAVE_INT64_TIMESTAMP
 	static const int64 TimestampScales[MAX_TIMESTAMP_PRECISION + 1] = {
@@ -728,7 +805,7 @@ AdjustTimestampForTypmod(Timestamp *time, int32 typmod)
 		&& (typmod != -1) && (typmod != MAX_TIMESTAMP_PRECISION))
 	{
 		if (typmod < 0 || typmod > MAX_TIMESTAMP_PRECISION)
-			ereport(ERROR,
+			ereturn(escontext, false,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				  errmsg("timestamp(%d) precision must be between %d and %d",
 						 typmod, 0, MAX_TIMESTAMP_PRECISION)));
@@ -755,6 +832,7 @@ AdjustTimestampForTypmod(Timestamp *time, int32 typmod)
 		*time = rint((double) *time * TimestampScales[typmod]) / TimestampScales[typmod];
 #endif
 	}
+	return true;
 }
 
 
@@ -785,15 +863,15 @@ timestamptz_in(PG_FUNCTION_ARGS)
 	dterr = ParseDateTime(str, workbuf, sizeof(workbuf),
 						  field, ftype, MAXDATEFIELDS, &nf);
 	if (dterr == 0)
-		dterr = DecodeDateTime(field, ftype, nf, &dtype, tm, &fsec, &tz);
+		PG_SAFE_CALL(DecodeDateTimeSafe, (field, ftype, nf, &dtype, tm, &fsec, &tz, &dterr, fcinfo->context));
 	if (dterr != 0)
-		DateTimeParseError(dterr, str, "timestamp with time zone");
+		PG_SAFE_CALL(DateTimeParseErrorSafe, (dterr, str, "timestamp with time zone", fcinfo->context));
 
 	switch (dtype)
 	{
 		case DTK_DATE:
 			if (tm2timestamp(tm, fsec, &tz, &result) != 0)
-				ereport(ERROR,
+				PG_ERETURN(fcinfo->context,
 						(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 						 errmsg("timestamp out of range: \"%s\"", str)));
 			break;
@@ -811,7 +889,7 @@ timestamptz_in(PG_FUNCTION_ARGS)
 			break;
 
 		case DTK_INVALID:
-			ereport(ERROR,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 			  errmsg("date/time value \"%s\" is no longer supported", str)));
 
@@ -824,7 +902,7 @@ timestamptz_in(PG_FUNCTION_ARGS)
 			TIMESTAMP_NOEND(result);
 	}
 
-	AdjustTimestampForTypmod(&result, typmod);
+	PG_SAFE_CALL(AdjustTimestampForTypmodSafe, (&result, typmod, fcinfo->context));
 
 	PG_RETURN_TIMESTAMPTZ(result);
 }
@@ -836,8 +914,19 @@ timestamptz_in(PG_FUNCTION_ARGS)
  * Note: some code paths update tm->tm_isdst, and some don't; current callers
  * don't care, so we don't bother being consistent.
  */
+static bool
+parse_sane_timezone_safe(struct pg_tm * tm, text *zone, int *result, Node *escontext);
+
 static int
 parse_sane_timezone(struct pg_tm * tm, text *zone)
+{
+	int result;
+	(void) parse_sane_timezone_safe(tm, zone, &result, NULL);
+	return result;
+}
+
+static bool
+parse_sane_timezone_safe(struct pg_tm * tm, text *zone, int *result, Node *escontext)
 {
 	char		tzname[TZ_STRLEN_MAX + 1];
 	int			rt;
@@ -861,7 +950,7 @@ parse_sane_timezone(struct pg_tm * tm, text *zone)
 	 * position of our input string.
 	 */
 	if (isdigit((unsigned char) *tzname))
-		ereport(ERROR,
+		ereturn(escontext, false,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("invalid input syntax for numeric time zone: \"%s\"",
 						tzname),
@@ -876,11 +965,11 @@ parse_sane_timezone(struct pg_tm * tm, text *zone)
 		pg_tz	   *tzp;
 
 		if (rt == DTERR_TZDISP_OVERFLOW)
-			ereport(ERROR,
+			ereturn(escontext, false,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				   errmsg("numeric time zone \"%s\" out of range", tzname)));
 		else if (rt != DTERR_BAD_FORMAT)
-			ereport(ERROR,
+			ereturn(escontext, false,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("time zone \"%s\" not recognized", tzname)));
 
@@ -888,7 +977,7 @@ parse_sane_timezone(struct pg_tm * tm, text *zone)
 		lowzone = downcase_truncate_identifier(tzname,
 											   strlen(tzname),
 											   false);
-		type = DecodeTimezoneAbbrev(0, lowzone, &val, &tzp);
+		safe_call(DecodeTimezoneAbbrevSafe, (0, lowzone, &val, &tzp, &type, escontext));
 
 		if (type == TZ || type == DTZ)
 		{
@@ -907,22 +996,36 @@ parse_sane_timezone(struct pg_tm * tm, text *zone)
 			if (tzp)
 				tz = DetermineTimeZoneOffset(tm, tzp);
 			else
-				ereport(ERROR,
+				ereturn(escontext, false,
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						 errmsg("time zone \"%s\" not recognized", tzname)));
 		}
 	}
 
-	return tz;
+	*result = tz;
+	return true;
 }
 
 /*
  * make_timestamp_internal
  *		workhorse for make_timestamp and make_timestamptz
  */
+static bool
+make_timestamp_internal_safe(int year, int month, int day,
+						int hour, int min, double sec, Timestamp *res, Node *escontext);
+
 static Timestamp
 make_timestamp_internal(int year, int month, int day,
 						int hour, int min, double sec)
+{
+	Timestamp result;
+	(void) make_timestamp_internal_safe(year, month, day, hour, min, sec, &result, NULL);
+	return result;
+}
+
+static bool
+make_timestamp_internal_safe(int year, int month, int day,
+						int hour, int min, double sec, Timestamp *res, Node *escontext)
 {
 	struct pg_tm tm;
 	TimeOffset	date;
@@ -941,13 +1044,13 @@ make_timestamp_internal(int year, int month, int day,
 	dterr = ValidateDate(DTK_DATE_M, false, false, false, &tm);
 
 	if (dterr != 0)
-		ereport(ERROR,
+		ereturn(escontext, false,
 				(errcode(ERRCODE_DATETIME_FIELD_OVERFLOW),
 				 errmsg("date field value out of range: %d-%02d-%02d",
 						year, month, day)));
 
 	if (!IS_VALID_JULIAN(tm.tm_year, tm.tm_mon, tm.tm_mday))
-		ereport(ERROR,
+		ereturn(escontext, false,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("date out of range: %d-%02d-%02d",
 						year, month, day)));
@@ -966,7 +1069,7 @@ make_timestamp_internal(int year, int month, int day,
 		hour > HOURS_PER_DAY ||
 	/* test for > 24:00:00 */
 		(hour == HOURS_PER_DAY && (min > 0 || sec > 0)))
-		ereport(ERROR,
+		ereturn(escontext, false,
 				(errcode(ERRCODE_DATETIME_FIELD_OVERFLOW),
 				 errmsg("time field value out of range: %d:%02d:%02g",
 						hour, min, sec)));
@@ -979,7 +1082,7 @@ make_timestamp_internal(int year, int month, int day,
 	result = date * USECS_PER_DAY + time;
 	/* check for major overflow */
 	if ((result - time) / USECS_PER_DAY != date)
-		ereport(ERROR,
+		ereturn(escontext, 0,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("timestamp out of range: %d-%02d-%02d %d:%02d:%02g",
 						year, month, day,
@@ -989,7 +1092,7 @@ make_timestamp_internal(int year, int month, int day,
 	/* caution: we want to allow 1999-12-31 24:00:00 */
 	if ((result < 0 && date > 0) ||
 		(result > 0 && date < -1))
-		ereport(ERROR,
+		ereturn(escontext, 0,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("timestamp out of range: %d-%02d-%02d %d:%02d:%02g",
 						year, month, day,
@@ -999,7 +1102,8 @@ make_timestamp_internal(int year, int month, int day,
 	result = date * SECS_PER_DAY + time;
 #endif
 
-	return result;
+	*res = result;
+	return true;
 }
 
 /*
@@ -1016,8 +1120,9 @@ make_timestamp(PG_FUNCTION_ARGS)
 	float8		sec = PG_GETARG_FLOAT8(5);
 	Timestamp	result;
 
-	result = make_timestamp_internal(year, month, mday,
-									 hour, min, sec);
+	if (!make_timestamp_internal_safe(year, month, mday,
+									 hour, min, sec, &result, fcinfo->context))
+		PG_RETURN_NULL();
 
 	PG_RETURN_TIMESTAMP(result);
 }
@@ -1035,11 +1140,15 @@ make_timestamptz(PG_FUNCTION_ARGS)
 	int32		min = PG_GETARG_INT32(4);
 	float8		sec = PG_GETARG_FLOAT8(5);
 	Timestamp	result;
+	TimestampTz	result_tz;
 
-	result = make_timestamp_internal(year, month, mday,
-									 hour, min, sec);
+	if (!make_timestamp_internal_safe(year, month, mday,
+									 hour, min, sec, &result, fcinfo->context))
+		PG_RETURN_NULL();
 
-	PG_RETURN_TIMESTAMPTZ(timestamp2timestamptz(result));
+	PG_SAFE_CALL(timestamp2timestamptz_safe, (result, &result_tz, fcinfo->context));
+
+	PG_RETURN_TIMESTAMPTZ(result_tz);
 }
 
 /*
@@ -1061,15 +1170,17 @@ make_timestamptz_at_timezone(PG_FUNCTION_ARGS)
 	int			tz;
 	fsec_t		fsec;
 
-	timestamp = make_timestamp_internal(year, month, mday,
-										hour, min, sec);
+	if (!make_timestamp_internal_safe(year, month, mday,
+									 hour, min, sec, &timestamp, fcinfo->context))
+		PG_RETURN_NULL();
 
 	if (timestamp2tm(timestamp, NULL, &tt, &fsec, NULL, NULL) != 0)
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("timestamp out of range")));
 
-	tz = parse_sane_timezone(&tt, zone);
+	if (!parse_sane_timezone_safe(&tt, zone, &tz, fcinfo->context))
+		PG_RETURN_NULL();
 
 	PG_RETURN_TIMESTAMPTZ((TimestampTz) dt2local(timestamp, -tz));
 }
@@ -1094,7 +1205,7 @@ timestamptz_out(PG_FUNCTION_ARGS)
 	else if (timestamp2tm(dt, &tz, tm, &fsec, &tzn, NULL) == 0)
 		EncodeDateTime(tm, fsec, true, tz, tzn, DateStyle, buf);
 	else
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("timestamp out of range")));
 
@@ -1133,11 +1244,11 @@ timestamptz_recv(PG_FUNCTION_ARGS)
 	if (TIMESTAMP_NOT_FINITE(timestamp))
 		 /* ok */ ;
 	else if (timestamp2tm(timestamp, &tz, tm, &fsec, NULL, NULL) != 0)
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("timestamp out of range")));
 
-	AdjustTimestampForTypmod(&timestamp, typmod);
+	PG_SAFE_CALL(AdjustTimestampForTypmodSafe, (&timestamp, typmod, fcinfo->context));
 
 	PG_RETURN_TIMESTAMPTZ(timestamp);
 }
@@ -1165,7 +1276,11 @@ timestamptztypmodin(PG_FUNCTION_ARGS)
 {
 	ArrayType  *ta = PG_GETARG_ARRAYTYPE_P(0);
 
-	PG_RETURN_INT32(anytimestamp_typmodin(true, ta));
+	int32 typmod = 0;
+	if (!anytimestamp_typmodin_safe(true, ta, &typmod, fcinfo->context))
+		PG_RETURN_NULL();
+
+	PG_RETURN_INT32(typmod);
 }
 
 Datum
@@ -1190,7 +1305,7 @@ timestamptz_scale(PG_FUNCTION_ARGS)
 
 	result = timestamp;
 
-	AdjustTimestampForTypmod(&result, typmod);
+	PG_SAFE_CALL(AdjustTimestampForTypmodSafe, (&result, typmod, fcinfo->context));
 
 	PG_RETURN_TIMESTAMPTZ(result);
 }
@@ -1251,7 +1366,7 @@ interval_in(PG_FUNCTION_ARGS)
 	{
 		if (dterr == DTERR_FIELD_OVERFLOW)
 			dterr = DTERR_INTERVAL_OVERFLOW;
-		DateTimeParseError(dterr, str, "interval");
+		PG_SAFE_CALL(DateTimeParseErrorSafe, (dterr, str, "interval", fcinfo->context));
 	}
 
 	result = (Interval *) palloc(sizeof(Interval));
@@ -1260,13 +1375,13 @@ interval_in(PG_FUNCTION_ARGS)
 	{
 		case DTK_DELTA:
 			if (tm2interval(tm, fsec, result) != 0)
-				ereport(ERROR,
+				PG_ERETURN(fcinfo->context,
 						(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 						 errmsg("interval out of range")));
 			break;
 
 		case DTK_INVALID:
-			ereport(ERROR,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 			  errmsg("date/time value \"%s\" is no longer supported", str)));
 			break;
@@ -1276,7 +1391,7 @@ interval_in(PG_FUNCTION_ARGS)
 				 dtype, str);
 	}
 
-	AdjustIntervalForTypmod(result, typmod);
+	PG_SAFE_CALL(AdjustIntervalForTypmodSafe, (result, typmod, fcinfo->context));
 
 	PG_RETURN_INTERVAL_P(result);
 }
@@ -1291,10 +1406,10 @@ interval_out(PG_FUNCTION_ARGS)
 	char	   *result;
 	struct pg_tm tt,
 			   *tm = &tt;
-	fsec_t		fsec;
+	fsec_t		fsec = 0;
 	char		buf[MAXDATELEN + 1];
 
-	if (interval2tm(*span, tm, &fsec) != 0)
+	if (interval2tm_safe(*span, tm, &fsec, fcinfo->context) != 0)
 		elog(ERROR, "could not convert interval to tm");
 
 	EncodeInterval(tm, fsec, IntervalStyle, buf);
@@ -1327,7 +1442,7 @@ interval_recv(PG_FUNCTION_ARGS)
 	interval->day = pq_getmsgint(buf, sizeof(interval->day));
 	interval->month = pq_getmsgint(buf, sizeof(interval->month));
 
-	AdjustIntervalForTypmod(interval, typmod);
+	PG_SAFE_CALL(AdjustIntervalForTypmodSafe, (interval, typmod, fcinfo->context));
 
 	PG_RETURN_INTERVAL_P(interval);
 }
@@ -1401,7 +1516,7 @@ intervaltypmodin(PG_FUNCTION_ARGS)
 				/* all OK */
 				break;
 			default:
-				ereport(ERROR,
+				PG_ERETURN(fcinfo->context,
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						 errmsg("invalid INTERVAL type modifier")));
 		}
@@ -1417,7 +1532,7 @@ intervaltypmodin(PG_FUNCTION_ARGS)
 	else if (n == 2)
 	{
 		if (tl[1] < 0)
-			ereport(ERROR,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("INTERVAL(%d) precision must not be negative",
 							tl[1])));
@@ -1434,7 +1549,7 @@ intervaltypmodin(PG_FUNCTION_ARGS)
 	}
 	else
 	{
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("invalid INTERVAL type modifier")));
 		typmod = 0;				/* keep compiler quiet */
@@ -1646,7 +1761,7 @@ interval_scale(PG_FUNCTION_ARGS)
 	result = palloc(sizeof(Interval));
 	*result = *interval;
 
-	AdjustIntervalForTypmod(result, typmod);
+	PG_SAFE_CALL(AdjustIntervalForTypmodSafe, (result, typmod, fcinfo->context));
 
 	PG_RETURN_INTERVAL_P(result);
 }
@@ -1657,6 +1772,12 @@ interval_scale(PG_FUNCTION_ARGS)
  */
 static void
 AdjustIntervalForTypmod(Interval *interval, int32 typmod)
+{
+	(void) AdjustIntervalForTypmodSafe(interval, typmod, NULL);
+}
+
+static bool
+AdjustIntervalForTypmodSafe(Interval *interval, int32 typmod, Node* escontext)
 {
 #ifdef HAVE_INT64_TIMESTAMP
 	static const int64 IntervalScales[MAX_INTERVAL_PRECISION + 1] = {
@@ -1822,13 +1943,15 @@ AdjustIntervalForTypmod(Interval *interval, int32 typmod)
 			/* fractional-second rounding will be dealt with below */
 		}
 		else
-			elog(ERROR, "unrecognized interval typmod: %d", typmod);
+			ereturn(escontext, false,
+						(errcode(ERRCODE_DATA_EXCEPTION),
+						 errmsg("unrecognized interval typmod: %d", typmod)));
 
 		/* Need to adjust subsecond precision? */
 		if (precision != INTERVAL_FULL_PRECISION)
 		{
 			if (precision < 0 || precision > MAX_INTERVAL_PRECISION)
-				ereport(ERROR,
+				ereturn(escontext, false,
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				   errmsg("interval(%d) precision must be between %d and %d",
 						  precision, 0, MAX_INTERVAL_PRECISION)));
@@ -1862,6 +1985,7 @@ AdjustIntervalForTypmod(Interval *interval, int32 typmod)
 #endif
 		}
 	}
+	return true;
 }
 
 /*
@@ -1884,7 +2008,7 @@ make_interval(PG_FUNCTION_ARGS)
 	 * inputs as well, but it's not entirely clear what limits to apply.
 	 */
 	if (isinf(secs) || isnan(secs))
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("interval out of range")));
 
@@ -2375,7 +2499,15 @@ tm2timestamp(struct pg_tm * tm, fsec_t fsec, int *tzp, Timestamp *result)
  * Convert a interval data type to a tm structure.
  */
 int
-interval2tm(Interval span, struct pg_tm * tm, fsec_t *fsec)
+interval2tm_safe(Interval span, struct pg_tm * tm, fsec_t *fsec, Node* escontext);
+
+int
+interval2tm(Interval span, struct pg_tm * tm, fsec_t *fsec) {
+	return interval2tm_safe(span, tm, fsec, NULL);
+}
+
+int
+interval2tm_safe(Interval span, struct pg_tm * tm, fsec_t *fsec, Node* escontext)
 {
 	TimeOffset	time;
 	TimeOffset	tfrac;
@@ -2390,7 +2522,7 @@ interval2tm(Interval span, struct pg_tm * tm, fsec_t *fsec)
 	time -= tfrac * USECS_PER_HOUR;
 	tm->tm_hour = tfrac;
 	if (!SAMESIGN(tm->tm_hour, tfrac))
-		ereport(ERROR,
+		ereturn(escontext, -1,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("interval out of range")));
 	tfrac = time / USECS_PER_MINUTE;
@@ -2674,7 +2806,7 @@ timestamp_eq_timestamptz(PG_FUNCTION_ARGS)
 	TimestampTz dt2 = PG_GETARG_TIMESTAMPTZ(1);
 	TimestampTz dt1;
 
-	dt1 = timestamp2timestamptz(timestampVal);
+	PG_SAFE_CALL(timestamp2timestamptz_safe, (timestampVal, &dt1, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamp_cmp_internal(dt1, dt2) == 0);
 }
@@ -2686,7 +2818,7 @@ timestamp_ne_timestamptz(PG_FUNCTION_ARGS)
 	TimestampTz dt2 = PG_GETARG_TIMESTAMPTZ(1);
 	TimestampTz dt1;
 
-	dt1 = timestamp2timestamptz(timestampVal);
+	PG_SAFE_CALL(timestamp2timestamptz_safe, (timestampVal, &dt1, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamp_cmp_internal(dt1, dt2) != 0);
 }
@@ -2698,7 +2830,7 @@ timestamp_lt_timestamptz(PG_FUNCTION_ARGS)
 	TimestampTz dt2 = PG_GETARG_TIMESTAMPTZ(1);
 	TimestampTz dt1;
 
-	dt1 = timestamp2timestamptz(timestampVal);
+	PG_SAFE_CALL(timestamp2timestamptz_safe, (timestampVal, &dt1, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamp_cmp_internal(dt1, dt2) < 0);
 }
@@ -2710,7 +2842,7 @@ timestamp_gt_timestamptz(PG_FUNCTION_ARGS)
 	TimestampTz dt2 = PG_GETARG_TIMESTAMPTZ(1);
 	TimestampTz dt1;
 
-	dt1 = timestamp2timestamptz(timestampVal);
+	PG_SAFE_CALL(timestamp2timestamptz_safe, (timestampVal, &dt1, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamp_cmp_internal(dt1, dt2) > 0);
 }
@@ -2722,7 +2854,7 @@ timestamp_le_timestamptz(PG_FUNCTION_ARGS)
 	TimestampTz dt2 = PG_GETARG_TIMESTAMPTZ(1);
 	TimestampTz dt1;
 
-	dt1 = timestamp2timestamptz(timestampVal);
+	PG_SAFE_CALL(timestamp2timestamptz_safe, (timestampVal, &dt1, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamp_cmp_internal(dt1, dt2) <= 0);
 }
@@ -2734,7 +2866,7 @@ timestamp_ge_timestamptz(PG_FUNCTION_ARGS)
 	TimestampTz dt2 = PG_GETARG_TIMESTAMPTZ(1);
 	TimestampTz dt1;
 
-	dt1 = timestamp2timestamptz(timestampVal);
+	PG_SAFE_CALL(timestamp2timestamptz_safe, (timestampVal, &dt1, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamp_cmp_internal(dt1, dt2) >= 0);
 }
@@ -2746,7 +2878,7 @@ timestamp_cmp_timestamptz(PG_FUNCTION_ARGS)
 	TimestampTz dt2 = PG_GETARG_TIMESTAMPTZ(1);
 	TimestampTz dt1;
 
-	dt1 = timestamp2timestamptz(timestampVal);
+	PG_SAFE_CALL(timestamp2timestamptz_safe, (timestampVal, &dt1, fcinfo->context));
 
 	PG_RETURN_INT32(timestamp_cmp_internal(dt1, dt2));
 }
@@ -2758,7 +2890,7 @@ timestamptz_eq_timestamp(PG_FUNCTION_ARGS)
 	Timestamp	timestampVal = PG_GETARG_TIMESTAMP(1);
 	TimestampTz dt2;
 
-	dt2 = timestamp2timestamptz(timestampVal);
+	PG_SAFE_CALL(timestamp2timestamptz_safe, (timestampVal, &dt2, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamp_cmp_internal(dt1, dt2) == 0);
 }
@@ -2770,7 +2902,7 @@ timestamptz_ne_timestamp(PG_FUNCTION_ARGS)
 	Timestamp	timestampVal = PG_GETARG_TIMESTAMP(1);
 	TimestampTz dt2;
 
-	dt2 = timestamp2timestamptz(timestampVal);
+	PG_SAFE_CALL(timestamp2timestamptz_safe, (timestampVal, &dt2, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamp_cmp_internal(dt1, dt2) != 0);
 }
@@ -2782,7 +2914,7 @@ timestamptz_lt_timestamp(PG_FUNCTION_ARGS)
 	Timestamp	timestampVal = PG_GETARG_TIMESTAMP(1);
 	TimestampTz dt2;
 
-	dt2 = timestamp2timestamptz(timestampVal);
+	PG_SAFE_CALL(timestamp2timestamptz_safe, (timestampVal, &dt2, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamp_cmp_internal(dt1, dt2) < 0);
 }
@@ -2794,7 +2926,7 @@ timestamptz_gt_timestamp(PG_FUNCTION_ARGS)
 	Timestamp	timestampVal = PG_GETARG_TIMESTAMP(1);
 	TimestampTz dt2;
 
-	dt2 = timestamp2timestamptz(timestampVal);
+	PG_SAFE_CALL(timestamp2timestamptz_safe, (timestampVal, &dt2, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamp_cmp_internal(dt1, dt2) > 0);
 }
@@ -2806,7 +2938,7 @@ timestamptz_le_timestamp(PG_FUNCTION_ARGS)
 	Timestamp	timestampVal = PG_GETARG_TIMESTAMP(1);
 	TimestampTz dt2;
 
-	dt2 = timestamp2timestamptz(timestampVal);
+	PG_SAFE_CALL(timestamp2timestamptz_safe, (timestampVal, &dt2, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamp_cmp_internal(dt1, dt2) <= 0);
 }
@@ -2818,7 +2950,7 @@ timestamptz_ge_timestamp(PG_FUNCTION_ARGS)
 	Timestamp	timestampVal = PG_GETARG_TIMESTAMP(1);
 	TimestampTz dt2;
 
-	dt2 = timestamp2timestamptz(timestampVal);
+	PG_SAFE_CALL(timestamp2timestamptz_safe, (timestampVal, &dt2, fcinfo->context));
 
 	PG_RETURN_BOOL(timestamp_cmp_internal(dt1, dt2) >= 0);
 }
@@ -2830,7 +2962,7 @@ timestamptz_cmp_timestamp(PG_FUNCTION_ARGS)
 	Timestamp	timestampVal = PG_GETARG_TIMESTAMP(1);
 	TimestampTz dt2;
 
-	dt2 = timestamp2timestamptz(timestampVal);
+	PG_SAFE_CALL(timestamp2timestamptz_safe, (timestampVal, &dt2, fcinfo->context));
 
 	PG_RETURN_INT32(timestamp_cmp_internal(dt1, dt2));
 }
@@ -2955,8 +3087,18 @@ interval_div_internal(Interval *interval1, Interval *interval2,
 static inline Timestamp
 timestamp_offset_internal(Timestamp timestamp, Interval *span)
 {
-	if (TIMESTAMP_NOT_FINITE(timestamp))
-		return timestamp;
+	Timestamp result;
+	(void) timestamp_offset_internal_safe(timestamp, span, &result, NULL);
+	return result;
+}
+
+static inline bool
+timestamp_offset_internal_safe(Timestamp timestamp, Interval *span, Timestamp *result, Node *escontext)
+{
+	if (TIMESTAMP_NOT_FINITE(timestamp)) {
+		*result = timestamp;
+		return true;
+	}
 
 	if (span->month != 0)
 	{
@@ -2965,7 +3107,7 @@ timestamp_offset_internal(Timestamp timestamp, Interval *span)
 		fsec_t		fsec = 0;
 
 		if (timestamp2tm(timestamp, NULL, tm, &fsec, NULL, NULL) != 0)
-			ereport(ERROR,
+			ereturn(escontext, false,
 					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 					 errmsg("timestamp out of range")));
 
@@ -2986,7 +3128,7 @@ timestamp_offset_internal(Timestamp timestamp, Interval *span)
 			tm->tm_mday = (day_tab[isleap(tm->tm_year)][tm->tm_mon - 1]);
 
 		if (tm2timestamp(tm, fsec, NULL, &timestamp) != 0)
-			ereport(ERROR,
+			ereturn(escontext, false,
 					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 					 errmsg("timestamp out of range")));
 	}
@@ -2999,7 +3141,7 @@ timestamp_offset_internal(Timestamp timestamp, Interval *span)
 		int			julian;
 
 		if (timestamp2tm(timestamp, NULL, tm, &fsec, NULL, NULL) != 0)
-			ereport(ERROR,
+			ereturn(escontext, false,
 					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 					 errmsg("timestamp out of range")));
 
@@ -3008,13 +3150,14 @@ timestamp_offset_internal(Timestamp timestamp, Interval *span)
 		j2date(julian, &tm->tm_year, &tm->tm_mon, &tm->tm_mday);
 
 		if (tm2timestamp(tm, fsec, NULL, &timestamp) != 0)
-			ereport(ERROR,
+			ereturn(escontext, false,
 					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 					 errmsg("timestamp out of range")));
 	}
 
 	timestamp += span->time;
-	return timestamp;
+	*result = timestamp;
+	return true;
 }
 
 /*
@@ -3023,13 +3166,23 @@ timestamp_offset_internal(Timestamp timestamp, Interval *span)
 static inline Timestamp
 timestamp_offset_multiple(Timestamp base, Interval *unit, int64 mul)
 {
+	Timestamp result;
+	(void) timestamp_offset_multiple_safe(base, unit, mul, &result, NULL);
+	return result;
+}
+
+static inline bool
+timestamp_offset_multiple_safe(Timestamp base, Interval *unit, int64 mul, Timestamp *result, Node *escontext)
+{
 	Interval span;
 
 	span.time = unit->time * mul;
 	span.month = unit->month * mul;
 	span.day = unit->day * mul;
 
-	return timestamp_offset_internal(base, &span);
+	safe_call(timestamp_offset_internal_safe, (base, &span, result, escontext));
+
+	return true;
 }
 
 /*
@@ -3049,10 +3202,20 @@ timestamp_offset_multiple(Timestamp base, Interval *unit, int64 mul)
 static inline TimestampTz
 timestamptz_offset_internal(TimestampTz timestamp, Interval *span)
 {
+	TimestampTz result;
+	(void) timestamptz_offset_internal_safe(timestamp, span, &result, NULL);
+	return result;
+}
+
+static inline bool
+timestamptz_offset_internal_safe(TimestampTz timestamp, Interval *span, TimestampTz *result, Node *escontext)
+{
 	int			tz;
 
-	if (TIMESTAMP_NOT_FINITE(timestamp))
-		return timestamp;
+	if (TIMESTAMP_NOT_FINITE(timestamp)) {
+		*result = timestamp;
+		return true;
+	}
 
 	if (span->month != 0)
 	{
@@ -3061,7 +3224,7 @@ timestamptz_offset_internal(TimestampTz timestamp, Interval *span)
 		fsec_t		fsec = 0;
 
 		if (timestamp2tm(timestamp, &tz, tm, &fsec, NULL, NULL) != 0)
-			ereport(ERROR,
+			ereturn(escontext, false,
 					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 					 errmsg("timestamp out of range")));
 
@@ -3084,7 +3247,7 @@ timestamptz_offset_internal(TimestampTz timestamp, Interval *span)
 		tz = DetermineTimeZoneOffset(tm, session_timezone);
 
 		if (tm2timestamp(tm, fsec, &tz, &timestamp) != 0)
-			ereport(ERROR,
+			ereturn(escontext, false,
 					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 					 errmsg("timestamp out of range")));
 	}
@@ -3097,7 +3260,7 @@ timestamptz_offset_internal(TimestampTz timestamp, Interval *span)
 		int			julian;
 
 		if (timestamp2tm(timestamp, &tz, tm, &fsec, NULL, NULL) != 0)
-			ereport(ERROR,
+			ereturn(escontext, false,
 					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 					 errmsg("timestamp out of range")));
 
@@ -3108,13 +3271,14 @@ timestamptz_offset_internal(TimestampTz timestamp, Interval *span)
 		tz = DetermineTimeZoneOffset(tm, session_timezone);
 
 		if (tm2timestamp(tm, fsec, &tz, &timestamp) != 0)
-			ereport(ERROR,
+			ereturn(escontext, false,
 					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 					 errmsg("timestamp out of range")));
 	}
 
 	timestamp += span->time;
-	return timestamp;
+	*result = timestamp;
+	return true;
 }
 
 
@@ -3124,13 +3288,23 @@ timestamptz_offset_internal(TimestampTz timestamp, Interval *span)
 static inline TimestampTz
 timestamptz_offset_multiple(TimestampTz base, Interval *unit, int64 mul)
 {
+	TimestampTz result;
+	(void) timestamptz_offset_multiple_safe(base, unit, mul, &result, NULL);
+	return result;
+}
+
+static inline bool
+timestamptz_offset_multiple_safe(TimestampTz base, Interval *unit, int64 mul, TimestampTz *result, Node *escontext)
+{
 	Interval span;
 
 	span.time = unit->time * mul;
 	span.month = unit->month * mul;
 	span.day = unit->day * mul;
 
-	return timestamptz_offset_internal(base, &span);
+	safe_call(timestamptz_offset_internal_safe, (base, &span, result, escontext));
+
+	return true;
 }
 
 
@@ -3399,7 +3573,7 @@ timestamp_mi(PG_FUNCTION_ARGS)
 	result = (Interval *) palloc(sizeof(Interval));
 
 	if (TIMESTAMP_NOT_FINITE(dt1) || TIMESTAMP_NOT_FINITE(dt2))
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("cannot subtract infinite timestamps")));
 
@@ -3605,7 +3779,7 @@ timestamp_pl_interval(PG_FUNCTION_ARGS)
 	Interval   *span = PG_GETARG_INTERVAL_P(1);
 	Timestamp	result;
 
-	result = timestamp_offset_internal(timestamp, span);
+	PG_SAFE_CALL(timestamp_offset_internal_safe, (timestamp, span, &result, fcinfo->context));
 
 	PG_RETURN_TIMESTAMP(result);
 }
@@ -3622,7 +3796,7 @@ timestamp_mi_interval(PG_FUNCTION_ARGS)
 	tspan.day = -span->day;
 	tspan.time = -span->time;
 
-	result = timestamp_offset_internal(timestamp, &tspan);
+	PG_SAFE_CALL(timestamp_offset_internal_safe, (timestamp, &tspan, &result, fcinfo->context));
 
 	PG_RETURN_TIMESTAMP(result);
 }
@@ -3636,7 +3810,8 @@ timestamptz_pl_interval(PG_FUNCTION_ARGS)
 {
 	TimestampTz timestamp = PG_GETARG_TIMESTAMPTZ(0);
 	Interval   *span = PG_GETARG_INTERVAL_P(1);
-	TimestampTz result = timestamptz_offset_internal(timestamp, span);
+	TimestampTz result = 0;
+	PG_SAFE_CALL(timestamptz_offset_internal_safe, (timestamp, span, &result, fcinfo->context));
 
 	PG_RETURN_TIMESTAMP(result);
 }
@@ -3647,13 +3822,14 @@ timestamptz_mi_interval(PG_FUNCTION_ARGS)
 	TimestampTz timestamp = PG_GETARG_TIMESTAMPTZ(0);
 	Interval   *span = PG_GETARG_INTERVAL_P(1);
 	Interval	tspan;
-	TimestampTz result;
+	TimestampTz result = 0;
 
 	tspan.month = -span->month;
 	tspan.day = -span->day;
 	tspan.time = -span->time;
 
-	result = timestamptz_offset_internal(timestamp, &tspan);
+	PG_SAFE_CALL(timestamptz_offset_internal_safe, (timestamp, &tspan, &result, fcinfo->context));
+
 	PG_RETURN_TIMESTAMP(result);
 }
 
@@ -3669,17 +3845,17 @@ interval_um(PG_FUNCTION_ARGS)
 	result->time = -interval->time;
 	/* overflow check copied from int4um */
 	if (interval->time != 0 && SAMESIGN(result->time, interval->time))
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("interval out of range")));
 	result->day = -interval->day;
 	if (interval->day != 0 && SAMESIGN(result->day, interval->day))
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("interval out of range")));
 	result->month = -interval->month;
 	if (interval->month != 0 && SAMESIGN(result->month, interval->month))
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("interval out of range")));
 
@@ -3729,21 +3905,21 @@ interval_pl(PG_FUNCTION_ARGS)
 	/* overflow check copied from int4pl */
 	if (SAMESIGN(span1->month, span2->month) &&
 		!SAMESIGN(result->month, span1->month))
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("interval out of range")));
 
 	result->day = span1->day + span2->day;
 	if (SAMESIGN(span1->day, span2->day) &&
 		!SAMESIGN(result->day, span1->day))
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("interval out of range")));
 
 	result->time = span1->time + span2->time;
 	if (SAMESIGN(span1->time, span2->time) &&
 		!SAMESIGN(result->time, span1->time))
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("interval out of range")));
 
@@ -3763,21 +3939,21 @@ interval_mi(PG_FUNCTION_ARGS)
 	/* overflow check copied from int4mi */
 	if (!SAMESIGN(span1->month, span2->month) &&
 		!SAMESIGN(result->month, span1->month))
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("interval out of range")));
 
 	result->day = span1->day - span2->day;
 	if (!SAMESIGN(span1->day, span2->day) &&
 		!SAMESIGN(result->day, span1->day))
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("interval out of range")));
 
 	result->time = span1->time - span2->time;
 	if (!SAMESIGN(span1->time, span2->time) &&
 		!SAMESIGN(result->time, span1->time))
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("interval out of range")));
 
@@ -3806,14 +3982,14 @@ interval_mul(PG_FUNCTION_ARGS)
 
 	result_double = span->month * factor;
 	if (result_double > INT_MAX || result_double < INT_MIN)
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("interval out of range")));
 	result->month = (int32) result_double;
 
 	result_double = span->day * factor;
 	if (result_double > INT_MAX || result_double < INT_MIN)
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("interval out of range")));
 	result->day = (int32) result_double;
@@ -3858,7 +4034,7 @@ interval_mul(PG_FUNCTION_ARGS)
 #ifdef HAVE_INT64_TIMESTAMP
 	result_double = rint(span->time * factor + sec_remainder * USECS_PER_SEC);
 	if (isnan(result_double) || !FLOAT8_FITS_IN_INT64(result_double))
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("interval out of range")));
 	result->time = (int64) result_double;
@@ -3958,7 +4134,7 @@ interval_div(PG_FUNCTION_ARGS)
 	result = (Interval *) palloc(sizeof(Interval));
 
 	if (factor == 0.0)
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DIVISION_BY_ZERO),
 				 errmsg("division by zero")));
 
@@ -4000,7 +4176,7 @@ interval_interval_div(PG_FUNCTION_ARGS)
 	float8		result = 0.0;
 
 	if (interval_cmp_internal(divisor, &IntervalZero) == 0)
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DIVISION_BY_ZERO),
 				 errmsg("division by zero")));
 
@@ -4023,7 +4199,7 @@ interval_interval_mod(PG_FUNCTION_ARGS)
 	Interval	*result =  (Interval *) palloc0(sizeof(Interval));
 
 	if (interval_cmp_internal(divisor, &IntervalZero) == 0)
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DIVISION_BY_ZERO),
 				 errmsg("division by zero")));
 
@@ -4305,12 +4481,12 @@ timestamp_age(PG_FUNCTION_ARGS)
 		}
 
 		if (tm2interval(tm, fsec, result) != 0)
-			ereport(ERROR,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 					 errmsg("interval out of range")));
 	}
 	else
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("timestamp out of range")));
 
@@ -4434,12 +4610,12 @@ timestamptz_age(PG_FUNCTION_ARGS)
 		}
 
 		if (tm2interval(tm, fsec, result) != 0)
-			ereport(ERROR,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 					 errmsg("interval out of range")));
 	}
 	else
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 				 errmsg("timestamp out of range")));
 
@@ -4503,6 +4679,14 @@ timestamp_li_fraction(Timestamp x, Timestamp x0, Timestamp x1,
 Timestamp
 timestamp_li_value(float8 f, Timestamp y0, Timestamp y1)
 {
+	Timestamp result = 0;
+	(void) timestamp_li_value_safe(f, y0, y1, &result, NULL);
+	return result;
+}
+
+bool
+timestamp_li_value_safe(float8 f, Timestamp y0, Timestamp y1, Timestamp *result, Node *escontext)
+{
 	Timestamp y;
 	Interval diffy;
 	Interval *offset;
@@ -4513,10 +4697,13 @@ timestamp_li_value(float8 f, Timestamp y0, Timestamp y1)
 	
 	offset = DatumGetIntervalP(DirectFunctionCall2(interval_mul, IntervalPGetDatum(&diffy),
 									Float8GetDatum(f)));
-	y = timestamp_offset_internal(y0, offset);
+	safe_call_with_free(timestamp_offset_internal_safe, (y0, offset, result, escontext), {
+		pfree(offset);
+	});
+	
 	pfree(offset);
 	
-	return y;
+	return true;
 }
 
 /*
@@ -4545,8 +4732,17 @@ timestamptz_li_fraction(TimestampTz x, TimestampTz x0, TimestampTz x1,
 Timestamp
 timestamptz_li_value(float8 f, TimestampTz y0, TimestampTz y1)
 {
+	Timestamp result = 0;
+	(void) timestamptz_li_value_safe(f, y0, y1, &result, NULL);
+	return result;
+}
+
+bool
+timestamptz_li_value_safe(float8 f, TimestampTz y0, TimestampTz y1, Timestamp *result, Node *escontext)
+{
 	/* Internally identical to Timestamp */
-	return timestamp_li_value(f, y0, y1);
+	safe_call(timestamp_li_value_safe, (f, y0, y1, result, escontext));
+	return true;
 }
 
 /*----------------------------------------------------------
@@ -4582,7 +4778,7 @@ timestamp_trunc(PG_FUNCTION_ARGS)
 	if (type == UNITS)
 	{
 		if (timestamp2tm(timestamp, NULL, tm, &fsec, NULL, NULL) != 0)
-			ereport(ERROR,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 					 errmsg("timestamp out of range")));
 
@@ -4671,7 +4867,7 @@ timestamp_trunc(PG_FUNCTION_ARGS)
 				break;
 
 			default:
-				ereport(ERROR,
+				PG_ERETURN(fcinfo->context,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("timestamp units \"%s\" not supported",
 								lowunits)));
@@ -4679,13 +4875,13 @@ timestamp_trunc(PG_FUNCTION_ARGS)
 		}
 
 		if (tm2timestamp(tm, fsec, NULL, &result) != 0)
-			ereport(ERROR,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 					 errmsg("timestamp out of range")));
 	}
 	else
 	{
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("timestamp units \"%s\" not recognized",
 						lowunits)));
@@ -4725,7 +4921,7 @@ timestamptz_trunc(PG_FUNCTION_ARGS)
 	if (type == UNITS)
 	{
 		if (timestamp2tm(timestamp, &tz, tm, &fsec, NULL, NULL) != 0)
-			ereport(ERROR,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 					 errmsg("timestamp out of range")));
 
@@ -4825,7 +5021,7 @@ timestamptz_trunc(PG_FUNCTION_ARGS)
 				break;
 
 			default:
-				ereport(ERROR,
+				PG_ERETURN(fcinfo->context,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("timestamp with time zone units \"%s\" not "
 								"supported", lowunits)));
@@ -4836,13 +5032,13 @@ timestamptz_trunc(PG_FUNCTION_ARGS)
 			tz = DetermineTimeZoneOffset(tm, session_timezone);
 
 		if (tm2timestamp(tm, fsec, &tz, &result) != 0)
-			ereport(ERROR,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 					 errmsg("timestamp out of range")));
 	}
 	else
 	{
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 			   errmsg("timestamp with time zone units \"%s\" not recognized",
 					  lowunits)));
@@ -4878,7 +5074,7 @@ interval_trunc(PG_FUNCTION_ARGS)
 
 	if (type == UNITS)
 	{
-		if (interval2tm(*interval, tm, &fsec) == 0)
+		if (interval2tm_safe(*interval, tm, &fsec, fcinfo->context) == 0)
 		{
 			switch (val)
 			{
@@ -4932,20 +5128,20 @@ interval_trunc(PG_FUNCTION_ARGS)
 
 				default:
 					if (val == DTK_WEEK)
-						ereport(ERROR,
+						PG_ERETURN(fcinfo->context,
 								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 								 errmsg("interval units \"%s\" not supported "
 							  "because months usually have fractional weeks",
 										lowunits)));
 					else
-						ereport(ERROR,
+						PG_ERETURN(fcinfo->context,
 								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 								 errmsg("interval units \"%s\" not supported",
 										lowunits)));
 			}
 
 			if (tm2interval(tm, fsec, result) != 0)
-				ereport(ERROR,
+				PG_ERETURN(fcinfo->context,
 						(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 						 errmsg("interval out of range")));
 		}
@@ -4954,7 +5150,7 @@ interval_trunc(PG_FUNCTION_ARGS)
 	}
 	else
 	{
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("interval units \"%s\" not recognized",
 						lowunits)));
@@ -5170,7 +5366,7 @@ timestamp_part(PG_FUNCTION_ARGS)
 	if (type == UNITS)
 	{
 		if (timestamp2tm(timestamp, NULL, tm, &fsec, NULL, NULL) != 0)
-			ereport(ERROR,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 					 errmsg("timestamp out of range")));
 
@@ -5302,7 +5498,7 @@ timestamp_part(PG_FUNCTION_ARGS)
 			case DTK_TZ_MINUTE:
 			case DTK_TZ_HOUR:
 			default:
-				ereport(ERROR,
+				PG_ERETURN(fcinfo->context,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("timestamp units \"%s\" not supported",
 								lowunits)));
@@ -5322,7 +5518,7 @@ timestamp_part(PG_FUNCTION_ARGS)
 				break;
 
 			default:
-				ereport(ERROR,
+				PG_ERETURN(fcinfo->context,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("timestamp units \"%s\" not supported",
 								lowunits)));
@@ -5332,7 +5528,7 @@ timestamp_part(PG_FUNCTION_ARGS)
 	}
 	else
 	{
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("timestamp units \"%s\" not recognized", lowunits)));
 		result = 0;
@@ -5376,7 +5572,7 @@ timestamptz_part(PG_FUNCTION_ARGS)
 	if (type == UNITS)
 	{
 		if (timestamp2tm(timestamp, &tz, tm, &fsec, NULL, NULL) != 0)
-			ereport(ERROR,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 					 errmsg("timestamp out of range")));
 
@@ -5508,7 +5704,7 @@ timestamptz_part(PG_FUNCTION_ARGS)
 				break;
 
 			default:
-				ereport(ERROR,
+				PG_ERETURN(fcinfo->context,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				errmsg("timestamp with time zone units \"%s\" not supported",
 					   lowunits)));
@@ -5529,7 +5725,7 @@ timestamptz_part(PG_FUNCTION_ARGS)
 				break;
 
 			default:
-				ereport(ERROR,
+				PG_ERETURN(fcinfo->context,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				errmsg("timestamp with time zone units \"%s\" not supported",
 					   lowunits)));
@@ -5538,7 +5734,7 @@ timestamptz_part(PG_FUNCTION_ARGS)
 	}
 	else
 	{
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 			   errmsg("timestamp with time zone units \"%s\" not recognized",
 					  lowunits)));
@@ -5576,7 +5772,7 @@ interval_part(PG_FUNCTION_ARGS)
 
 	if (type == UNITS)
 	{
-		if (interval2tm(*interval, tm, &fsec) == 0)
+		if (interval2tm_safe(*interval, tm, &fsec, fcinfo->context) == 0)
 		{
 			switch (val)
 			{
@@ -5644,7 +5840,7 @@ interval_part(PG_FUNCTION_ARGS)
 					break;
 
 				default:
-					ereport(ERROR,
+					PG_ERETURN(fcinfo->context,
 							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							 errmsg("interval units \"%s\" not supported",
 									lowunits)));
@@ -5671,7 +5867,7 @@ interval_part(PG_FUNCTION_ARGS)
 	}
 	else
 	{
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("interval units \"%s\" not recognized",
 						lowunits)));
@@ -5723,7 +5919,7 @@ timestamp_zone(PG_FUNCTION_ARGS)
 										   strlen(tzname),
 										   false);
 
-	type = DecodeTimezoneAbbrev(0, lowzone, &val, &tzp);
+	safe_call(DecodeTimezoneAbbrevSafe, (0, lowzone, &val, &tzp, &type, fcinfo->context));
 
 	if (type == TZ || type == DTZ)
 	{
@@ -5735,7 +5931,7 @@ timestamp_zone(PG_FUNCTION_ARGS)
 	{
 		/* dynamic-offset abbreviation, resolve using specified time */
 		if (timestamp2tm(timestamp, NULL, &tm, &fsec, NULL, tzp) != 0)
-			ereport(ERROR,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 					 errmsg("timestamp out of range")));
 		tz = -DetermineTimeZoneAbbrevOffset(&tm, tzname, tzp);
@@ -5749,19 +5945,19 @@ timestamp_zone(PG_FUNCTION_ARGS)
 		{
 			/* Apply the timezone change */
 			if (timestamp2tm(timestamp, NULL, &tm, &fsec, NULL, tzp) != 0)
-				ereport(ERROR,
+				PG_ERETURN(fcinfo->context,
 						(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 						 errmsg("timestamp out of range")));
 			tz = DetermineTimeZoneOffset(&tm, tzp);
 			if (tm2timestamp(&tm, fsec, &tz, &result) != 0)
-				ereport(ERROR,
+				PG_ERETURN(fcinfo->context,
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						 errmsg("could not convert to time zone \"%s\"",
 								tzname)));
 		}
 		else
 		{
-			ereport(ERROR,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("time zone \"%s\" not recognized", tzname)));
 			result = 0;			/* keep compiler quiet */
@@ -5786,7 +5982,7 @@ timestamp_izone(PG_FUNCTION_ARGS)
 		PG_RETURN_TIMESTAMPTZ(timestamp);
 
 	if (zone->month != 0 || zone->day != 0)
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 		  errmsg("interval time zone \"%s\" must not include months or days",
 				 DatumGetCString(DirectFunctionCall1(interval_out,
@@ -5810,12 +6006,26 @@ Datum
 timestamp_timestamptz(PG_FUNCTION_ARGS)
 {
 	Timestamp	timestamp = PG_GETARG_TIMESTAMP(0);
+	TimestampTz	result;
 
-	PG_RETURN_TIMESTAMPTZ(timestamp2timestamptz(timestamp));
+	PG_SAFE_CALL(timestamp2timestamptz_safe, (timestamp, &result, fcinfo->context));
+
+	PG_RETURN_TIMESTAMPTZ(result);
 }
+
+static bool
+timestamp2timestamptz_safe(Timestamp timestamp, TimestampTz *res, Node *escontext);
 
 static TimestampTz
 timestamp2timestamptz(Timestamp timestamp)
+{
+	TimestampTz result;
+	(void) timestamp2timestamptz_safe(timestamp, &result, NULL);
+	return result;
+}
+
+static bool
+timestamp2timestamptz_safe(Timestamp timestamp, TimestampTz *res, Node *escontext)
 {
 	TimestampTz result;
 	struct pg_tm tt,
@@ -5828,19 +6038,20 @@ timestamp2timestamptz(Timestamp timestamp)
 	else
 	{
 		if (timestamp2tm(timestamp, NULL, tm, &fsec, NULL, NULL) != 0)
-			ereport(ERROR,
+			ereturn(escontext, false,
 					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 					 errmsg("timestamp out of range")));
 
 		tz = DetermineTimeZoneOffset(tm, session_timezone);
 
 		if (tm2timestamp(tm, fsec, &tz, &result) != 0)
-			ereport(ERROR,
+			ereturn(escontext, false,
 					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 					 errmsg("timestamp out of range")));
 	}
 
-	return result;
+	*res = result;
+	return true;
 }
 
 /* timestamptz_timestamp()
@@ -5861,11 +6072,11 @@ timestamptz_timestamp(PG_FUNCTION_ARGS)
 	else
 	{
 		if (timestamp2tm(timestamp, &tz, tm, &fsec, NULL, NULL) != 0)
-			ereport(ERROR,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 					 errmsg("timestamp out of range")));
 		if (tm2timestamp(tm, fsec, NULL, &result) != 0)
-			ereport(ERROR,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 					 errmsg("timestamp out of range")));
 	}
@@ -5907,7 +6118,7 @@ timestamptz_zone(PG_FUNCTION_ARGS)
 										   strlen(tzname),
 										   false);
 
-	type = DecodeTimezoneAbbrev(0, lowzone, &val, &tzp);
+	safe_call(DecodeTimezoneAbbrevSafe, (0, lowzone, &val, &tzp, &type, fcinfo->context));
 
 	if (type == TZ || type == DTZ)
 	{
@@ -5920,7 +6131,8 @@ timestamptz_zone(PG_FUNCTION_ARGS)
 		/* dynamic-offset abbreviation, resolve using specified time */
 		int			isdst;
 
-		tz = DetermineTimeZoneAbbrevOffsetTS(timestamp, tzname, tzp, &isdst);
+		if (!DetermineTimeZoneAbbrevOffsetTSSafe(timestamp, tzname, tzp, &isdst, &tz, fcinfo->context))
+			PG_RETURN_NULL();
 		result = dt2local(timestamp, tz);
 	}
 	else
@@ -5934,18 +6146,18 @@ timestamptz_zone(PG_FUNCTION_ARGS)
  			fsec_t		fsec = 0;
 
 			if (timestamp2tm(timestamp, &tz, &tm, &fsec, NULL, tzp) != 0)
-				ereport(ERROR,
+				PG_ERETURN(fcinfo->context,
 						(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
 						 errmsg("timestamp out of range")));
 			if (tm2timestamp(&tm, fsec, NULL, &result) != 0)
-				ereport(ERROR,
+				PG_ERETURN(fcinfo->context,
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						 errmsg("could not convert to time zone \"%s\"",
 								tzname)));
 		}
 		else
 		{
-			ereport(ERROR,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("time zone \"%s\" not recognized", tzname)));
 			result = 0;			/* keep compiler quiet */
@@ -5971,7 +6183,7 @@ timestamptz_izone(PG_FUNCTION_ARGS)
 		PG_RETURN_TIMESTAMP(timestamp);
 
 	if (zone->month != 0 || zone->day != 0)
-		ereport(ERROR,
+		PG_ERETURN(fcinfo->context,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 		  errmsg("interval time zone \"%s\" must not include months or days",
 				 DatumGetCString(DirectFunctionCall1(interval_out,
@@ -6032,7 +6244,7 @@ generate_series_timestamp(PG_FUNCTION_ARGS)
 		fctx->step_sign = interval_cmp_internal(&fctx->step, &interval_zero);
 
 		if (fctx->step_sign == 0)
-			ereport(ERROR,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("step size cannot equal zero")));
 
@@ -6113,7 +6325,7 @@ generate_series_timestamptz(PG_FUNCTION_ARGS)
 		fctx->step_sign = interval_cmp_internal(&fctx->step, &interval_zero);
 
 		if (fctx->step_sign == 0)
-			ereport(ERROR,
+			PG_ERETURN(fcinfo->context,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("step size cannot equal zero")));
 

--- a/src/backend/utils/adt/varchar.c
+++ b/src/backend/utils/adt/varchar.c
@@ -617,7 +617,7 @@ varchar(PG_FUNCTION_ARGS)
 	{
 		for (i = maxmblen; i < len; i++)
 			if (s_data[i] != ' ')
-				ereport(ERROR,
+				PG_ERETURN(fcinfo->context,
 						(errcode(ERRCODE_STRING_DATA_RIGHT_TRUNCATION),
 					  errmsg("value too long for type character varying(%d)",
 							 maxlen)));

--- a/src/include/fmgr.h
+++ b/src/include/fmgr.h
@@ -579,6 +579,8 @@ extern Datum OidFunctionCall9Coll(Oid functionId, Oid collation,
 					 Datum arg6, Datum arg7, Datum arg8,
 					 Datum arg9);
 
+extern Datum DirectFunctionCall1CollSafe(PGFunction func, Oid collation,
+						Datum arg1, fmNodePtr escontext);
 extern Datum OidFunctionCall3CollSafe(Oid functionId, Oid collation,
 					 Datum arg1, Datum arg2,
 					 Datum arg3, fmNodePtr escontext);
@@ -644,7 +646,8 @@ extern Datum OidFunctionCall3CollSafe(Oid functionId, Oid collation,
 #define OidFunctionCall9(functionId, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) \
 	OidFunctionCall9Coll(functionId, InvalidOid, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
 
-
+#define DirectFunctionCall1Safe(func, arg1, context) \
+	DirectFunctionCall1CollSafe(func, InvalidOid, arg1, context)
 #define OidFunctionCall3Safe(functionId, arg1, arg2, arg3, escontext) \
 	OidFunctionCall3CollSafe(functionId, InvalidOid, arg1, arg2, arg3, escontext)
 

--- a/src/include/utils/builtins.h
+++ b/src/include/utils/builtins.h
@@ -294,7 +294,7 @@ extern Datum current_schemas(PG_FUNCTION_ARGS);
 
 /* numutils.c */
 extern int32 pg_atoi(char *s, int size, int c);
-extern int32 pg_atoi_safe(char *s, int size, int c, Node* escontext);
+extern bool pg_atoi_safe(char *s, int size, int c, int32 *result, Node* context);
 extern void pg_itoa(int16 i, char *a);
 extern void pg_ltoa(int32 l, char *a);
 extern void pg_lltoa(int64 ll, char *a);

--- a/src/include/utils/datetime.h
+++ b/src/include/utils/datetime.h
@@ -298,10 +298,16 @@ extern int ParseDateTime(const char *timestr, char *workbuf, size_t buflen,
 extern int DecodeDateTime(char **field, int *ftype,
 			   int nf, int *dtype,
 			   struct pg_tm * tm, fsec_t *fsec, int *tzp);
+extern bool DecodeDateTimeSafe(char **field, int *ftype,
+			   int nf, int *dtype,
+			   struct pg_tm * tm, fsec_t *fsec, int *tzp, int *result, Node *escontext);
 extern int	DecodeTimezone(char *str, int *tzp);
 extern int DecodeTimeOnly(char **field, int *ftype,
 			   int nf, int *dtype,
 			   struct pg_tm * tm, fsec_t *fsec, int *tzp);
+extern bool DecodeTimeOnlySafe(char **field, int *ftype,
+			   int nf, int *dtype,
+			   struct pg_tm * tm, fsec_t *fsec, int *tzp, int *result, Node *escontext);
 extern int DecodeInterval(char **field, int *ftype, int nf, int range,
 			   int *dtype, struct pg_tm * tm, fsec_t *fsec);
 extern int DecodeISO8601Interval(char *str,
@@ -309,11 +315,15 @@ extern int DecodeISO8601Interval(char *str,
 
 extern void DateTimeParseError(int dterr, const char *str,
 				   const char *datatype) __attribute__((noreturn));
+extern bool DateTimeParseErrorSafe(int dterr, const char *str,
+				   const char *datatype, Node *escontext);
 
 extern int	DetermineTimeZoneOffset(struct pg_tm * tm, pg_tz *tzp);
 extern int	DetermineTimeZoneAbbrevOffset(struct pg_tm * tm, const char *abbr, pg_tz *tzp);
 extern int DetermineTimeZoneAbbrevOffsetTS(TimestampTz ts, const char *abbr,
 								pg_tz *tzp, int *isdst);
+extern bool DetermineTimeZoneAbbrevOffsetTSSafe(TimestampTz ts, const char *abbr,
+								pg_tz *tzp, int *isdst, int *result, Node *escontext);
 
 extern void EncodeDateOnly(struct pg_tm * tm, int style, char *str);
 extern void EncodeTimeOnly(struct pg_tm * tm, fsec_t fsec, bool print_tz, int tz, int style, char *str);
@@ -326,6 +336,8 @@ extern int ValidateDate(int fmask, bool isjulian, bool is2digits, bool bc,
 
 extern int DecodeTimezoneAbbrev(int field, char *lowtoken,
 					 int *offset, pg_tz **tz);
+extern bool DecodeTimezoneAbbrevSafe(int field, char *lowtoken,
+					 int *offset, pg_tz **tz, int *result, Node *escontext);
 extern int	DecodeSpecial(int field, char *lowtoken, int *val);
 extern int	DecodeUnits(int field, char *lowtoken, int *val);
 

--- a/src/include/utils/elog.h
+++ b/src/include/utils/elog.h
@@ -255,6 +255,54 @@ extern void errfinish(int dummy,...);
 #define ereturn(context, dummy_value, rest)	\
 	ereturn_domain(context, dummy_value, TEXTDOMAIN, rest)
 
+#define ereturn_domain_with_free(context, dummy_value, domain, rest, free)	\
+	do { \
+		errsave_domain(context, domain, rest); \
+		do free while(0); \
+		return dummy_value; \
+	} while(0)
+#define ereturn_with_free(context, dummy_value, rest, free)	\
+	ereturn_domain_with_free(context, dummy_value, TEXTDOMAIN, rest, free)
+
+/*	
+ *
+ */
+#define PG_ERETURN_DOMAIN(context, domain, rest)	\
+	do { \
+		errsave_domain(context, domain, rest); \
+		PG_RETURN_NULL(); \
+	} while(0)
+#define PG_ERETURN(context, rest)	\
+	PG_ERETURN_DOMAIN(context, TEXTDOMAIN, rest)
+
+/*
+ * Use to call function with "soft" error handling from another function with "soft" error handling
+ */
+#define safe_call(func, args) \
+	do { \
+		if (!func args) { \
+			return false; \
+		} \
+	} while(0);
+
+#define safe_call_with_free(func, args, free) \
+	do { \
+		if (!func args) { \
+			do free while(0); \
+			return false; \
+		} \
+	} while(0);
+
+/*
+ * Use to call function with "soft" error handling from PG function. 
+ * Same as safe_call but sets fcinfo.isnull = true
+ */
+#define PG_SAFE_CALL(func, args) \
+	do { \
+		if (!func args) \
+			PG_RETURN_NULL(); \
+	} while(0);
+
 extern bool errsave_start(struct Node* context, const char *filename, int lineno,
 		 const char *funcname, const char *domain);
 

--- a/src/include/utils/float_utils.h
+++ b/src/include/utils/float_utils.h
@@ -38,4 +38,17 @@ do {															\
 		 errmsg("value out of range: underflow")));				\
 } while(0)
 
+#define PG_CHECKFLOATVAL_SAFE(val, inf_is_valid, zero_is_valid)			\
+do {															\
+	if (isinf(val) && !(inf_is_valid))							\
+		PG_ERETURN(fcinfo->context,								\
+				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),	\
+		  errmsg("value out of range: overflow")));				\
+																\
+	if ((val) == 0.0 && !(zero_is_valid))						\
+		PG_ERETURN(fcinfo->context,								\
+				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),	\
+		 errmsg("value out of range: underflow")));				\
+} while(0)
+
 #endif /* FLOAT_UTILS_H */

--- a/src/include/utils/jsonapi.h
+++ b/src/include/utils/jsonapi.h
@@ -102,6 +102,7 @@ typedef struct JsonSemAction
  * does nothing and just continues.
  */
 extern void pg_parse_json(JsonLexContext *lex, JsonSemAction *sem);
+extern bool pg_parse_json_safe(JsonLexContext *lex, JsonSemAction *sem, Node *escontext);
 
 /*
  * constructors for JsonLexContext, with or without strval element.

--- a/src/include/utils/timestamp.h
+++ b/src/include/utils/timestamp.h
@@ -16,6 +16,7 @@
 #include "datatype/timestamp.h"
 #include "fmgr.h"
 #include "pgtime.h"
+#include "nodes/miscnodes.h"
 
 
 /*
@@ -235,10 +236,12 @@ extern Datum timestamptz_part(PG_FUNCTION_ARGS);
 extern float8 timestamp_li_fraction(Timestamp x, Timestamp x0, Timestamp x1, 
 									bool *eq_bounds, bool *eq_abscissas);
 extern Timestamp timestamp_li_value(float8 f, Timestamp y0, Timestamp y1);
+extern bool timestamp_li_value_safe(float8 f, Timestamp y0, Timestamp y1, Timestamp *result, Node *escontext);
 
 extern float8 timestamptz_li_fraction(TimestampTz x, TimestampTz x0, TimestampTz x1, 
 									  bool *eq_bounds, bool *eq_abscissas);
 extern Timestamp timestamptz_li_value(float8 f, TimestampTz y0, TimestampTz y1);
+extern bool timestamptz_li_value_safe(float8 f, TimestampTz y0, TimestampTz y1, Timestamp *result, Node *escontext);
 
 extern Datum now(PG_FUNCTION_ARGS);
 extern Datum statement_timestamp(PG_FUNCTION_ARGS);
@@ -282,6 +285,7 @@ extern int timestamp2tm(Timestamp dt, int *tzp, struct pg_tm * tm,
 extern void dt2time(Timestamp dt, int *hour, int *min, int *sec, fsec_t *fsec);
 
 extern int	interval2tm(Interval span, struct pg_tm * tm, fsec_t *fsec);
+extern int	interval2tm_safe(Interval span, struct pg_tm * tm, fsec_t *fsec, Node *escontext);
 extern int	tm2interval(struct pg_tm * tm, fsec_t fsec, Interval *span);
 
 extern Timestamp SetEpochTimestamp(void);


### PR DESCRIPTION
|datatype|IO|convert|ops|generate_series|
|:---|:---|:---|:---|:---|
|int| ✅|✅|✅|⬜️|
|float| ✅|✅|✅|⬜️|
|numeric| ✅|✅|⬜️|⬜️|
|bool|✅|✅|✅|⬜️|
|time| ✅|✅|✅|⬜️|
|date| ✅|✅|✅|⬜️|
|timestamp| ✅|✅|✅|⬜️|
|json| ✅|✅|⬜️|⬜️|
|jsonb| ✅|✅|⬜️|⬜️|


"Soft" error handling is needed by [try_convert](https://github.com/open-gpdb/gpdb/pull/10)

To verify that "soft" error handling is correct and all "safe" functions are using only other "safe" functions without `ereport` use `/contrib/try_convert/verify.py` in [try_convert](https://github.com/open-gpdb/gpdb/pull/10)

## Verification

current `verify.py` result

```
FOUND 96 CASTs
REQUIRED 2 _IN FUNCTIONS
REQUIRED 2 _OUT FUNCTIONS
REQUIRED 68 FUNCTIONS FROM CREATE CAST
body for ______unknown_funcid(('abstime', 'time', '______unknown_funcid')) not found
FOUND 107 FUNCTIONS BODIES
FOUND 58 SAFE FUNCTIONS BODIES
REQUIRED 36 SAFE FUNCTIONS VARIANTS
    WARNING: call unsafe function appendStringInfoChar in hstore_to_json
    WARNING: call unsafe function escape_json in hstore_to_json
    WARNING: call unsafe function escape_json in hstore_to_json
    WARNING: call unsafe function appendStringInfoChar in hstore_to_json
    WARNING: call unsafe function elog in timestamp_in
    WARNING: call unsafe function elog in timestamptz_in
    WARNING: call unsafe function elog in interval_in
    WARNING: call unsafe function elog in interval_out
    WARNING: call unsafe function elog in abstimein
    WARNING: call unsafe function elog in reltimein
    WARNING: call unsafe function elog in timestamp_interval_bound_common_safe
    WARNING: call unsafe function elog in timestamp_interval_bound_common_safe
    WARNING: call unsafe function elog in timestamp_interval_bound_common_safe
    WARNING: call unsafe function elog in timestamptz_interval_bound_common_safe
    WARNING: call unsafe function elog in timestamptz_interval_bound_common_safe
    WARNING: call unsafe function elog in timestamptz_interval_bound_common_safe
    WARNING: call unsafe function check_stack_depth in parse_object
    WARNING: call unsafe function check_stack_depth in parse_array
    WARNING: call unsafe function appendStringInfoChar in json_lex_string
    WARNING: call unsafe function appendStringInfoChar in json_lex_string
    WARNING: call unsafe function appendStringInfoChar in json_lex_string
    WARNING: call unsafe function appendStringInfoChar in json_lex_string
    WARNING: call unsafe function appendStringInfoChar in json_lex_string
    WARNING: call unsafe function appendStringInfoChar in json_lex_string
    WARNING: call unsafe function appendStringInfoChar in json_lex_string
    WARNING: call unsafe function appendStringInfoChar in json_lex_string
    WARNING: call unsafe function elog in report_parse_error
    WARNING: call unsafe function elog in pg_atoi_safe
    WARNING: call unsafe function elog in pg_atoi_safe
FOUND 14 UNSAFE CONVERT FUNCTIONS
    WARNING: in safe function report_parse_error: "return" used only with "true", not "false"
FOUND 0 UNSAFE VARIANT USAGES
FOUND 0 UNWRAPPED SAFE FUNCTION USAGES
FOUND 0 WRONG WRAP USAGES
```

### Description

`appendStringInfoChar` -> `enlargeStringInfo` -> `ereport(out of memory)`

`escape_json` -> `appendStringInfoString` -> `appendStringInfo` -> `enlargeStringInfo` -> `ereport(out of memory)`

`check_stack_depth` -> `ereport(stack depth limit exceeded)`

elog in:

timestamp_in - elog can called only from bug

timestamptz_in - elog can called only from bug

interval_in - elog can called only from bug

interval_out - need fix

abstimein - elog can called only from bug

reltimein - elog can called only from bug

timestamp_interval_bound_common_safe - 3 zero div

timestamptz_interval_bound_common_safe - 3 zero div

pg_atoi_safe - elog can called only from bug



## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
