### PR TITLE
Add views for getting cummulative IC stats

### DIFF
--- a/gpcontrib/Makefile
+++ b/gpcontrib/Makefile
@@ -26,7 +26,8 @@ ifeq "$(enable_debug_extensions)" "yes"
                gp_error_handling \
                gp_subtransaction_overflow \
                gp_check_functions \
-               gp_aux_catalog
+               gp_aux_catalog \
+			   gp_interconnect_stats
 else
 	recurse_targets = gp_sparse_vector \
                gp_distribution_policy \
@@ -41,7 +42,8 @@ else
                gp_error_handling \
                gp_subtransaction_overflow \
                gp_check_functions \
-               gp_aux_catalog
+               gp_aux_catalog \
+			   gp_interconnect_stats
 endif
 
 ifeq "$(with_zstd)" "yes"

--- a/gpcontrib/gp_interconnect_stats/Makefile
+++ b/gpcontrib/gp_interconnect_stats/Makefile
@@ -1,0 +1,23 @@
+EXTENSION = gp_interconnect_stats
+MODULES = gp_interconnect_stats
+
+EXTENSION_VERSION = 1.0
+
+
+DATA = gp_interconnect_stats--1.0.sql
+
+OBJS = gp_interconnect_stats.o
+
+MODULE_big = gp_interconnect_stats
+
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = gpcontrib/gp_interconnect_stats
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/gpcontrib/gp_interconnect_stats/gp_interconnect_stats--1.0.sql
+++ b/gpcontrib/gp_interconnect_stats/gp_interconnect_stats--1.0.sql
@@ -1,0 +1,135 @@
+/* gpcontrib/gp_interconnect_stats/gp_interconnect_stats--1.0.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION gp_interconnect_stats" to load this file. \quit
+
+CREATE FUNCTION __gp_interconnect_get_stats_f_on_master(
+	OUT gp_segment_id smallint,
+	OUT total_recv_queue_size bigint,
+	OUT recv_queue_conting_time bigint,
+	OUT total_capacity bigint,
+	OUT capacity_counting_time bigint,
+	OUT total_buffers bigint,
+	OUT buffer_counting_time bigint,
+	OUT retransmits bigint,
+	OUT startup_cached_pkts bigint,
+	OUT mismatches bigint,
+	OUT crs_errors bigint,
+	OUT snd_pkt_num bigint,
+	OUT recv_pkt_num bigint,
+	OUT disordered_pkt_num bigint,
+	OUT duplicate_pkt_num bigint,
+	OUT recv_ack_num bigint,
+	OUT status_query_msg_num bigint
+)
+RETURNS SETOF record
+LANGUAGE C VOLATILE EXECUTE ON MASTER
+AS '$libdir/gp_interconnect_stats', 'gp_interconnect_get_stats';
+
+CREATE FUNCTION __gp_interconnect_get_stats_f_on_segments(
+	OUT gp_segment_id smallint,
+	OUT total_recv_queue_size bigint,
+	OUT recv_queue_conting_time bigint,
+	OUT total_capacity bigint,
+	OUT capacity_counting_time bigint,
+	OUT total_buffers bigint,
+	OUT buffer_counting_time bigint,
+	OUT retransmits bigint,
+	OUT startup_cached_pkts bigint,
+	OUT mismatches bigint,
+	OUT crs_errors bigint,
+	OUT snd_pkt_num bigint,
+	OUT recv_pkt_num bigint,
+	OUT disordered_pkt_num bigint,
+	OUT duplicate_pkt_num bigint,
+	OUT recv_ack_num bigint,
+	OUT status_query_msg_num bigint
+)
+RETURNS SETOF record LANGUAGE C VOLATILE EXECUTE ON ALL SEGMENTS
+AS '$libdir/gp_interconnect_stats', 'gp_interconnect_get_stats';
+
+
+--------------------------------------------------------------------------------
+-- @view:
+--              gp_interconnect_stats_per_segment
+--
+-- @doc:
+--              Cummulative interconnect statistics per segment
+--
+--------------------------------------------------------------------------------
+CREATE VIEW gp_interconnect_stats_per_segment AS
+    SELECT c.hostname, s.* FROM (
+        SELECT * FROM __gp_interconnect_get_stats_f_on_master()
+        UNION ALL
+        SELECT * FROM __gp_interconnect_get_stats_f_on_segments()
+    ) s
+    INNER JOIN pg_catalog.gp_segment_configuration AS c
+        ON s.gp_segment_id = c.content
+        AND c.role = 'p'
+    ;
+
+GRANT SELECT ON gp_interconnect_stats_per_segment TO public;
+
+--------------------------------------------------------------------------------
+-- @view:
+--              gp_interconnect_stats
+--
+-- @doc:
+--              Cummulative interconnect statistics
+--
+--------------------------------------------------------------------------------
+CREATE VIEW gp_interconnect_stats AS
+    SELECT
+        sum(total_recv_queue_size) as total_recv_queue_size
+	  , sum(recv_queue_conting_time) as recv_queue_conting_time
+	  , sum(total_capacity) as total_capacity
+	  , sum(capacity_counting_time) as capacity_counting_time
+	  , sum(total_buffers) as total_buffers
+	  , sum(buffer_counting_time) as buffer_counting_time
+	  , sum(retransmits) as retransmits
+	  , sum(startup_cached_pkts) as startup_cached_pkts
+	  , sum(mismatches) as mismatches
+	  , sum(crs_errors) as crs_errors
+	  , sum(snd_pkt_num) as snd_pkt_num
+	  , sum(recv_pkt_num) as recv_pkt_num
+	  , sum(disordered_pkt_num) as disordered_pkt_num
+	  , sum(duplicate_pkt_num) as duplicate_pkt_num
+	  , sum(recv_ack_num) as recv_ack_num
+	  , sum(status_query_msg_num) as status_query_msg_num
+    FROM gp_interconnect_stats_per_segment
+    ;
+
+GRANT SELECT ON gp_interconnect_stats TO public;
+
+--------------------------------------------------------------------------------
+-- @view:
+--              gp_interconnect_stats_per_host
+--
+-- @doc:
+--              Cummulative interconnect statistics grouped by host
+--
+--------------------------------------------------------------------------------
+
+CREATE VIEW gp_interconnect_stats_per_host AS
+    SELECT
+        hostname
+      , sum(total_recv_queue_size) as total_recv_queue_size
+	  , sum(recv_queue_conting_time) as recv_queue_conting_time
+	  , sum(total_capacity) as total_capacity
+	  , sum(capacity_counting_time) as capacity_counting_time
+	  , sum(total_buffers) as total_buffers
+	  , sum(buffer_counting_time) as buffer_counting_time
+	  , sum(retransmits) as retransmits
+	  , sum(startup_cached_pkts) as startup_cached_pkts
+	  , sum(mismatches) as mismatches
+	  , sum(crs_errors) as crs_errors
+	  , sum(snd_pkt_num) as snd_pkt_num
+	  , sum(recv_pkt_num) as recv_pkt_num
+	  , sum(disordered_pkt_num) as disordered_pkt_num
+	  , sum(duplicate_pkt_num) as duplicate_pkt_num
+	  , sum(recv_ack_num) as recv_ack_num
+	  , sum(status_query_msg_num) as status_query_msg_num
+    FROM gp_interconnect_stats_per_segment
+    GROUP BY hostname;
+
+GRANT SELECT ON gp_interconnect_stats_per_host TO public;

--- a/gpcontrib/gp_interconnect_stats/gp_interconnect_stats.c
+++ b/gpcontrib/gp_interconnect_stats/gp_interconnect_stats.c
@@ -1,0 +1,27 @@
+/*--------------------------------------------------------------------------
+ *
+ * gp_interconnect_stats.c
+ *	  Routine for getting UDPIFC interconnect stats
+ *
+ **--------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "cdb/cdbvars.h"
+#include "cdb/ml_ipc.h"
+#include "fmgr.h"
+
+PG_MODULE_MAGIC;
+
+PG_FUNCTION_INFO_V1(gp_interconnect_get_stats);
+
+Datum
+gp_interconnect_get_stats(PG_FUNCTION_ARGS)
+{
+	if (Gp_interconnect_type == INTERCONNECT_TYPE_UDPIFC)
+		return GpInterconnectGetStatsUDPIFC(fcinfo);
+	ereport(WARNING,
+		(errcode(ERRCODE_WARNING_GP_INTERCONNECTION),
+		errmsg("Interconnect statistics are collected only for UDPIFC protocol")));
+	PG_RETURN_NULL();
+}

--- a/gpcontrib/gp_interconnect_stats/gp_interconnect_stats.control
+++ b/gpcontrib/gp_interconnect_stats/gp_interconnect_stats.control
@@ -1,0 +1,3 @@
+comment = 'Cummulative statistics from UDPIFC interconnect protocol'
+default_version = '1.0'
+relocatable = false

--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -249,6 +249,21 @@ InitMotionLayerIPC(void)
 	elog(DEBUG1, "Interconnect listening on tcp port %d udp port %d (0x%x)", tcp_listener, udp_listener, Gp_listener_port);
 }
 
+void
+InterconnectShmemInit(void)
+{
+	if (Gp_interconnect_type == INTERCONNECT_TYPE_UDPIFC)
+		InterconnectShmemInitUDPIFC();
+}
+
+Size
+InterconnectShmemSize(void)
+{
+	if (Gp_interconnect_type == INTERCONNECT_TYPE_UDPIFC)
+		return InterconnectShmemSizeUDPIFC();
+	return 0;
+}
+
 /* See ml_ipc.h */
 void
 CleanUpMotionLayerIPC(void)

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -28,6 +28,7 @@
 
 #include "access/transam.h"
 #include "access/xact.h"
