### PR TITLE
Add views for getting cummulative IC stats

### DIFF
--- a/gpcontrib/Makefile
+++ b/gpcontrib/Makefile
@@ -25,7 +25,8 @@ ifeq "$(enable_debug_extensions)" "yes"
                gp_percentile_agg \
                gp_error_handling \
                gp_subtransaction_overflow \
-               gp_check_functions
+               gp_check_functions \
+			   gp_interconnect_stats
 else
 	recurse_targets = gp_sparse_vector \
                gp_distribution_policy \
@@ -39,7 +40,8 @@ else
                gp_percentile_agg \
                gp_error_handling \
                gp_subtransaction_overflow \
-               gp_check_functions
+               gp_check_functions \
+			   gp_interconnect_stats
 endif
 
 ifeq "$(with_zstd)" "yes"

--- a/gpcontrib/gp_interconnect_stats/Makefile
+++ b/gpcontrib/gp_interconnect_stats/Makefile
@@ -1,0 +1,23 @@
+EXTENSION = gp_interconnect_stats
+MODULES = gp_interconnect_stats
+
+EXTENSION_VERSION = 1.0
+
+
+DATA = gp_interconnect_stats--1.0.sql
+
+OBJS = gp_interconnect_stats.o
+
+MODULE_big = gp_interconnect_stats
+
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = gpcontrib/gp_interconnect_stats
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/gpcontrib/gp_interconnect_stats/gp_interconnect_stats--1.0.sql
+++ b/gpcontrib/gp_interconnect_stats/gp_interconnect_stats--1.0.sql
@@ -1,0 +1,135 @@
+/* gpcontrib/gp_interconnect_stats/gp_interconnect_stats--1.0.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION gp_interconnect_stats" to load this file. \quit
+
+CREATE FUNCTION __gp_interconnect_get_stats_f_on_master(
+	OUT gp_segment_id smallint,
+	OUT total_recv_queue_size bigint,
+	OUT recv_queue_conting_time bigint,
+	OUT total_capacity bigint,
+	OUT capacity_counting_time bigint,
+	OUT total_buffers bigint,
+	OUT buffer_counting_time bigint,
+	OUT retransmits bigint,
+	OUT startup_cached_pkts bigint,
+	OUT mismatches bigint,
+	OUT crs_errors bigint,
+	OUT snd_pkt_num bigint,
+	OUT recv_pkt_num bigint,
+	OUT disordered_pkt_num bigint,
+	OUT duplicate_pkt_num bigint,
+	OUT recv_ack_num bigint,
+	OUT status_query_msg_num bigint
+)
+RETURNS SETOF record
+LANGUAGE C VOLATILE EXECUTE ON MASTER
+AS '$libdir/gp_interconnect_stats', 'gp_interconnect_get_stats';
+
+CREATE FUNCTION __gp_interconnect_get_stats_f_on_segments(
+	OUT gp_segment_id smallint,
+	OUT total_recv_queue_size bigint,
+	OUT recv_queue_conting_time bigint,
+	OUT total_capacity bigint,
+	OUT capacity_counting_time bigint,
+	OUT total_buffers bigint,
+	OUT buffer_counting_time bigint,
+	OUT retransmits bigint,
+	OUT startup_cached_pkts bigint,
+	OUT mismatches bigint,
+	OUT crs_errors bigint,
+	OUT snd_pkt_num bigint,
+	OUT recv_pkt_num bigint,
+	OUT disordered_pkt_num bigint,
+	OUT duplicate_pkt_num bigint,
+	OUT recv_ack_num bigint,
+	OUT status_query_msg_num bigint
+)
+RETURNS SETOF record LANGUAGE C VOLATILE EXECUTE ON ALL SEGMENTS
+AS '$libdir/gp_interconnect_stats', 'gp_interconnect_get_stats';
+
+
+--------------------------------------------------------------------------------
+-- @view:
+--              gp_interconnect_stats_per_segment
+--
+-- @doc:
+--              Cummulative interconnect statistics per segment
+--
+--------------------------------------------------------------------------------
+CREATE VIEW gp_interconnect_stats_per_segment AS
+    SELECT c.hostname, s.* FROM (
+        SELECT * FROM __gp_interconnect_get_stats_f_on_master()
+        UNION ALL
+        SELECT * FROM __gp_interconnect_get_stats_f_on_segments()
+    ) s
+    INNER JOIN pg_catalog.gp_segment_configuration AS c
+        ON s.gp_segment_id = c.content
+        AND c.role = 'p'
+    ;
+
+GRANT SELECT ON gp_interconnect_stats_per_segment TO public;
+
+--------------------------------------------------------------------------------
+-- @view:
+--              gp_interconnect_stats
+--
+-- @doc:
+--              Cummulative interconnect statistics
+--
+--------------------------------------------------------------------------------
+CREATE VIEW gp_interconnect_stats AS
+    SELECT
+        sum(total_recv_queue_size) as total_recv_queue_size
+	  , sum(recv_queue_conting_time) as recv_queue_conting_time
+	  , sum(total_capacity) as total_capacity
+	  , sum(capacity_counting_time) as capacity_counting_time
+	  , sum(total_buffers) as total_buffers
+	  , sum(buffer_counting_time) as buffer_counting_time
+	  , sum(retransmits) as retransmits
+	  , sum(startup_cached_pkts) as startup_cached_pkts
+	  , sum(mismatches) as mismatches
+	  , sum(crs_errors) as crs_errors
+	  , sum(snd_pkt_num) as snd_pkt_num
+	  , sum(recv_pkt_num) as recv_pkt_num
+	  , sum(disordered_pkt_num) as disordered_pkt_num
+	  , sum(duplicate_pkt_num) as duplicate_pkt_num
+	  , sum(recv_ack_num) as recv_ack_num
+	  , sum(status_query_msg_num) as status_query_msg_num
+    FROM gp_interconnect_stats_per_segment
+    ;
+
+GRANT SELECT ON gp_interconnect_stats TO public;
+
+--------------------------------------------------------------------------------
+-- @view:
+--              gp_interconnect_stats_per_host
+--
+-- @doc:
+--              Cummulative interconnect statistics grouped by host
+--
+--------------------------------------------------------------------------------
+
+CREATE VIEW gp_interconnect_stats_per_host AS
+    SELECT
+        hostname
+      , sum(total_recv_queue_size) as total_recv_queue_size
+	  , sum(recv_queue_conting_time) as recv_queue_conting_time
+	  , sum(total_capacity) as total_capacity
+	  , sum(capacity_counting_time) as capacity_counting_time
+	  , sum(total_buffers) as total_buffers
+	  , sum(buffer_counting_time) as buffer_counting_time
+	  , sum(retransmits) as retransmits
+	  , sum(startup_cached_pkts) as startup_cached_pkts
+	  , sum(mismatches) as mismatches
+	  , sum(crs_errors) as crs_errors
+	  , sum(snd_pkt_num) as snd_pkt_num
+	  , sum(recv_pkt_num) as recv_pkt_num
+	  , sum(disordered_pkt_num) as disordered_pkt_num
+	  , sum(duplicate_pkt_num) as duplicate_pkt_num
+	  , sum(recv_ack_num) as recv_ack_num
+	  , sum(status_query_msg_num) as status_query_msg_num
+    FROM gp_interconnect_stats_per_segment
+    GROUP BY hostname;
+
+GRANT SELECT ON gp_interconnect_stats_per_host TO public;

--- a/gpcontrib/gp_interconnect_stats/gp_interconnect_stats.c
+++ b/gpcontrib/gp_interconnect_stats/gp_interconnect_stats.c
@@ -1,0 +1,27 @@
+/*--------------------------------------------------------------------------
+ *
+ * gp_interconnect_stats.c
+ *	  Routine for getting UDPIFC interconnect stats
+ *
+ **--------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "cdb/cdbvars.h"
+#include "cdb/ml_ipc.h"
+#include "fmgr.h"
+
+PG_MODULE_MAGIC;
+
+PG_FUNCTION_INFO_V1(gp_interconnect_get_stats);
+
+Datum
+gp_interconnect_get_stats(PG_FUNCTION_ARGS)
+{
+	if (Gp_interconnect_type == INTERCONNECT_TYPE_UDPIFC)
+		return GpInterconnectGetStatsUDPIFC(fcinfo);
+	ereport(WARNING,
+		(errcode(ERRCODE_WARNING_GP_INTERCONNECTION),
+		errmsg("Interconnect statistics are collected only for UDPIFC protocol")));
+	PG_RETURN_NULL();
+}

--- a/gpcontrib/gp_interconnect_stats/gp_interconnect_stats.control
+++ b/gpcontrib/gp_interconnect_stats/gp_interconnect_stats.control
@@ -1,0 +1,3 @@
+comment = 'Cummulative statistics from UDPIFC interconnect protocol'
+default_version = '1.0'
+relocatable = false

--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -249,6 +249,21 @@ InitMotionLayerIPC(void)
 	elog(DEBUG1, "Interconnect listening on tcp port %d udp port %d (0x%x)", tcp_listener, udp_listener, Gp_listener_port);
 }
 
+void
+InterconnectShmemInit(void)
+{
+	if (Gp_interconnect_type == INTERCONNECT_TYPE_UDPIFC)
+		InterconnectShmemInitUDPIFC();
+}
+
+Size
+InterconnectShmemSize(void)
+{
+	if (Gp_interconnect_type == INTERCONNECT_TYPE_UDPIFC)
+		return InterconnectShmemSizeUDPIFC();
+	return 0;
+}
+
 /* See ml_ipc.h */
 void
 CleanUpMotionLayerIPC(void)

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -26,6 +26,7 @@
 #include "access/appendonlywriter.h"
 #include "cdb/cdblocaldistribxact.h"
 #include "cdb/cdbvars.h"
