### PR TITLE
Separate building build docker image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -229,6 +229,18 @@ jobs:
     - name: Build Environment Image
       run: docker build . --file docker/build/Dockerfile --tag gp_build_jammy:1234
 
+    - name: Push Environment Image
+      run: |
+        IMAGE_ID=ghcr.io/${{ github.repository_owner }}/gp_build_jammy
+        IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+        VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+        [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+        [ "$VERSION" == "main" ] && VERSION=latest
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION
+
     - name: Build Greenplum Image
       run: docker build . --file docker/test/Dockerfile --tag test_test:1234
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -241,13 +241,13 @@ jobs:
     - name: Upload Greenplum Image artifact
       uses: actions/upload-artifact@v4
       with:
-        name: myimage
+        name: greenplum_image
         path: /tmp/greenplum_image.tar
 
     - name: Upload Environment Image artifact
       uses: actions/upload-artifact@v4
       with:
-        name: myimage
+        name: gp_build_jammy
         path: /tmp/gp_build_jammy.tar
 
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -231,15 +231,14 @@ jobs:
 
     - name: Push Environment Image
       run: |
-        IMAGE_ID=ghcr.io/${{ github.repository_owner }}/gp_build_jammy
+        $IMAGE_NAME="gp_build_jammy"
+        IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
         IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-        VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-        [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-        [ "$VERSION" == "main" ] && VERSION=latest
-          echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
-          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
+        $VERSION="latest"
+        echo IMAGE_ID=$IMAGE_ID
+        echo VERSION=$VERSION
+        docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+        docker push $IMAGE_ID:$VERSION
 
     - name: Build Greenplum Image
       run: docker build . --file docker/test/Dockerfile --tag test_test:1234

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,6 +214,12 @@ jobs:
     outputs:
       build_timestamp: ${{ steps.set_timestamp.outputs.timestamp }}
 
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+
     steps:
     - uses: actions/checkout@v4
 
@@ -225,6 +231,7 @@ jobs:
         context: .
         file: ./docker/build/Dockerfile
         tags: gp_build_jammy:1234
+        load: true
     - name: Build and push
       uses: docker/build-push-action@v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -231,15 +231,24 @@ jobs:
 
     - name: Build Greenplum Image
       run: docker build . --file docker/test/Dockerfile --tag test_test:1234
+
+    - name: Save Environment Image
+      run: docker save -o /tmp/greenplum_image.tar test_test:1234
       
     - name: Save Greenplum Image
-      run: docker save -o /tmp/myimage.tar test_test:1234
+      run: docker save -o /tmp/gp_build_jammy.tar gp_build_jammy:1234
     
-    - name: Upload artifact
+    - name: Upload Greenplum Image artifact
       uses: actions/upload-artifact@v4
       with:
         name: myimage
-        path: /tmp/myimage.tar
+        path: /tmp/greenplum_image.tar
+
+    - name: Upload Environment Image artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: myimage
+        path: /tmp/gp_build_jammy.tar
 
 
 
@@ -295,12 +304,12 @@ jobs:
     - name: Download artifact
       uses: actions/download-artifact@v4
       with:
-        name: myimage
+        name: greenplum_image
         path: /tmp
     - name: Load Docker image
       run: |
         docker image ls -a
-        docker load --input /tmp/myimage.tar
+        docker load --input /tmp/greenplum_image.tar
         docker image ls -a
 
     - name: "Run Tests: ${{ matrix.test }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -219,6 +219,12 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: .
+        file: ./docker/build/Dockerfile
+        tags: gp_build_jammy:1234
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
         file: ./docker/test/Dockerfile
         tags: test_test:1234
         outputs: type=docker,dest=/tmp/myimage.tar

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -225,20 +225,15 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-    - name: Build and push
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        file: ./docker/build/Dockerfile
-        tags: gp_build_jammy:1234
-        load: true
-    - name: Build and push
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        file: ./docker/test/Dockerfile
-        tags: test_test:1234
-        outputs: type=docker,dest=/tmp/myimage.tar
+
+    - name: Build Environment Image
+      run: docker build . --file docker/build/Dockerfile --tag gp_build_jammy:1234
+
+    - name: Build Greenplum Image
+      run: docker build . --file docker/test/Dockerfile --tag test_test:1234
+      
+    - name: Save Greenplum Image
+      run: docker save -o /tmp/myimage.tar test_test:1234
     
     - name: Upload artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -231,10 +231,10 @@ jobs:
 
     - name: Push Environment Image
       run: |
-        $IMAGE_NAME="gp_build_jammy"
+        IMAGE_NAME=gp_build_jammy
         IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
         IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-        $VERSION="latest"
+        VERSION=latest
         echo IMAGE_ID=$IMAGE_ID
         echo VERSION=$VERSION
         docker tag $IMAGE_NAME $IMAGE_ID:$VERSION

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,0 +1,55 @@
+FROM ubuntu:jammy
+
+ARG accessKeyId
+ARG secretAccessKey
+ARG bucketName
+ARG yezzeyRef
+
+ENV YEZZEY_REF=${yezzeyRef:-v1.8_opengpdb}
+
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN stat -fc %T /sys/fs/cgroup/
+
+RUN useradd -rm -d /home/gpadmin -s /bin/bash -g root -G sudo -u 1001 gpadmin
+
+RUN ln -snf /usr/share/zoneinfo/Europe/London /etc/localtime && echo Europe/London > /etc/timezone \
+&& apt-get update -o Acquire::AllowInsecureRepositories=true && apt-get install -y --no-install-recommends --allow-unauthenticated \
+  build-essential libssl-dev gnupg devscripts \
+  openssl libssl-dev debhelper debootstrap \
+  make equivs bison ca-certificates-java ca-certificates \
+  cmake curl cgroup-tools flex gcc-9 g++-9 g++-9-multilib \
+  git krb5-multidev libapr1-dev libbz2-dev libcurl4-gnutls-dev \
+  libevent-dev libkrb5-dev libldap2-dev libperl-dev libreadline6-dev \
+  libssl-dev libxml2-dev libyaml-dev libzstd-dev libaprutil1-dev \
+  libpam0g-dev libpam0g libcgroup1 libyaml-0-2 libldap2-dev openssl \
+  ninja-build python2-dev python-setuptools quilt unzip wget zlib1g-dev libuv1-dev \
+  libgpgme-dev libgpgme11 sudo iproute2 less software-properties-common \
+  openssh-client openssh-server
+
+RUN apt-get install -y locales \
+&& locale-gen "en_US.UTF-8" \
+&& update-locale LC_ALL="en_US.UTF-8"
+
+RUN echo 'gpadmin ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers
+
+USER gpadmin
+WORKDIR /home/gpadmin
+
+RUN cd /tmp/ \
+&& git clone https://github.com/greenplum-db/gp-xerces-archive.git \
+&& cd ./gp-xerces-archive/ && mkdir build && cd build && ../configure --prefix=/usr/local && make -j \
+&& sudo make install
+
+RUN cd /tmp/ \
+&& git clone https://github.com/boundary/sigar.git \
+&& cd ./sigar/ \
+&& mkdir build && cd build && cmake .. && make \
+&& sudo make install
+
+COPY ./README.ubuntu22.bash /home/gpadmin
+
+RUN sudo DEBIAN_FRONTEND=noninteractive ./README.ubuntu22.bash \
+&& sudo apt install -y libhyperic-sigar-java libaprutil1-dev libuv1-dev

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy
+FROM gp_build_jammy:1234
 
 ARG accessKeyId
 ARG secretAccessKey
@@ -11,53 +11,12 @@ ENV YEZZEY_REF=${yezzeyRef:-v1.8_opengpdb}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN stat -fc %T /sys/fs/cgroup/
-
-RUN useradd -rm -d /home/gpadmin -s /bin/bash -g root -G sudo -u 1001 gpadmin
-
-RUN ln -snf /usr/share/zoneinfo/Europe/London /etc/localtime && echo Europe/London > /etc/timezone \
-&& apt-get update -o Acquire::AllowInsecureRepositories=true && apt-get install -y --no-install-recommends --allow-unauthenticated \
-  build-essential libssl-dev gnupg devscripts \
-  openssl libssl-dev debhelper debootstrap \
-  make equivs bison ca-certificates-java ca-certificates \
-  cmake curl cgroup-tools flex gcc-9 g++-9 g++-9-multilib \
-  git krb5-multidev libapr1-dev libbz2-dev libcurl4-gnutls-dev \
-  libevent-dev libkrb5-dev libldap2-dev libperl-dev libreadline6-dev \
-  libssl-dev libxml2-dev libyaml-dev libzstd-dev libaprutil1-dev \
-  libpam0g-dev libpam0g libcgroup1 libyaml-0-2 libldap2-dev openssl \
-  ninja-build python2-dev python-setuptools quilt unzip wget zlib1g-dev libuv1-dev \
-  libgpgme-dev libgpgme11 sudo iproute2 less software-properties-common \
-  openssh-client openssh-server
-
-RUN apt-get install -y locales \
-&& locale-gen "en_US.UTF-8" \
-&& update-locale LC_ALL="en_US.UTF-8"
-
-RUN echo 'gpadmin ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers
-
 USER gpadmin
 WORKDIR /home/gpadmin
 
-COPY yezzey_test/generate_ssh_key.sh /home/gpadmin/
-
-RUN ["/home/gpadmin/generate_ssh_key.sh"]
-
-
-RUN cd /tmp/ \
-&& git clone https://github.com/greenplum-db/gp-xerces-archive.git \
-&& cd ./gp-xerces-archive/ && mkdir build && cd build && ../configure --prefix=/usr/local && make -j \
-&& sudo make install
-
-RUN cd /tmp/ \
-&& git clone https://github.com/boundary/sigar.git \
-&& cd ./sigar/ \
-&& mkdir build && cd build && cmake .. && make \
-&& sudo make install
-
 COPY . /home/gpadmin
 
-RUN sudo DEBIAN_FRONTEND=noninteractive ./README.ubuntu22.bash \
-&& sudo apt install -y libhyperic-sigar-java libaprutil1-dev libuv1-dev
+RUN /home/gpadmin/generate_ssh_key.sh
 
 RUN sudo mkdir /usr/local/gpdb \
 && sudo chown gpadmin:root /usr/local/gpdb

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -11,12 +11,13 @@ ENV YEZZEY_REF=${yezzeyRef:-v1.8_opengpdb}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 
+COPY yezzey_test/generate_ssh_key.sh /home/gpadmin/
+RUN /home/gpadmin/generate_ssh_key.sh
+
 USER gpadmin
 WORKDIR /home/gpadmin
 
 COPY . /home/gpadmin
-
-RUN /home/gpadmin/generate_ssh_key.sh
 
 RUN sudo mkdir /usr/local/gpdb \
 && sudo chown gpadmin:root /usr/local/gpdb


### PR DESCRIPTION
Сейчас ГП собирается суммарно за 9 минут.

Я разделил установку пакетов и саму сборку разных на 2 image'а (https://github.com/open-gpdb/gpdb/pull/138) (https://github.com/open-gpdb/gpdb/actions/runs/13591301620/job/37997853964):

3 минуты - пакеты

6 минут - сборка

На загрузку уже готового пакета уйдёт порядка 1 минуты

Экономия в 2 минуты, не знаю будут ли они решать на фоне сколько работают сами тесты

[ic-good-opt-off](https://github.com/open-gpdb/gpdb/actions/runs/13589666731/job/37993092694#logs) - 29 минут

[ic-good-opt-on](https://github.com/open-gpdb/gpdb/actions/runs/13589666731/job/37993093138#logs) - 44 минуты

[ic-contrib](https://github.com/open-gpdb/gpdb/actions/runs/13589666731/job/37993094543#logs) - 50 минут

[ic-gpcontrib](https://github.com/open-gpdb/gpdb/actions/runs/13589666731/job/37993095012#logs) - 21 минута

[ic-resgroup](https://github.com/open-gpdb/gpdb/actions/runs/13589666731/job/37993094098#logs) - 12 минут

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