+#include "funcapi.h"
 #include "nodes/execnodes.h"
 #include "nodes/pg_list.h"
 #include "nodes/print.h"
@@ -38,6 +39,8 @@
 #include "port/pg_crc32c.h"
 #include "postmaster/postmaster.h"
 #include "storage/latch.h"
+#include "storage/lock.h"
+#include "storage/pg_shmem.h"
 #include "storage/pmsignal.h"
 #include "utils/builtins.h"
 #include "utils/guc.h"
@@ -631,6 +634,30 @@ typedef struct ICStatistics
 
 /* Statistics for UDP interconnect. */
 static ICStatistics ic_statistics;
+
+/* Same as above but to be accumulated in shared memory across all processes */
+/* Also those numbers are expected to grow big, hence uint64_t */
+typedef struct ICStatisticsShmem
+{
+	uint64		totalRecvQueueSize;
+	uint64		recvQueueSizeCountingTime;
+	uint64		totalCapacity;
+	uint64		capacityCountingTime;
+	uint64		totalBuffers;
+	uint64		bufferCountingTime;
+	uint64		retransmits;
+	uint64		startupCachedPktNum;
+	uint64		mismatchNum;
+	uint64		crcErrors;
+	uint64		sndPktNum;
+	uint64		recvPktNum;
+	uint64		disorderedPktNum;
+	uint64		duplicatedPktNum;
+	uint64		recvAckNum;
+	uint64		statusQueryMsgNum;
+} ICStatisticsShmem;
+
+static ICStatisticsShmem *pICStatisticsShmem = NULL;
 
 /* Cached sockaddr of the listening udp socket */
 static struct sockaddr_storage udp_dummy_packet_sockaddr;
