### PR TITLE
error while skip_locked with rootpartition

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -187,6 +187,14 @@ vacuum(VacuumStmt *vacstmt, Oid relid, bool do_toast,
 		ereport(ERROR,
 				(errcode(ERRCODE_SYNTAX_ERROR),
 				 errmsg("ROOTPARTITION option cannot be used together with VACUUM, try ANALYZE ROOTPARTITION")));
+
+	if ((vacstmt->options & VACOPT_ROOTONLY) &&
+	    (vacstmt->options & VACOPT_NOWAIT))
+		ereport(ERROR,
+				(errcode(ERRCODE_SYNTAX_ERROR),
+				 errmsg("ROOTPARTITION option cannot be used together with SKIP_LOCKED")));
+	
+	
 	static bool in_vacuum = false;
 
 	/* sanity checks on options */

--- a/src/test/isolation2/expected/skip_locked_vacuum_analyze.out
+++ b/src/test/isolation2/expected/skip_locked_vacuum_analyze.out
@@ -28,6 +28,9 @@ ANALYZE
 1: rollback;
 ROLLBACK
 
+1: analyze SKIP_LOCKED ROOTPARTITION tp;
+ERROR:  ROOTPARTITION option cannot be used together with SKIP_LOCKED
+
 1:drop table tp;
 DROP
 1:drop table tp1;

--- a/src/test/isolation2/sql/skip_locked_vacuum_analyze.sql
+++ b/src/test/isolation2/sql/skip_locked_vacuum_analyze.sql
@@ -22,5 +22,7 @@ PARTITION by RANGE (id)
 2: analyze SKIP_LOCKED tp;
 1: rollback;
 
+1: analyze SKIP_LOCKED ROOTPARTITION tp;
+
 1:drop table tp;
 1:drop table tp1;


### PR DESCRIPTION
By implementing ```analyze skip_locked rootpartition``` will not do anything. We output an error so that it is obvious that such functionality does not work