### PR TITLE
Fix typo to enable debug extensions in regress

### DIFF
--- a/docker/regress/Dockerfile
+++ b/docker/regress/Dockerfile
@@ -65,7 +65,7 @@ RUN git clone https://github.com/open-gpdb/yezzey.git gpcontrib/yezzey -b ${YEZZ
 
 RUN sed -i '/^trusted/d' gpcontrib/yezzey/yezzey.control 
 RUN ./configure --with-perl --with-python --with-libxml --disable-orca --prefix=/usr/local/gpdb \
---enable-depend --enable-cassert --enable-debug --without-mdblocales --without-zstd --enable-debug-extension CFLAGS='-fno-omit-frame-pointer -Wno-implicit-fallthrough -O3 -pthread' 
+--enable-depend --enable-cassert --enable-debug --without-mdblocales --without-zstd --enable-debug-extensions CFLAGS='-fno-omit-frame-pointer -Wno-implicit-fallthrough -O3 -pthread' 
 RUN make -j8 && make -j8 install
 
 ENTRYPOINT ["./docker/regress/run_tests.sh"]


### PR DESCRIPTION


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