@@ -1407,6 +1434,42 @@ ic_reset_pthread_sigmasks(sigset_t *sigs)
 #endif
 
 	return;
+}
+
+Size
+InterconnectShmemSizeUDPIFC(void) {
+	return sizeof(ICStatisticsShmem);
+}
+
+void
+InterconnectShmemInitUDPIFC(void)
+{
+	bool found;
+	pICStatisticsShmem = ShmemInitStruct("global interconnect statistics",
+                                       sizeof(ICStatisticsShmem), &found);
+    if (pICStatisticsShmem == NULL)
+        ereport(FATAL,
+			(errcode(ERRCODE_OUT_OF_MEMORY),
+			 errmsg("not enough shared memory for global interconnect statistics")));
+	if (!found)
+	{
+		pICStatisticsShmem->totalRecvQueueSize = 0;
+		pICStatisticsShmem->recvQueueSizeCountingTime = 0;
+		pICStatisticsShmem->totalCapacity = 0;
+		pICStatisticsShmem->capacityCountingTime = 0;
+		pICStatisticsShmem->totalBuffers = 0;
+		pICStatisticsShmem->bufferCountingTime = 0;
+		pICStatisticsShmem->retransmits = 0;
+		pICStatisticsShmem->startupCachedPktNum = 0;
+		pICStatisticsShmem->mismatchNum = 0;
+		pICStatisticsShmem->crcErrors = 0;
+		pICStatisticsShmem->sndPktNum = 0;
+		pICStatisticsShmem->recvPktNum = 0;
+		pICStatisticsShmem->disorderedPktNum = 0;
+		pICStatisticsShmem->duplicatedPktNum = 0;
+		pICStatisticsShmem->recvAckNum = 0;
+		pICStatisticsShmem->statusQueryMsgNum = 0;
+	}
 }
 
 /*
@@ -3373,6 +3436,32 @@ chunkTransportStateEntryInitialized(ChunkTransportState *transportStates,
 }
 
 /*
+ * updateGlobalInterconnectStats
+ *		Append local interconnect stats to global cummulative stats
+ */
+static void updateGlobalInterconnectStats(void)
+{
+	LWLockAcquire(ICStatisticsLock, LW_EXCLUSIVE);
+	pICStatisticsShmem->totalRecvQueueSize += ic_statistics.totalRecvQueueSize;
+	pICStatisticsShmem->recvQueueSizeCountingTime += ic_statistics.recvQueueSizeCountingTime;
+	pICStatisticsShmem->totalCapacity += ic_statistics.totalCapacity;
+	pICStatisticsShmem->capacityCountingTime += ic_statistics.capacityCountingTime;
+	pICStatisticsShmem->totalBuffers += ic_statistics.totalBuffers;
+	pICStatisticsShmem->bufferCountingTime += ic_statistics.bufferCountingTime;
+	pICStatisticsShmem->retransmits += ic_statistics.retransmits;
+	pICStatisticsShmem->startupCachedPktNum += ic_statistics.startupCachedPktNum;
+	pICStatisticsShmem->mismatchNum += ic_statistics.mismatchNum;
+	pICStatisticsShmem->crcErrors += ic_statistics.crcErrors;
+	pICStatisticsShmem->sndPktNum += ic_statistics.sndPktNum;
+	pICStatisticsShmem->recvPktNum += ic_statistics.recvPktNum;
+	pICStatisticsShmem->disorderedPktNum += ic_statistics.disorderedPktNum;
+	pICStatisticsShmem->duplicatedPktNum += ic_statistics.duplicatedPktNum;
+	pICStatisticsShmem->recvAckNum += ic_statistics.recvAckNum;
+	pICStatisticsShmem->statusQueryMsgNum += ic_statistics.statusQueryMsgNum;
+	LWLockRelease(ICStatisticsLock);
+}
+
+/*
  * computeNetworkStatistics
  * 		Compute the max/min/avg network statistics.
  */
