### PR TITLE
Fix compile-time errors

### DIFF
--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1645,7 +1645,7 @@ cdbexplain_NodeSummary(ExplainState *es, CdbExplain_NodeSummary *ns) {
 
 			appendStringInfoSpaces(es->str, nsi_spaces);
 
-			appendStringInfo(es->str, "(seg%d) %d %.2f %.2f %.2f %.2f %.2f %.0f %.0f %.0f %.0f %.0f %d %.2f %.0f %d %d %d %ld %d %d\n", 
+			appendStringInfo(es->str, "(seg%d) %d %.2ld %.2ld %.2f %.2f %.2f %.0f %.0f %.0f %.0f %.0f %d %.2ld %.0f %d %d %d %ld %d %d\n", 
 				ns->segindex0 + i, 
 				nsi->pstype, 
 				nsi->starttime.tv_sec, nsi->counter.tv_sec, nsi->firsttuple, nsi->startup, nsi->total,


### PR DESCRIPTION
```
explain_gp.c:1568:1: warning: no previous prototype for ‘cdbexplain_NodeSummary’ [-Wmissing-prototypes]
 1568 | cdbexplain_NodeSummary(ExplainState *es, CdbExplain_NodeSummary *ns) {
      | ^~~~~~~~~~~~~~~~~~~~~~
In file included from explain.c:140:
explain_gp.c: In function ‘cdbexplain_NodeSummary’: explain_gp.c:1648:66: warning: format ‘%f’ expects argument of type ‘double’, but argument 5 has type ‘__time_t’ {aka ‘long int’} [-Wformat=]
 1648 |                         appendStringInfo(es->str, "(seg%d) %d %.2f %.2f %.2f %.2f %.2f %.0f %.0f %.0f %.0f %.0f %d %.2f %.0f %d %d %d %ld %d %d\n",
      |                                                               ~~~^
      |                                                                  |
      |                                                                  double
      |                                                               %.2ld
......
 1651 |                                 nsi->starttime.tv_sec, nsi->counter.tv_sec, nsi->firsttuple, nsi->startup, nsi->total,
      |                                 ~~~~~~~~~~~~~~~~~~~~~
      |                                               |
      |                                               __time_t {aka long int}
explain_gp.c:1648:71: warning: format ‘%f’ expects argument of type ‘double’, but argument 6 has type ‘__time_t’ {aka ‘long int’} [-Wformat=]
 1648 |                         appendStringInfo(es->str, "(seg%d) %d %.2f %.2f %.2f %.2f %.2f %.0f %.0f %.0f %.0f %.0f %d %.2f %.0f %d %d %d %ld %d %d\n",
      |                                                                    ~~~^
      |                                                                       |
      |                                                                       double
      |                                                                    %.2ld
......
 1651 |                                 nsi->starttime.tv_sec, nsi->counter.tv_sec, nsi->firsttuple, nsi->startup, nsi->total,
      |                                                        ~~~~~~~~~~~~~~~~~~~
      |                                                                    |
      |                                                                    __time_t {aka long int}
explain_gp.c:1648:119: warning: format ‘%f’ expects argument of type ‘double’, but argument 16 has type ‘__time_t’ {aka ‘long int’} [-Wformat=]
 1648 |                         appendStringInfo(es->str, "(seg%d) %d %.2f %.2f %.2f %.2f %.2f %.0f %.0f %.0f %.0f %.0f %d %.2f %.0f %d %d %d %ld %d %d\n",
      |                                                                                                                    ~~~^
      |                                                                                                                       |
      |                                                                                                                       double
      |                                                                                                                    %.2ld
......
 1654 |                                 nsi->firststart.tv_sec,
      |                                 ~~~~~~~~~~~~~~~~~~~~~~
      |                                                |
      |                                                __time_t {aka long int}
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -fno-aggressive-loop-optimizations -Wno-

```
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
