### PR TITLE
Revert "Fix explain_format and gporca tests (#70)" in 6 28

### DIFF
--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -881,7 +881,8 @@ QUERY PLAN
       ]
     },
     "Settings": {
-      "Optimizer": "Postgres query optimizer"
+      "Optimizer": "Postgres query optimizer",
+      "Settings": ["optimizer=off"]
     }
   }
 ]

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -878,7 +878,8 @@ QUERY PLAN
       ]
     },
     "Settings": {
-      "Optimizer": "Postgres query optimizer"
+      "Optimizer": "Postgres query optimizer",
+      "Settings": ["optimizer=on"]
     }
   }
 ]

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -13596,7 +13596,8 @@ and first_id in (select first_id from mat_w);
                              Output: material_test_1.first_id
                              Filter: (material_test_1.second_id = ANY ('{1,2,3,4}'::integer[]))
  Optimizer: Postgres query optimizer
-(22 rows)
+ Settings: enable_seqscan=on, optimizer=off
+(23 rows)
 
 with mat_w as (
 select first_id
@@ -13658,7 +13659,8 @@ from mat m1 join mat m2 on m1.j = m2.j;
                            ->  Bitmap Index Scan on material_bitmapscan_idx  (cost=0.00..102.66 rows=334 width=0)
                                  Index Cond: (material_bitmapscan_1.k = 'Thu Jun 03 00:00:00 2021'::timestamp without time zone)
  Optimizer: Postgres query optimizer
-(22 rows)
+ Settings: optimizer=off
+(23 rows)
 
 with mat as(
     select i, j from material_bitmapscan where i = 2 and j = 2

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -13815,7 +13815,8 @@ and first_id in (select first_id from mat_w);
                      ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=3 width=4)
                            Output: share0_ref2.first_id
  Optimizer: Pivotal Optimizer (GPORCA)
-(30 rows)
+ Settings: optimizer=on
+(31 rows)
 
 with mat_w as (
 select first_id
@@ -13885,7 +13886,8 @@ from mat m1 join mat m2 on m1.j = m2.j;
                            ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=1 width=4)
                                  Output: share0_ref2.i, share0_ref2.j
  Optimizer: Pivotal Optimizer (GPORCA)
-(30 rows)
+ Settings: optimizer=on
+(31 rows)
 
 with mat as(
     select i, j from material_bitmapscan where i = 2 and j = 2


### PR DESCRIPTION
This reverts commit b5fd829ec7180b024f72ba5f10ca5d6f721e0be5.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