@@ -3675,6 +3764,7 @@ TeardownUDPIFCInterconnect_Internal(ChunkTransportState *transportStates,
 		 (minRtt == ~((uint64) 0) ? 0 : minRtt), (minDev == ~((uint64) 0) ? 0 : minDev), avgRtt, avgDev, maxRtt, maxDev,
 		 snd_control_info.cwnd, ic_statistics.statusQueryMsgNum);
 
+	updateGlobalInterconnectStats();
 	ic_control_info.isSender = false;
 	memset(&ic_statistics, 0, sizeof(ICStatistics));
 
@@ -6538,7 +6628,7 @@ handleMismatch(icpkthdr *pkt, struct sockaddr_storage *peer, int peer_len)
 			{
 				/*
 				 * ic_control_info.ic_instance_id < pkt->icId, from the future
-				 */ 
+				 */
 				if (gp_interconnect_cache_future_packets)
 				{
 					cached = cacheFuturePacket(pkt, peer, peer_len);
@@ -7033,4 +7123,82 @@ uint32
 getActiveMotionConns(void)
 {
 	return ic_statistics.activeConnectionsNum;
+}
+
+Datum
+GpInterconnectGetStatsUDPIFC(PG_FUNCTION_ARGS)
+{
+	/*
+	 * Build a tuple descriptor for our result type
+	 * The number and type of attributes have to match the definition of the
+	 * view gp_interconnect_stats_per_segment
+	 */
+#define NUM_IC_STATS_ELEM 17
+	TupleDesc tupdesc = CreateTemplateTupleDesc(NUM_IC_STATS_ELEM, false);
+
+	TupleDescInitEntry(tupdesc, (AttrNumber) 1, "segid",
+			INT2OID, -1 /* typmod */, 0 /* attdim */);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 2, "total_recv_queue_size",
+			INT8OID, -1 /* typmod */, 0 /* attdim */);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 3, "recv_queue_conting_time",
+			INT8OID, -1 /* typmod */, 0 /* attdim */);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 4, "total_capacity",
+			INT8OID, -1 /* typmod */, 0 /* attdim */);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 5, "capacity_counting_time",
+			INT8OID, -1 /* typmod */, 0 /* attdim */);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 6, "total_buffers",
+			INT8OID, -1 /* typmod */, 0 /* attdim */);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 7, "buffer_counting_time",
+			INT8OID, -1 /* typmod */, 0 /* attdim */);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 8, "retransmits",
+			INT8OID, -1 /* typmod */, 0 /* attdim */);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 9, "startup_cached_pkts",
+			INT8OID, -1 /* typmod */, 0 /* attdim */);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 10, "mismatches",
+			INT8OID, -1 /* typmod */, 0 /* attdim */);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 11, "crs_errors",
+			INT8OID, -1 /* typmod */, 0 /* attdim */);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 12, "snd_pkt_num",
+			INT8OID, -1 /* typmod */, 0 /* attdim */);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 13, "recv_pkt_num",
+			INT8OID, -1 /* typmod */, 0 /* attdim */);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 14, "disordered_pkt_num",
+			INT8OID, -1 /* typmod */, 0 /* attdim */);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 15, "duplicate_pkt_num",
+			INT8OID, -1 /* typmod */, 0 /* attdim */);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 16, "recv_ack_num",
+			INT8OID, -1 /* typmod */, 0 /* attdim */);
+	TupleDescInitEntry(tupdesc, (AttrNumber) 17, "status_query_msg_num",
+			INT8OID, -1 /* typmod */, 0 /* attdim */);
+
+	tupdesc =  BlessTupleDesc(tupdesc);
+
+	Datum		values[NUM_IC_STATS_ELEM];
+	bool		nulls[NUM_IC_STATS_ELEM];
+	MemSet(nulls, 0, sizeof(nulls));
+
+	LWLockAcquire(ICStatisticsLock, LW_EXCLUSIVE);
+	values[0] = Int32GetDatum(GpIdentity.segindex);
+	values[1] = Int64GetDatum(pICStatisticsShmem->totalRecvQueueSize);
+	values[2] = Int64GetDatum(pICStatisticsShmem->recvQueueSizeCountingTime);
+	values[3] = Int64GetDatum(pICStatisticsShmem->totalCapacity);
+	values[4] = Int64GetDatum(pICStatisticsShmem->capacityCountingTime);
+	values[5] = Int64GetDatum(pICStatisticsShmem->totalBuffers);
+	values[6] = Int64GetDatum(pICStatisticsShmem->bufferCountingTime);
+	values[7] = Int64GetDatum(pICStatisticsShmem->retransmits);
+	values[8] = Int64GetDatum(pICStatisticsShmem->startupCachedPktNum);
+	values[9] = Int64GetDatum(pICStatisticsShmem->mismatchNum);
+	values[10] = Int64GetDatum(pICStatisticsShmem->crcErrors);
+	values[11] = Int64GetDatum(pICStatisticsShmem->sndPktNum);
+	values[12] = Int64GetDatum(pICStatisticsShmem->recvPktNum);
+	values[13] = Int64GetDatum(pICStatisticsShmem->disorderedPktNum);
+	values[14] = Int64GetDatum(pICStatisticsShmem->duplicatedPktNum);
+	values[15] = Int64GetDatum(pICStatisticsShmem->recvAckNum);
+	values[16] = Int64GetDatum(pICStatisticsShmem->statusQueryMsgNum);
+	LWLockRelease(ICStatisticsLock);
+
+	HeapTuple tuple = heap_form_tuple(tupdesc, values, nulls);
+	Datum result = HeapTupleGetDatum(tuple);
+
+	PG_RETURN_DATUM(result);
 }

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -26,6 +26,7 @@
 #include "access/appendonlywriter.h"
 #include "cdb/cdblocaldistribxact.h"
 #include "cdb/cdbvars.h"
