### PR TITLE
Revert "Update external_table.source: fix external table source"

### DIFF
--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -4826,7 +4826,7 @@ LOCATION (
 )
 FORMAT 'CUSTOM' (formatter='gpformatter');
 SELECT * FROM tbl_ext_gpformatter;
-ERROR:  unexpected end of file (fileam.c:1098)  (seg0 slice1 127.0.1.1:6002 pid=155340) (fileam.c:1086)
+ERROR:  unexpected end of file (fileam.c:1096)  (seg0 slice1 127.0.1.1:6002 pid=155340) (fileam.c:1086)
 CONTEXT:  External table tbl_ext_gpformatter
 COMMIT;
 --


### PR DESCRIPTION
This reverts commit 429f0397d52734c212be3f809665824c89d24f9d.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