+#include "cdb/ml_ipc.h"
 #include "commands/async.h"
 #include "miscadmin.h"
 #include "pgstat.h"
@@ -183,7 +184,7 @@ CreateSharedMemoryAndSemaphores(int port)
 
 #ifdef FAULT_INJECTOR
 		size = add_size(size, FaultInjector_ShmemSize());
-#endif			
+#endif
 
 		/* This elog happens before we know the name of the log file we are supposed to use */
 		elog(DEBUG1, "Size not including the buffer pool %lu",
@@ -210,6 +211,8 @@ CreateSharedMemoryAndSemaphores(int port)
 
 		/* size of parallel cursor count */
 		size = add_size(size, ParallelCursorCountSize());
+
+		size = add_size(size, InterconnectShmemSize());
 
 		elog(DEBUG3, "invoking IpcMemoryCreate(size=%zu)", size);
 
@@ -286,7 +289,7 @@ CreateSharedMemoryAndSemaphores(int port)
 		InitAppendOnlyWriter();
 
 	/*
-	 * Set up resource manager 
+	 * Set up resource manager
 	 */
 	ResManagerShmemInit();
 
@@ -303,14 +306,14 @@ CreateSharedMemoryAndSemaphores(int port)
 
 	CreateSharedProcArray();
 	CreateSharedBackendStatus();
-	
+
 	/*
 	 * Set up Shared snapshot slots
 	 *
-	 * TODO: only need to do this if we aren't the QD. for now we are just 
-	 *		 doing it all the time and wasting shemem on the QD.  This is 
+	 * TODO: only need to do this if we aren't the QD. for now we are just
+	 *		 doing it all the time and wasting shemem on the QD.  This is
 	 *		 because this happens at postmaster startup time when we don't
-	 *		 know who we are.  
+	 *		 know who we are.
 	 */
 	CreateSharedSnapshotArray();
 	TwoPhaseShmemInit();
@@ -356,6 +359,8 @@ CreateSharedMemoryAndSemaphores(int port)
 
 	FtsProbeShmemInit();
 
+	InterconnectShmemInit();
+
 #ifdef EXEC_BACKEND
 
 	/*
@@ -375,7 +380,7 @@ CreateSharedMemoryAndSemaphores(int port)
 	/* Initialize shared memory for parallel retrieve cursor */
 	if (!IsUnderPostmaster)
 		EndpointShmemInit();
-	
+
 	if (Gp_role == GP_ROLE_DISPATCH)
 		ParallelCursorCountInit();
 

--- a/src/include/cdb/ml_ipc.h
+++ b/src/include/cdb/ml_ipc.h
@@ -306,6 +306,11 @@ extern ChunkTransportStateEntry *removeChunkTransportState(ChunkTransportState *
 
 extern TupleChunkListItem RecvTupleChunk(MotionConn *conn, ChunkTransportState *transportStates);
 
+extern Size InterconnectShmemSize(void);
+extern Size InterconnectShmemSizeUDPIFC(void);
+extern void InterconnectShmemInit(void);
+extern void InterconnectShmemInitUDPIFC(void);
+extern Datum GpInterconnectGetStatsUDPIFC(PG_FUNCTION_ARGS);
 extern void InitMotionTCP(int *listenerSocketFd, uint16 *listenerPort);
 extern void InitMotionUDPIFC(int *listenerSocketFd, uint16 *listenerPort);
 extern void markUDPConnInactiveIFC(MotionConn *conn);

--- a/src/include/storage/lwlock.h
+++ b/src/include/storage/lwlock.h
@@ -143,7 +143,8 @@ extern PGDLLIMPORT LWLockPadded *MainLWLockArray;
 #define FTSReplicationStatusLock	(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 11].lock)
 #define TwophaseCommitLock			(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 12].lock)
 #define ParallelCursorEndpointLock	(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 13].lock)
-#define GP_NUM_INDIVIDUAL_LWLOCKS		13
+#define ICStatisticsLock			(&MainLWLockArray[PG_NUM_INDIVIDUAL_LWLOCKS + 14].lock)
+#define GP_NUM_INDIVIDUAL_LWLOCKS		14
 
 /*
  * It would probably be better to allocate separate LWLock tranches


### PR DESCRIPTION
- gp_interconnect_stats_per_segment
- gp_interconnect_stats_per_segment_per_segment
- gp_interconnect_stats_per_segment_per_host

For now this feature is implemented as a contrib package to avoid upgrading system catalogs in a minor release.
Also, it only supports UDPIFC protocol because that's what most installations use.

On my local test runs it looks like this:
```
postgres=# select * from gp_interconnect_stats_per_segment;
-[ RECORD 1 ]-----------+-------------
hostname                | smiatkin-nix
gp_segment_id           | -1
total_recv_queue_size   | 91033
recv_queue_conting_time | 64646
total_capacity          | 469367
capacity_counting_time  | 22867
total_buffers           | 1396350
buffer_counting_time    | 34122
retransmits             | 66
startup_cached_pkts     | 7
mismatches              | 77
crs_errors              | 0
snd_pkt_num             | 23635
recv_pkt_num            | 50080
disordered_pkt_num      | 0
duplicate_pkt_num       | 125
recv_ack_num            | 35162
status_query_msg_num    | 26
-[ RECORD 2 ]-----------+-------------
hostname                | smiatkin-nix
gp_segment_id           | 1
total_recv_queue_size   | 42487
recv_queue_conting_time | 66288
total_capacity          | 470008
capacity_counting_time  | 29533
total_buffers           | 1356890
buffer_counting_time    | 62450
retransmits             | 67
startup_cached_pkts     | 87
mismatches              | 113
crs_errors              | 0
snd_pkt_num             | 36395
recv_pkt_num            | 34369
disordered_pkt_num      | 0
duplicate_pkt_num       | 32
recv_ack_num            | 51297
status_query_msg_num    | 2
-[ RECORD 3 ]-----------+-------------
hostname                | smiatkin-nix
gp_segment_id           | 2
total_recv_queue_size   | 35936
recv_queue_conting_time | 63646
total_capacity          | 445655
capacity_counting_time  | 24331
total_buffers           | 1311581
buffer_counting_time    | 52703
retransmits             | 67
startup_cached_pkts     | 82
mismatches              | 117
crs_errors              | 0
snd_pkt_num             | 31023
recv_pkt_num            | 32670
disordered_pkt_num      | 0
duplicate_pkt_num       | 28
recv_ack_num            | 43196
status_query_msg_num    | 1
-[ RECORD 4 ]-----------+-------------
hostname                | smiatkin-nix
gp_segment_id           | 0
total_recv_queue_size   | 42088
recv_queue_conting_time | 56051
total_capacity          | 452634
capacity_counting_time  | 21515
total_buffers           | 1343493
buffer_counting_time    | 49594
retransmits             | 68
startup_cached_pkts     | 78
mismatches              | 122
crs_errors              | 0
snd_pkt_num             | 28844
recv_pkt_num            | 31178
disordered_pkt_num      | 0
duplicate_pkt_num       | 53
recv_ack_num            | 39692
status_query_msg_num    | 1

```


```
postgres=# select * from gp_interconnect_stats;
-[ RECORD 1 ]-----------+--------
total_recv_queue_size   | 202403
recv_queue_conting_time | 239691
total_capacity          | 1836322
capacity_counting_time  | 95822
total_buffers           | 5393524
buffer_counting_time    | 189145
retransmits             | 268
startup_cached_pkts     | 241
mismatches              | 397
crs_errors              | 0
snd_pkt_num             | 112893
recv_pkt_num            | 141312
disordered_pkt_num      | 0
duplicate_pkt_num       | 238
recv_ack_num            | 161186
status_query_msg_num    | 30
```

And seems to be working.

Btw collecting these stats is always ON and cannot be turned off, so even if we simply run installcheck-world we should notice when things go wrong. But to see stats, one has to execute create extension gp_interconnect_stats;