+#include "cdb/ml_ipc.h"
 #include "commands/async.h"
 #include "miscadmin.h"
 #include "pgstat.h"
@@ -184,7 +185,7 @@ CreateSharedMemoryAndSemaphores(int port)
 
 #ifdef FAULT_INJECTOR
 		size = add_size(size, FaultInjector_ShmemSize());
-#endif			
+#endif
 
 #ifdef ENABLE_IC_PROXY
 		size = add_size(size, ICProxyShmemSize());
@@ -215,6 +216,8 @@ CreateSharedMemoryAndSemaphores(int port)
 
 		/* size of parallel cursor count */
 		size = add_size(size, ParallelCursorCountSize());
+
+		size = add_size(size, InterconnectShmemSize());
 
 		elog(DEBUG3, "invoking IpcMemoryCreate(size=%zu)", size);
 
@@ -291,7 +294,7 @@ CreateSharedMemoryAndSemaphores(int port)
 		InitAppendOnlyWriter();
 
 	/*
-	 * Set up resource manager 
+	 * Set up resource manager
 	 */
 	ResManagerShmemInit();
 
@@ -308,14 +311,14 @@ CreateSharedMemoryAndSemaphores(int port)
 
 	CreateSharedProcArray();
 	CreateSharedBackendStatus();
