### PR TITLE
Enable copy for demo cluster

### DIFF
--- a/gpAux/gpdemo/Makefile
+++ b/gpAux/gpdemo/Makefile
@@ -24,6 +24,10 @@ ifeq ($(WITH_MIRRORS), )
 WITH_MIRRORS = true
 endif
 
+ifeq ($(ENABLE_COPY), )
+ENABLE_COPY = true
+endif
+
 ifeq ($(WITH_MIRRORS), true)
 WITH_STANDBY = true
 endif
@@ -32,6 +36,7 @@ export DEMO_PORT_BASE=$(PORT_BASE)
 export NUM_PRIMARY_MIRROR_PAIRS
 export WITH_MIRRORS
 export WITH_STANDBY
+export ENABLE_COPY
 export BLDWRAP_POSTGRES_CONF_ADDONS
 export DEFAULT_QD_MAX_CONNECT=150
 

--- a/gpAux/gpdemo/demo_cluster.sh
+++ b/gpAux/gpdemo/demo_cluster.sh
@@ -340,6 +340,17 @@ if [ "${WITH_MIRRORS}" == "true" ]; then
 	EOF
 fi
 
+if [ "${ENABLE_COPY}" == "true" ]; then
+    cat >> $CLUSTER_CONFIG_POSTGRES_ADDONS <<-EOF
+
+		# Turn on COPY for cluster
+		ycmdb.yc_allow_copy_to_program=on
+		ycmdb.yc_allow_copy_from_file=on
+		ycmdb.yc_allow_copy_to_file=on
+
+	EOF
+fi
+
 
 STANDBY_INIT_OPTS=""
 if [ "${WITH_STANDBY}" == "true" ]; then


### PR DESCRIPTION
We support special cloud options 
```
		ycmdb.yc_allow_copy_to_program=on
		ycmdb.yc_allow_copy_from_file=on
		ycmdb.yc_allow_copy_to_file=on
```

They are disabled by default but used in installcheck test suite. Let's enable them for the demo-cluster, which is used in our tests, and on-prem installations can also use them.

Fix test "copy" and maybe some others, not sure wich of them, lets start with test "copy"

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
