### PR TITLE
Update cdbdisp_query.c: fix compile warning

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -869,8 +869,8 @@ buildGpQueryString(DispatchCommandQueryParms *pQueryParms,
 	int			sddesc_len = pQueryParms->serializedQueryDispatchDesclen;
 	const char *dtxContextInfo = pQueryParms->serializedDtxContextInfo;
 	int			dtxContextInfo_len = pQueryParms->serializedDtxContextInfolen;
-	char *queryEnvInfo = 0;
-	int			queryEnvInfo_len = NULL;
+	char 	   *queryEnvInfo = NULL;
+	int			queryEnvInfo_len = 0;
 	int64		currentStatementStartTimestamp = GetCurrentStatementStartTimestamp();
 	Oid			sessionUserId = GetSessionUserId();
 	Oid			outerUserId = GetOuterUserId();


### PR DESCRIPTION
```

cdbdisp_query.c: In function ‘buildGpQueryString’:
cdbdisp_query.c:873:52: warning: initialization of ‘int’ from ‘void *’ makes integer from pointer without a cast [-Wint-conversion]
  873 |         int                     queryEnvInfo_len = NULL;
      |                                                    ^~~~
touch objfiles.txt
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