-	
+
 	/*
 	 * Set up Shared snapshot slots
 	 *
-	 * TODO: only need to do this if we aren't the QD. for now we are just 
-	 *		 doing it all the time and wasting shemem on the QD.  This is 
+	 * TODO: only need to do this if we aren't the QD. for now we are just
+	 *		 doing it all the time and wasting shemem on the QD.  This is
 	 *		 because this happens at postmaster startup time when we don't
-	 *		 know who we are.  
+	 *		 know who we are.
 	 */
 	CreateSharedSnapshotArray();
 	TwoPhaseShmemInit();
@@ -365,6 +368,8 @@ CreateSharedMemoryAndSemaphores(int port)
 
 	FtsProbeShmemInit();
 
+	InterconnectShmemInit();
+
 #ifdef EXEC_BACKEND
 
 	/*
@@ -384,7 +389,7 @@ CreateSharedMemoryAndSemaphores(int port)
 	/* Initialize shared memory for parallel retrieve cursor */
 	if (!IsUnderPostmaster)
 		EndpointShmemInit();
-	
+
 	if (Gp_role == GP_ROLE_DISPATCH)
 		ParallelCursorCountInit();
 

--- a/src/include/cdb/ml_ipc.h
+++ b/src/include/cdb/ml_ipc.h
@@ -306,6 +306,11 @@ extern ChunkTransportStateEntry *removeChunkTransportState(ChunkTransportState *
 
 extern TupleChunkListItem RecvTupleChunk(MotionConn *conn, ChunkTransportState *transportStates);
 
+extern Size InterconnectShmemSize(void);
+extern Size InterconnectShmemSizeUDPIFC(void);
+extern void InterconnectShmemInit(void);
+extern void InterconnectShmemInitUDPIFC(void);
+extern Datum GpInterconnectGetStatsUDPIFC(PG_FUNCTION_ARGS);
 extern void InitMotionTCP(int *listenerSocketFd, uint16 *listenerPort);
 extern void InitMotionUDPIFC(int *listenerSocketFd, uint16 *listenerPort);
 extern void markUDPConnInactiveIFC(MotionConn *conn);

--- a/src/include/storage/lwlock.h
+++ b/src/include/storage/lwlock.h
@@ -143,7 +143,8 @@ extern PGDLLIMPORT LWLockPadded *MainLWLockArray;
 #define FTSReplicationStatusLock	(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 11].lock)
 #define TwophaseCommitLock			(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 12].lock)
 #define ParallelCursorEndpointLock	(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 13].lock)
-#define GP_NUM_INDIVIDUAL_LWLOCKS		13
+#define ICStatisticsLock			(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 14].lock)
+#define GP_NUM_INDIVIDUAL_LWLOCKS		14
 
 /*
  * It would probably be better to allocate separate LWLock tranches


### PR DESCRIPTION
- gp_interconnect_stats_per_segment
- gp_interconnect_stats_per_segment_per_segment
- gp_interconnect_stats_per_segment_per_host

For now this feature is implemented as a contrib package to avoid upgrading system catalogs in a minor release.
Also, it only supports UDPIFC protocol because that's what most installations use.


On my test runs it looks like this:
```
postgres=# select * from gp_interconnect_stats;
-[ RECORD 1 ]-----------+------
total_recv_queue_size   | 7481
recv_queue_conting_time | 22307
total_capacity          | 4456
capacity_counting_time  | 2276
total_buffers           | 27386
buffer_counting_time    | 14129
retransmits             | 0
startup_cached_pkts     | 45
mismatches              | 322
crs_errors              | 0
snd_pkt_num             | 11845
recv_pkt_num            | 11523
disordered_pkt_num      | 0
duplicate_pkt_num       | 0
recv_ack_num            | 12506
status_query_msg_num    | 3
```

```
postgres=# select * from gp_interconnect_stats_per_segment;
-[ RECORD 1 ]-----------+-------------
hostname                | smiatkin-nix
gp_segment_id           | -1
total_recv_queue_size   | 1266
recv_queue_conting_time | 7931
total_capacity          | 840
capacity_counting_time  | 240
total_buffers           | 1315
buffer_counting_time    | 563
retransmits             | 0
startup_cached_pkts     | 0
mismatches              | 5
crs_errors              | 0
snd_pkt_num             | 519
recv_pkt_num            | 3677
disordered_pkt_num      | 0
duplicate_pkt_num       | 0
recv_ack_num            | 519
status_query_msg_num    | 0
-[ RECORD 2 ]-----------+-------------
hostname                | smiatkin-nix
gp_segment_id           | 2
total_recv_queue_size   | 477
recv_queue_conting_time | 2092
total_capacity          | 196
capacity_counting_time  | 68
total_buffers           | 5252
buffer_counting_time    | 2214
retransmits             | 0
startup_cached_pkts     | 10
mismatches              | 20
crs_errors              | 0
snd_pkt_num             | 2183
recv_pkt_num            | 1070
disordered_pkt_num      | 0
duplicate_pkt_num       | 0
recv_ack_num            | 2193
status_query_msg_num    | 0
-[ RECORD 3 ]-----------+-------------
hostname                | smiatkin-nix
gp_segment_id           | 0
total_recv_queue_size   | 569
recv_queue_conting_time | 2123
total_capacity          | 168
capacity_counting_time  | 60
total_buffers           | 5041
buffer_counting_time    | 2121
retransmits             | 0
startup_cached_pkts     | 8
mismatches              | 27
crs_errors              | 0
snd_pkt_num             | 2103
recv_pkt_num            | 1062
disordered_pkt_num      | 0
duplicate_pkt_num       | 0
recv_ack_num            | 2114
status_query_msg_num    | 0
-[ RECORD 4 ]-----------+-------------
hostname                | smiatkin-nix
gp_segment_id           | 1
total_recv_queue_size   | 498
recv_queue_conting_time | 2111
total_capacity          | 181
capacity_counting_time  | 65
total_buffers           | 5040
buffer_counting_time    | 2139
retransmits             | 0
startup_cached_pkts     | 2
mismatches              | 21
crs_errors              | 0
snd_pkt_num             | 2114
recv_pkt_num            | 1056
disordered_pkt_num      | 0
duplicate_pkt_num       | 0
recv_ack_num            | 2126
status_query_msg_num    | 0
```
And seems to be working.

Btw collecting these stats is always ON and cannot be turned off, so even if we simply run installcheck-world we should notice when things go wrong. But to see stats, one has to execute `create extension gp_interconnect_stats;`