### PR TITLE
Cherry-pick: Fix plans for queries to replicated table with volatile function

### DIFF
--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -573,6 +573,14 @@ ParallelizeCorrelatedSubPlanMutator(Node *node, ParallelizeCorrelatedPlanWalkerC
 		if (ctx->movement == MOVEMENT_BROADCAST)
 		{
 			Assert (NULL != ctx->currentPlanFlow);
+
+			if (scanPlan->flow->locustype == CdbLocusType_SegmentGeneral &&
+				contain_volatile_functions((Node *) scanPlan->qual))
+			{
+				scanPlan->flow->locustype = CdbLocusType_SingleQE;
+				scanPlan->flow->flotype = FLOW_SINGLETON;
+			}
+
 			broadcastPlan(scanPlan, false /* stable */ , false /* rescannable */,
 						  ctx->currentPlanFlow->numsegments /* numsegments */);
 		}

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -845,7 +845,13 @@ apply_motion_mutator(Node *node, ApplyMotionState *context)
 	if (IsA(newnode, Motion) &&flow->req_move != MOVEMENT_NONE)
 	{
 		plan = ((Motion *) newnode)->plan.lefttree;
-		flow = plan->flow;
+
+		/* We'll recreate this motion later below. But we should save motion
+		 * request to create appropriate motion above the child node.
+		 * Original flow for the child node will be restored
+		 * after motion creation. */
+		flow->flow_before_req_move = plan->flow;
+		plan->flow = flow;
 		newnode = (Node *) plan;
 	}
 

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -6589,12 +6589,15 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node, List *is_split_upd
 				 * Obviously, tmp_tab in new segments can't get data if we don't
 				 * add a broadcast here. 
 				 */
-				if (optimizer_replicated_table_insert &&
-					subplan->flow->flotype == FLOW_SINGLETON &&
-					subplan->flow->locustype == CdbLocusType_SegmentGeneral &&
-					!contain_volatile_functions((Node *)subplan->targetlist))
+				if (subplan->flow->flotype == FLOW_SINGLETON &&
+					subplan->flow->locustype == CdbLocusType_SegmentGeneral)
 				{
-					if (subplan->flow->numsegments >= targetPolicy->numsegments)
+					if (contain_volatile_functions((Node *)subplan->targetlist))
+					{
+						subplan->flow->locustype = CdbLocusType_SingleQE;
+					}
+					else if (optimizer_replicated_table_insert &&
+							 subplan->flow->numsegments >= targetPolicy->numsegments)
 					{
 						/*
 						 * A query to reach here:

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -1324,14 +1324,13 @@ select j, (select 5) AS "Uncorrelated Field" from t;
 -- Check sub-selects with distributed replicated tables and volatile functions
 --
 set optimizer = off;
-drop table if exists t;
-create table t (i bigint) distributed replicated;
-create table t1 (a bigint) distributed by (a);
-create table t2 (a bigint, b float) distributed replicated;
+create table repl_tbl_1 (i bigint) distributed replicated;
+create table dist_tbl (a bigint) distributed by (a);
+create table repl_tbl_2 (a bigint, b float) distributed replicated;
 create or replace function f(i bigint) returns bigint language sql security definer as $$ select i; $$;
 create sequence seq increment by 1 minvalue 1 maxvalue 2 start 2 no cycle;
 -- ensure we make gather motion when volatile functions in subplan
-explain (costs off, verbose) select (select f(i) from t);
+explain (costs off, verbose) select (select f(i) from repl_tbl_1);
                              QUERY PLAN                             
 --------------------------------------------------------------------
  Result
@@ -1339,13 +1338,13 @@ explain (costs off, verbose) select (select f(i) from t);
    InitPlan 1 (returns $0)  (slice2)
      ->  Gather Motion 1:1  (slice1; segments: 1)
            Output: (f(i))
-           ->  Seq Scan on rpt.t
+           ->  Seq Scan on rpt.repl_tbl_1
                  Output: f(i)
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (9 rows)
 
-explain (costs off, verbose) select (select f(i) from t group by f(i));
+explain (costs off, verbose) select (select f(i) from repl_tbl_1 group by f(i));
                              QUERY PLAN                             
 --------------------------------------------------------------------
  Result
@@ -1355,14 +1354,14 @@ explain (costs off, verbose) select (select f(i) from t group by f(i));
            Output: (f(i))
            ->  HashAggregate
                  Output: (f(i))
-                 Group Key: f(t.i)
-                 ->  Seq Scan on rpt.t
+                 Group Key: f(repl_tbl_1.i)
+                 ->  Seq Scan on rpt.repl_tbl_1
                        Output: i, f(i)
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (12 rows)
 
-explain (costs off, verbose) select (select i from t group by i having f(i) > 0);
+explain (costs off, verbose) select (select i from repl_tbl_1 group by i having f(i) > 0);
                              QUERY PLAN                             
 --------------------------------------------------------------------
  Result
@@ -1372,143 +1371,143 @@ explain (costs off, verbose) select (select i from t group by i having f(i) > 0)
            Output: i
            ->  HashAggregate
                  Output: i
-                 Group Key: t.i
-                 Filter: (f(t.i) > 0)
-                 ->  Seq Scan on rpt.t
+                 Group Key: repl_tbl_1.i
+                 Filter: (f(repl_tbl_1.i) > 0)
+                 ->  Seq Scan on rpt.repl_tbl_1
                        Output: i
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (13 rows)
 
 -- ensure we do not make broadcast motion
-explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
+explain (costs off, verbose) select * from dist_tbl where a in (select random() from repl_tbl_1 where i=a group by i);
                              QUERY PLAN                             
 --------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   Output: t1.a
-   ->  Seq Scan on rpt.t1
-         Output: t1.a
+   Output: dist_tbl.a
+   ->  Seq Scan on rpt.dist_tbl
+         Output: dist_tbl.a
          Filter: (SubPlan 1)
          SubPlan 1  (slice1; segments: 1)
            ->  Result
-                 Output: random(), t.i
-                 Filter: (t.i = t1.a)
+                 Output: random(), repl_tbl_1.i
+                 Filter: (repl_tbl_1.i = dist_tbl.a)
                  ->  Materialize
-                       Output: t.i, t.i
-                       ->  Seq Scan on rpt.t
-                             Output: t.i, t.i
+                       Output: repl_tbl_1.i, repl_tbl_1.i
+                       ->  Seq Scan on rpt.repl_tbl_1
+                             Output: repl_tbl_1.i, repl_tbl_1.i
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (15 rows)
 
-explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
+explain (costs off, verbose) select * from dist_tbl where a in (select random() from repl_tbl_1 where i=a);
                              QUERY PLAN                             
 --------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   Output: t1.a
-   ->  Seq Scan on rpt.t1
-         Output: t1.a
+   Output: dist_tbl.a
+   ->  Seq Scan on rpt.dist_tbl
+         Output: dist_tbl.a
          Filter: (SubPlan 1)
          SubPlan 1  (slice1; segments: 1)
            ->  Result
                  Output: random()
-                 Filter: (t.i = t1.a)
+                 Filter: (repl_tbl_1.i = dist_tbl.a)
                  ->  Materialize
-                       Output: t.i
-                       ->  Seq Scan on rpt.t
-                             Output: t.i
+                       Output: repl_tbl_1.i
+                       ->  Seq Scan on rpt.repl_tbl_1
+                             Output: repl_tbl_1.i
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (15 rows)
 
 -- ensure we make broadcast motion when volatile function in deleting motion flow
-explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
+explain (costs off, verbose) insert into repl_tbl_2 (a, b) select i, random() from repl_tbl_1;
                              QUERY PLAN                             
 --------------------------------------------------------------------
- Insert on rpt.t2
+ Insert on rpt.repl_tbl_2
    ->  Broadcast Motion 1:3  (slice1; segments: 1)
-         Output: t.i, (random())
-         ->  Seq Scan on rpt.t
-               Output: t.i, random()
+         Output: repl_tbl_1.i, (random())
+         ->  Seq Scan on rpt.repl_tbl_1
+               Output: repl_tbl_1.i, random()
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (7 rows)
 
 -- ensure we make broadcast motion when volatile function in correlated subplan qual
-explain (costs off, verbose) select * from t1 where a in (select f(i) from t where i=a and f(i) > 0);
+explain (costs off, verbose) select * from dist_tbl where a in (select f(i) from repl_tbl_1 where i=a and f(i) > 0);
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
-   Output: t1.a
-   ->  Seq Scan on rpt.t1
-         Output: t1.a
+   Output: dist_tbl.a
+   ->  Seq Scan on rpt.dist_tbl
+         Output: dist_tbl.a
          Filter: (SubPlan 1)
          SubPlan 1  (slice2; segments: 3)
            ->  Result
-                 Output: f(t.i)
+                 Output: f(repl_tbl_1.i)
                  ->  Result
-                       Output: t.i
-                       Filter: (t.i = t1.a)
+                       Output: repl_tbl_1.i
+                       Filter: (repl_tbl_1.i = dist_tbl.a)
                        ->  Materialize
-                             Output: t.i, t.i
+                             Output: repl_tbl_1.i, repl_tbl_1.i
                              ->  Broadcast Motion 1:3  (slice1; segments: 1)
-                                   Output: t.i, t.i
-                                   ->  Seq Scan on rpt.t
-                                         Output: t.i, t.i
-                                         Filter: (f(t.i) > 0)
+                                   Output: repl_tbl_1.i, repl_tbl_1.i
+                                   ->  Seq Scan on rpt.repl_tbl_1
+                                         Output: repl_tbl_1.i, repl_tbl_1.i
+                                         Filter: (f(repl_tbl_1.i) > 0)
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (20 rows)
 
 -- ensure we do not break broadcast motion
-explain (costs off, verbose) select * from t1 where 1 <= ALL (select i from t group by i having random() > 0);
+explain (costs off, verbose) select * from dist_tbl where 1 <= ALL (select i from repl_tbl_1 group by i having random() > 0);
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
-   Output: t1.a
+   Output: dist_tbl.a
    ->  Result
-         Output: t1.a
+         Output: dist_tbl.a
          One-Time Filter: (SubPlan 1)
-         ->  Seq Scan on rpt.t1
-               Output: t1.a
+         ->  Seq Scan on rpt.dist_tbl
+               Output: dist_tbl.a
          SubPlan 1  (slice2; segments: 3)
            ->  Materialize
-                 Output: t.i
+                 Output: repl_tbl_1.i
                  ->  Broadcast Motion 1:3  (slice1; segments: 1)
-                       Output: t.i
+                       Output: repl_tbl_1.i
                        ->  HashAggregate
-                             Output: t.i
-                             Group Key: t.i
+                             Output: repl_tbl_1.i
+                             Group Key: repl_tbl_1.i
                              Filter: (random() > '0'::double precision)
-                             ->  Seq Scan on rpt.t
-                                   Output: t.i
+                             ->  Seq Scan on rpt.repl_tbl_1
+                                   Output: repl_tbl_1.i
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (20 rows)
 
 -- ensure we make redistribute motion above scan
-explain (costs off, verbose) insert into t1 (select nextval('seq') from t);
+explain (costs off, verbose) insert into dist_tbl (select nextval('seq') from repl_tbl_1);
                              QUERY PLAN                             
 --------------------------------------------------------------------
- Insert on rpt.t1
+ Insert on rpt.dist_tbl
    ->  Redistribute Motion 1:3  (slice1; segments: 1)
          Output: (nextval('seq'::regclass))
          Hash Key: (nextval('seq'::regclass))
-         ->  Seq Scan on rpt.t
+         ->  Seq Scan on rpt.repl_tbl_1
                Output: nextval('seq'::regclass)
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (8 rows)
 
-drop table if exists t;
-drop table if exists t1;
-drop table if exists t2;
+drop table if exists repl_tbl_1;
+drop table if exists dist_tbl;
+drop table if exists repl_tbl_2;
 drop function if exists f(i bigint);
 drop sequence if exists seq;
 reset optimizer;
 -- start_ignore
 drop schema rpt cascade;
-NOTICE:  drop cascades to 18 other objects
+NOTICE:  drop cascades to 19 other objects
 DETAIL:  drop cascades to table foo
 drop cascades to table bar
 drop cascades to view v_foo
@@ -1527,4 +1526,5 @@ drop cascades to table t2_13532
 drop cascades to table dist_tab
 drop cascades to table rep_tab
 drop cascades to table rand_tab
+drop cascades to table t
 -- end_ignore

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -1323,14 +1323,16 @@ select j, (select 5) AS "Uncorrelated Field" from t;
 --
 -- Check sub-selects with distributed replicated tables and volatile functions
 --
+set optimizer = off;
+drop table if exists t;
 create table t (i int) distributed replicated;
 create table t1 (a int) distributed by (a);
 create table t2 (a int, b float) distributed replicated;
 create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
 -- ensure we make gather motion when volatile functions in subplan
 explain (costs off, verbose) select (select f(i) from t);
-                     QUERY PLAN                      
------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Result
    Output: $0
    InitPlan 1 (returns $0)  (slice2)
@@ -1339,12 +1341,12 @@ explain (costs off, verbose) select (select f(i) from t);
            ->  Seq Scan on rpt.t
                  Output: f(i)
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (9 rows)
 
 explain (costs off, verbose) select (select f(i) from t group by f(i));
-                     QUERY PLAN                      
------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Result
    Output: $0
    InitPlan 1 (returns $0)  (slice2)
@@ -1356,12 +1358,12 @@ explain (costs off, verbose) select (select f(i) from t group by f(i));
                  ->  Seq Scan on rpt.t
                        Output: i, f(i)
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (12 rows)
 
 explain (costs off, verbose) select (select i from t group by i having f(i) > 0);
-                     QUERY PLAN                      
------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Result
    Output: $0
    InitPlan 1 (returns $0)  (slice2)
@@ -1374,36 +1376,33 @@ explain (costs off, verbose) select (select i from t group by i having f(i) > 0)
                  ->  Seq Scan on rpt.t
                        Output: i
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (13 rows)
 
 -- ensure we do not make broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
-                     QUERY PLAN                      
------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: t1.a
    ->  Seq Scan on rpt.t1
          Output: t1.a
          Filter: (SubPlan 1)
          SubPlan 1  (slice1; segments: 1)
-           ->  GroupAggregate
+           ->  Result
                  Output: random(), t.i
-                 Group Key: t.i
-                 ->  Result
-                       Output: t.i
-                       Filter: (t.i = t1.a)
-                       ->  Materialize
+                 Filter: (t.i = t1.a)
+                 ->  Materialize
+                       Output: t.i, t.i
+                       ->  Seq Scan on rpt.t
                              Output: t.i, t.i
-                             ->  Seq Scan on rpt.t
-                                   Output: t.i, t.i
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
-(18 rows)
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
+(15 rows)
 
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
-                     QUERY PLAN                      
------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: t1.a
    ->  Seq Scan on rpt.t1
@@ -1418,20 +1417,20 @@ explain (costs off, verbose) select * from t1 where a in (select random() from t
                        ->  Seq Scan on rpt.t
                              Output: t.i
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (15 rows)
 
 -- ensure we make broadcast motion when volatile function in deleting motion flow
 explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
-                     QUERY PLAN                      
------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Insert on rpt.t2
    ->  Broadcast Motion 1:3  (slice1; segments: 1)
          Output: t.i, (random())
          ->  Seq Scan on rpt.t
                Output: t.i, random()
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (7 rows)
 
 -- ensure we make broadcast motion when volatile function in correlated subplan qual
@@ -1457,7 +1456,7 @@ explain (costs off, verbose) select * from t1 where a in (select f(i) from t whe
                                          Output: t.i, t.i
                                          Filter: (f(t.i) > 0)
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (20 rows)
 
 -- ensure we do not break broadcast motion
@@ -1483,16 +1482,17 @@ explain (costs off, verbose) select * from t1 where 1 <= ALL (select i from t gr
                              ->  Seq Scan on rpt.t
                                    Output: t.i
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (20 rows)
 
 drop table if exists t;
 drop table if exists t1;
 drop table if exists t2;
 drop function if exists f(i int);
+reset optimizer;
 -- start_ignore
 drop schema rpt cascade;
-NOTICE:  drop cascades to 13 other objects
+NOTICE:  drop cascades to 18 other objects
 DETAIL:  drop cascades to table foo
 drop cascades to table bar
 drop cascades to view v_foo
@@ -1508,4 +1508,7 @@ drop cascades to table t_replicate_src
 drop cascades to table rtbl
 drop cascades to table t1_13532
 drop cascades to table t2_13532
+drop cascades to table dist_tab
+drop cascades to table rep_tab
+drop cascades to table rand_tab
 -- end_ignore

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -1325,10 +1325,11 @@ select j, (select 5) AS "Uncorrelated Field" from t;
 --
 set optimizer = off;
 drop table if exists t;
-create table t (i int) distributed replicated;
-create table t1 (a int) distributed by (a);
-create table t2 (a int, b float) distributed replicated;
-create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
+create table t (i bigint) distributed replicated;
+create table t1 (a bigint) distributed by (a);
+create table t2 (a bigint, b float) distributed replicated;
+create or replace function f(i bigint) returns bigint language sql security definer as $$ select i; $$;
+create sequence seq increment by 1 minvalue 1 maxvalue 2 start 2 no cycle;
 -- ensure we make gather motion when volatile functions in subplan
 explain (costs off, verbose) select (select f(i) from t);
                              QUERY PLAN                             
@@ -1485,10 +1486,25 @@ explain (costs off, verbose) select * from t1 where 1 <= ALL (select i from t gr
  Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (20 rows)
 
+-- ensure we make redistribute motion above scan
+explain (costs off, verbose) insert into t1 (select nextval('seq') from t);
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Insert on rpt.t1
+   ->  Redistribute Motion 1:3  (slice1; segments: 1)
+         Output: (nextval('seq'::regclass))
+         Hash Key: (nextval('seq'::regclass))
+         ->  Seq Scan on rpt.t
+               Output: nextval('seq'::regclass)
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
+(8 rows)
+
 drop table if exists t;
 drop table if exists t1;
 drop table if exists t2;
-drop function if exists f(i int);
+drop function if exists f(i bigint);
+drop sequence if exists seq;
 reset optimizer;
 -- start_ignore
 drop schema rpt cascade;

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -787,7 +787,7 @@ explain (costs off, verbose) select * from t_hashdist left join t_replicate_vola
                      Output: t_replicate_volatile.a, t_replicate_volatile.b, t_replicate_volatile.c
          SubPlan 1  (slice2; segments: 3)
            ->  Materialize
-                 Output: random()
+                 Output: (random())
                  ->  Broadcast Motion 1:3  (slice1; segments: 1)
                        Output: (random())
                        ->  Seq Scan on rpt.t_replicate_volatile t_replicate_volatile_1
@@ -901,14 +901,35 @@ explain (costs off) select a from t_replicate_volatile union all select * from n
 create table t_replicate_dst(id serial, i integer) distributed replicated;
 create table t_replicate_src(i integer) distributed replicated;
 insert into t_replicate_src select i from generate_series(1, 5) i;
-explain (costs off) insert into t_replicate_dst (i) select i from t_replicate_src;
-                    QUERY PLAN                     
----------------------------------------------------
- Insert on t_replicate_dst
+explain (costs off, verbose) insert into t_replicate_dst (i) select i from t_replicate_src;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Insert on rpt.t_replicate_dst
    ->  Broadcast Motion 1:3  (slice1; segments: 1)
-         ->  Seq Scan on t_replicate_src
+         Output: ((nextval('t_replicate_dst_id_seq'::regclass))::integer), t_replicate_src.i
+         ->  Seq Scan on rpt.t_replicate_src
+               Output: nextval('t_replicate_dst_id_seq'::regclass), t_replicate_src.i
  Optimizer: Postgres query optimizer
-(4 rows)
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
+(7 rows)
+
+explain (costs off, verbose) with s as (select i from t_replicate_src group by i having random() > 0) insert into t_replicate_dst (i) select i from s;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Insert on rpt.t_replicate_dst
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)
+         Output: ((nextval('t_replicate_dst_id_seq'::regclass))::integer), "*SELECT*".i
+         ->  Subquery Scan on "*SELECT*"
+               Output: nextval('t_replicate_dst_id_seq'::regclass), "*SELECT*".i
+               ->  HashAggregate
+                     Output: t_replicate_src.i
+                     Group Key: t_replicate_src.i
+                     Filter: (random() > '0'::double precision)
+                     ->  Seq Scan on rpt.t_replicate_src
+                           Output: t_replicate_src.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
+(13 rows)
 
 insert into t_replicate_dst (i) select i from t_replicate_src;
 select distinct id from gp_dist_random('t_replicate_dst') order by id;
@@ -1299,6 +1320,176 @@ select j, (select 5) AS "Uncorrelated Field" from t;
  2 |                  5
 (1 row)
 
+--
+-- Check sub-selects with distributed replicated tables and volatile functions
+--
+create table t (i int) distributed replicated;
+create table t1 (a int) distributed by (a);
+create table t2 (a int, b float) distributed replicated;
+create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
+-- ensure we make gather motion when volatile functions in subplan
+explain (costs off, verbose) select (select f(i) from t);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Result
+   Output: $0
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Gather Motion 1:1  (slice1; segments: 1)
+           Output: (f(i))
+           ->  Seq Scan on rpt.t
+                 Output: f(i)
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(9 rows)
+
+explain (costs off, verbose) select (select f(i) from t group by f(i));
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Result
+   Output: $0
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Gather Motion 1:1  (slice1; segments: 1)
+           Output: (f(i))
+           ->  HashAggregate
+                 Output: (f(i))
+                 Group Key: f(t.i)
+                 ->  Seq Scan on rpt.t
+                       Output: i, f(i)
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(12 rows)
+
+explain (costs off, verbose) select (select i from t group by i having f(i) > 0);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Result
+   Output: $0
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Gather Motion 1:1  (slice1; segments: 1)
+           Output: i
+           ->  HashAggregate
+                 Output: i
+                 Group Key: t.i
+                 Filter: (f(t.i) > 0)
+                 ->  Seq Scan on rpt.t
+                       Output: i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(13 rows)
+
+-- ensure we do not make broadcast motion
+explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: t1.a
+   ->  Seq Scan on rpt.t1
+         Output: t1.a
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice1; segments: 1)
+           ->  GroupAggregate
+                 Output: random(), t.i
+                 Group Key: t.i
+                 ->  Result
+                       Output: t.i
+                       Filter: (t.i = t1.a)
+                       ->  Materialize
+                             Output: t.i, t.i
+                             ->  Seq Scan on rpt.t
+                                   Output: t.i, t.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(18 rows)
+
+explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: t1.a
+   ->  Seq Scan on rpt.t1
+         Output: t1.a
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice1; segments: 1)
+           ->  Result
+                 Output: random()
+                 Filter: (t.i = t1.a)
+                 ->  Materialize
+                       Output: t.i
+                       ->  Seq Scan on rpt.t
+                             Output: t.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(15 rows)
+
+-- ensure we make broadcast motion when volatile function in deleting motion flow
+explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Insert on rpt.t2
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)
+         Output: t.i, (random())
+         ->  Seq Scan on rpt.t
+               Output: t.i, random()
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(7 rows)
+
+-- ensure we make broadcast motion when volatile function in correlated subplan qual
+explain (costs off, verbose) select * from t1 where a in (select f(i) from t where i=a and f(i) > 0);
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: t1.a
+   ->  Seq Scan on rpt.t1
+         Output: t1.a
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Result
+                 Output: f(t.i)
+                 ->  Result
+                       Output: t.i
+                       Filter: (t.i = t1.a)
+                       ->  Materialize
+                             Output: t.i, t.i
+                             ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                                   Output: t.i, t.i
+                                   ->  Seq Scan on rpt.t
+                                         Output: t.i, t.i
+                                         Filter: (f(t.i) > 0)
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(20 rows)
+
+-- ensure we do not break broadcast motion
+explain (costs off, verbose) select * from t1 where 1 <= ALL (select i from t group by i having random() > 0);
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: t1.a
+   ->  Result
+         Output: t1.a
+         One-Time Filter: (SubPlan 1)
+         ->  Seq Scan on rpt.t1
+               Output: t1.a
+         SubPlan 1  (slice2; segments: 3)
+           ->  Materialize
+                 Output: t.i
+                 ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                       Output: t.i
+                       ->  HashAggregate
+                             Output: t.i
+                             Group Key: t.i
+                             Filter: (random() > '0'::double precision)
+                             ->  Seq Scan on rpt.t
+                                   Output: t.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(20 rows)
+
+drop table if exists t;
+drop table if exists t1;
+drop table if exists t2;
+drop function if exists f(i int);
 -- start_ignore
 drop schema rpt cascade;
 NOTICE:  drop cascades to 13 other objects

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -942,17 +942,17 @@ select distinct id from gp_dist_random('t_replicate_dst') order by id;
 
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
-ERROR:  could not devise a plan (cdbpath.c:2089)
+ERROR:  could not devise a plan (cdbpath.c:2092)
 explain (costs off) update t_replicate_volatile set a = 1 from t_replicate_volatile x where x.a + random() = t_replicate_volatile.b;
-ERROR:  could not devise a plan (cdbpath.c:2089)
+ERROR:  could not devise a plan (cdbpath.c:2092)
 explain (costs off) update t_replicate_volatile set a = 1 from t_hashdist x where x.a + random() = t_replicate_volatile.b;
-ERROR:  could not devise a plan (cdbpath.c:2089)
+ERROR:  could not devise a plan (cdbpath.c:2092)
 explain (costs off) delete from t_replicate_volatile where a < random();
-ERROR:  could not devise a plan (cdbpath.c:2089)
+ERROR:  could not devise a plan (cdbpath.c:2092)
 explain (costs off) delete from t_replicate_volatile using t_replicate_volatile x where t_replicate_volatile.a + x.b < random();
-ERROR:  could not devise a plan (cdbpath.c:2089)
+ERROR:  could not devise a plan (cdbpath.c:2092)
 explain (costs off) update t_replicate_volatile set a = random();
-ERROR:  could not devise a plan (createplan.c:6507)
+ERROR:  could not devise a plan (createplan.c:6412)
 -- limit
 explain (costs off) insert into t_replicate_volatile select * from t_replicate_volatile limit 1;
                                 QUERY PLAN                                 
@@ -1266,7 +1266,7 @@ select c from rep_tab where c in (select distinct d from rand_tab);
 
 -- test for optimizer_enable_replicated_table
 explain (costs off) select * from rep_tab;
-                QUERY PLAN
+                QUERY PLAN                
 ------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Seq Scan on rep_tab
@@ -1279,7 +1279,7 @@ explain (costs off) select * from rep_tab;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Use optimizer_enable_replicated_table to enable replicated tables
 WARNING:  relcache reference leak: relation "rep_tab" not closed
-                QUERY PLAN
+                QUERY PLAN                
 ------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Seq Scan on rep_tab
@@ -1334,14 +1334,16 @@ select j, (select 5) AS "Uncorrelated Field" from t;
 --
 -- Check sub-selects with distributed replicated tables and volatile functions
 --
+set optimizer = off;
+drop table if exists t;
 create table t (i int) distributed replicated;
 create table t1 (a int) distributed by (a);
 create table t2 (a int, b float) distributed replicated;
 create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
 -- ensure we make gather motion when volatile functions in subplan
 explain (costs off, verbose) select (select f(i) from t);
-                     QUERY PLAN                      
------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Result
    Output: $0
    InitPlan 1 (returns $0)  (slice2)
@@ -1350,12 +1352,12 @@ explain (costs off, verbose) select (select f(i) from t);
            ->  Seq Scan on rpt.t
                  Output: f(i)
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (9 rows)
 
 explain (costs off, verbose) select (select f(i) from t group by f(i));
-                     QUERY PLAN                      
------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Result
    Output: $0
    InitPlan 1 (returns $0)  (slice2)
@@ -1367,12 +1369,12 @@ explain (costs off, verbose) select (select f(i) from t group by f(i));
                  ->  Seq Scan on rpt.t
                        Output: i, f(i)
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (12 rows)
 
 explain (costs off, verbose) select (select i from t group by i having f(i) > 0);
-                     QUERY PLAN                      
------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Result
    Output: $0
    InitPlan 1 (returns $0)  (slice2)
@@ -1385,36 +1387,33 @@ explain (costs off, verbose) select (select i from t group by i having f(i) > 0)
                  ->  Seq Scan on rpt.t
                        Output: i
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (13 rows)
 
 -- ensure we do not make broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
-                     QUERY PLAN                      
------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: t1.a
    ->  Seq Scan on rpt.t1
          Output: t1.a
          Filter: (SubPlan 1)
          SubPlan 1  (slice1; segments: 1)
-           ->  GroupAggregate
+           ->  Result
                  Output: random(), t.i
-                 Group Key: t.i
-                 ->  Result
-                       Output: t.i
-                       Filter: (t.i = t1.a)
-                       ->  Materialize
+                 Filter: (t.i = t1.a)
+                 ->  Materialize
+                       Output: t.i, t.i
+                       ->  Seq Scan on rpt.t
                              Output: t.i, t.i
-                             ->  Seq Scan on rpt.t
-                                   Output: t.i, t.i
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
-(18 rows)
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
+(15 rows)
 
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
-                     QUERY PLAN                      
------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: t1.a
    ->  Seq Scan on rpt.t1
@@ -1429,20 +1428,20 @@ explain (costs off, verbose) select * from t1 where a in (select random() from t
                        ->  Seq Scan on rpt.t
                              Output: t.i
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (15 rows)
 
 -- ensure we make broadcast motion when volatile function in deleting motion flow
 explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
-                     QUERY PLAN                      
------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Insert on rpt.t2
    ->  Broadcast Motion 1:3  (slice1; segments: 1)
          Output: t.i, (random())
          ->  Seq Scan on rpt.t
                Output: t.i, random()
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (7 rows)
 
 -- ensure we make broadcast motion when volatile function in correlated subplan qual
@@ -1468,7 +1467,7 @@ explain (costs off, verbose) select * from t1 where a in (select f(i) from t whe
                                          Output: t.i, t.i
                                          Filter: (f(t.i) > 0)
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (20 rows)
 
 -- ensure we do not break broadcast motion
@@ -1494,16 +1493,17 @@ explain (costs off, verbose) select * from t1 where 1 <= ALL (select i from t gr
                              ->  Seq Scan on rpt.t
                                    Output: t.i
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (20 rows)
 
 drop table if exists t;
 drop table if exists t1;
 drop table if exists t2;
 drop function if exists f(i int);
+reset optimizer;
 -- start_ignore
 drop schema rpt cascade;
-NOTICE:  drop cascades to 13 other objects
+NOTICE:  drop cascades to 18 other objects
 DETAIL:  drop cascades to table foo
 drop cascades to table bar
 drop cascades to view v_foo
@@ -1519,4 +1519,7 @@ drop cascades to table t_replicate_src
 drop cascades to table rtbl
 drop cascades to table t1_13532
 drop cascades to table t2_13532
+drop cascades to table dist_tab
+drop cascades to table rep_tab
+drop cascades to table rand_tab
 -- end_ignore

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -1335,14 +1335,13 @@ select j, (select 5) AS "Uncorrelated Field" from t;
 -- Check sub-selects with distributed replicated tables and volatile functions
 --
 set optimizer = off;
-drop table if exists t;
-create table t (i bigint) distributed replicated;
-create table t1 (a bigint) distributed by (a);
-create table t2 (a bigint, b float) distributed replicated;
+create table repl_tbl_1 (i bigint) distributed replicated;
+create table dist_tbl (a bigint) distributed by (a);
+create table repl_tbl_2 (a bigint, b float) distributed replicated;
 create or replace function f(i bigint) returns bigint language sql security definer as $$ select i; $$;
 create sequence seq increment by 1 minvalue 1 maxvalue 2 start 2 no cycle;
 -- ensure we make gather motion when volatile functions in subplan
-explain (costs off, verbose) select (select f(i) from t);
+explain (costs off, verbose) select (select f(i) from repl_tbl_1);
                              QUERY PLAN                             
 --------------------------------------------------------------------
  Result
@@ -1350,13 +1349,13 @@ explain (costs off, verbose) select (select f(i) from t);
    InitPlan 1 (returns $0)  (slice2)
      ->  Gather Motion 1:1  (slice1; segments: 1)
            Output: (f(i))
-           ->  Seq Scan on rpt.t
+           ->  Seq Scan on rpt.repl_tbl_1
                  Output: f(i)
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (9 rows)
 
-explain (costs off, verbose) select (select f(i) from t group by f(i));
+explain (costs off, verbose) select (select f(i) from repl_tbl_1 group by f(i));
                              QUERY PLAN                             
 --------------------------------------------------------------------
  Result
@@ -1366,14 +1365,14 @@ explain (costs off, verbose) select (select f(i) from t group by f(i));
            Output: (f(i))
            ->  HashAggregate
                  Output: (f(i))
-                 Group Key: f(t.i)
-                 ->  Seq Scan on rpt.t
+                 Group Key: f(repl_tbl_1.i)
+                 ->  Seq Scan on rpt.repl_tbl_1
                        Output: i, f(i)
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (12 rows)
 
-explain (costs off, verbose) select (select i from t group by i having f(i) > 0);
+explain (costs off, verbose) select (select i from repl_tbl_1 group by i having f(i) > 0);
                              QUERY PLAN                             
 --------------------------------------------------------------------
  Result
@@ -1383,143 +1382,143 @@ explain (costs off, verbose) select (select i from t group by i having f(i) > 0)
            Output: i
            ->  HashAggregate
                  Output: i
-                 Group Key: t.i
-                 Filter: (f(t.i) > 0)
-                 ->  Seq Scan on rpt.t
+                 Group Key: repl_tbl_1.i
+                 Filter: (f(repl_tbl_1.i) > 0)
+                 ->  Seq Scan on rpt.repl_tbl_1
                        Output: i
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (13 rows)
 
 -- ensure we do not make broadcast motion
-explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
+explain (costs off, verbose) select * from dist_tbl where a in (select random() from repl_tbl_1 where i=a group by i);
                              QUERY PLAN                             
 --------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   Output: t1.a
-   ->  Seq Scan on rpt.t1
-         Output: t1.a
+   Output: dist_tbl.a
+   ->  Seq Scan on rpt.dist_tbl
+         Output: dist_tbl.a
          Filter: (SubPlan 1)
          SubPlan 1  (slice1; segments: 1)
            ->  Result
-                 Output: random(), t.i
-                 Filter: (t.i = t1.a)
+                 Output: random(), repl_tbl_1.i
+                 Filter: (repl_tbl_1.i = dist_tbl.a)
                  ->  Materialize
-                       Output: t.i, t.i
-                       ->  Seq Scan on rpt.t
-                             Output: t.i, t.i
+                       Output: repl_tbl_1.i, repl_tbl_1.i
+                       ->  Seq Scan on rpt.repl_tbl_1
+                             Output: repl_tbl_1.i, repl_tbl_1.i
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (15 rows)
 
-explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
+explain (costs off, verbose) select * from dist_tbl where a in (select random() from repl_tbl_1 where i=a);
                              QUERY PLAN                             
 --------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   Output: t1.a
-   ->  Seq Scan on rpt.t1
-         Output: t1.a
+   Output: dist_tbl.a
+   ->  Seq Scan on rpt.dist_tbl
+         Output: dist_tbl.a
          Filter: (SubPlan 1)
          SubPlan 1  (slice1; segments: 1)
            ->  Result
                  Output: random()
-                 Filter: (t.i = t1.a)
+                 Filter: (repl_tbl_1.i = dist_tbl.a)
                  ->  Materialize
-                       Output: t.i
-                       ->  Seq Scan on rpt.t
-                             Output: t.i
+                       Output: repl_tbl_1.i
+                       ->  Seq Scan on rpt.repl_tbl_1
+                             Output: repl_tbl_1.i
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (15 rows)
 
 -- ensure we make broadcast motion when volatile function in deleting motion flow
-explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
+explain (costs off, verbose) insert into repl_tbl_2 (a, b) select i, random() from repl_tbl_1;
                              QUERY PLAN                             
 --------------------------------------------------------------------
- Insert on rpt.t2
+ Insert on rpt.repl_tbl_2
    ->  Broadcast Motion 1:3  (slice1; segments: 1)
-         Output: t.i, (random())
-         ->  Seq Scan on rpt.t
-               Output: t.i, random()
+         Output: repl_tbl_1.i, (random())
+         ->  Seq Scan on rpt.repl_tbl_1
+               Output: repl_tbl_1.i, random()
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (7 rows)
 
 -- ensure we make broadcast motion when volatile function in correlated subplan qual
-explain (costs off, verbose) select * from t1 where a in (select f(i) from t where i=a and f(i) > 0);
+explain (costs off, verbose) select * from dist_tbl where a in (select f(i) from repl_tbl_1 where i=a and f(i) > 0);
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
-   Output: t1.a
-   ->  Seq Scan on rpt.t1
-         Output: t1.a
+   Output: dist_tbl.a
+   ->  Seq Scan on rpt.dist_tbl
+         Output: dist_tbl.a
          Filter: (SubPlan 1)
          SubPlan 1  (slice2; segments: 3)
            ->  Result
-                 Output: f(t.i)
+                 Output: f(repl_tbl_1.i)
                  ->  Result
-                       Output: t.i
-                       Filter: (t.i = t1.a)
+                       Output: repl_tbl_1.i
+                       Filter: (repl_tbl_1.i = dist_tbl.a)
                        ->  Materialize
-                             Output: t.i, t.i
+                             Output: repl_tbl_1.i, repl_tbl_1.i
                              ->  Broadcast Motion 1:3  (slice1; segments: 1)
-                                   Output: t.i, t.i
-                                   ->  Seq Scan on rpt.t
-                                         Output: t.i, t.i
-                                         Filter: (f(t.i) > 0)
+                                   Output: repl_tbl_1.i, repl_tbl_1.i
+                                   ->  Seq Scan on rpt.repl_tbl_1
+                                         Output: repl_tbl_1.i, repl_tbl_1.i
+                                         Filter: (f(repl_tbl_1.i) > 0)
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (20 rows)
 
 -- ensure we do not break broadcast motion
-explain (costs off, verbose) select * from t1 where 1 <= ALL (select i from t group by i having random() > 0);
+explain (costs off, verbose) select * from dist_tbl where 1 <= ALL (select i from repl_tbl_1 group by i having random() > 0);
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
-   Output: t1.a
+   Output: dist_tbl.a
    ->  Result
-         Output: t1.a
+         Output: dist_tbl.a
          One-Time Filter: (SubPlan 1)
-         ->  Seq Scan on rpt.t1
-               Output: t1.a
+         ->  Seq Scan on rpt.dist_tbl
+               Output: dist_tbl.a
          SubPlan 1  (slice2; segments: 3)
            ->  Materialize
-                 Output: t.i
+                 Output: repl_tbl_1.i
                  ->  Broadcast Motion 1:3  (slice1; segments: 1)
-                       Output: t.i
+                       Output: repl_tbl_1.i
                        ->  HashAggregate
-                             Output: t.i
-                             Group Key: t.i
+                             Output: repl_tbl_1.i
+                             Group Key: repl_tbl_1.i
                              Filter: (random() > '0'::double precision)
-                             ->  Seq Scan on rpt.t
-                                   Output: t.i
+                             ->  Seq Scan on rpt.repl_tbl_1
+                                   Output: repl_tbl_1.i
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (20 rows)
 
 -- ensure we make redistribute motion above scan
-explain (costs off, verbose) insert into t1 (select nextval('seq') from t);
+explain (costs off, verbose) insert into dist_tbl (select nextval('seq') from repl_tbl_1);
                              QUERY PLAN                             
 --------------------------------------------------------------------
- Insert on rpt.t1
+ Insert on rpt.dist_tbl
    ->  Redistribute Motion 1:3  (slice1; segments: 1)
          Output: (nextval('seq'::regclass))
          Hash Key: (nextval('seq'::regclass))
-         ->  Seq Scan on rpt.t
+         ->  Seq Scan on rpt.repl_tbl_1
                Output: nextval('seq'::regclass)
  Optimizer: Postgres query optimizer
  Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (8 rows)
 
-drop table if exists t;
-drop table if exists t1;
-drop table if exists t2;
+drop table if exists repl_tbl_1;
+drop table if exists dist_tbl;
+drop table if exists repl_tbl_2;
 drop function if exists f(i bigint);
 drop sequence if exists seq;
 reset optimizer;
 -- start_ignore
 drop schema rpt cascade;
-NOTICE:  drop cascades to 18 other objects
+NOTICE:  drop cascades to 19 other objects
 DETAIL:  drop cascades to table foo
 drop cascades to table bar
 drop cascades to view v_foo
@@ -1538,4 +1537,5 @@ drop cascades to table t2_13532
 drop cascades to table dist_tab
 drop cascades to table rep_tab
 drop cascades to table rand_tab
+drop cascades to table t
 -- end_ignore

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -1336,10 +1336,11 @@ select j, (select 5) AS "Uncorrelated Field" from t;
 --
 set optimizer = off;
 drop table if exists t;
-create table t (i int) distributed replicated;
-create table t1 (a int) distributed by (a);
-create table t2 (a int, b float) distributed replicated;
-create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
+create table t (i bigint) distributed replicated;
+create table t1 (a bigint) distributed by (a);
+create table t2 (a bigint, b float) distributed replicated;
+create or replace function f(i bigint) returns bigint language sql security definer as $$ select i; $$;
+create sequence seq increment by 1 minvalue 1 maxvalue 2 start 2 no cycle;
 -- ensure we make gather motion when volatile functions in subplan
 explain (costs off, verbose) select (select f(i) from t);
                              QUERY PLAN                             
@@ -1496,10 +1497,25 @@ explain (costs off, verbose) select * from t1 where 1 <= ALL (select i from t gr
  Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (20 rows)
 
+-- ensure we make redistribute motion above scan
+explain (costs off, verbose) insert into t1 (select nextval('seq') from t);
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Insert on rpt.t1
+   ->  Redistribute Motion 1:3  (slice1; segments: 1)
+         Output: (nextval('seq'::regclass))
+         Hash Key: (nextval('seq'::regclass))
+         ->  Seq Scan on rpt.t
+               Output: nextval('seq'::regclass)
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
+(8 rows)
+
 drop table if exists t;
 drop table if exists t1;
 drop table if exists t2;
-drop function if exists f(i int);
+drop function if exists f(i bigint);
+drop sequence if exists seq;
 reset optimizer;
 -- start_ignore
 drop schema rpt cascade;

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -785,7 +785,7 @@ explain (costs off, verbose) select * from t_hashdist left join t_replicate_vola
                      Output: t_replicate_volatile.a, t_replicate_volatile.b, t_replicate_volatile.c
          SubPlan 1  (slice2; segments: 3)
            ->  Materialize
-                 Output: random()
+                 Output: (random())
                  ->  Broadcast Motion 1:3  (slice1; segments: 1)
                        Output: (random())
                        ->  Seq Scan on rpt.t_replicate_volatile t_replicate_volatile_1
@@ -899,14 +899,35 @@ explain (costs off) select a from t_replicate_volatile union all select * from n
 create table t_replicate_dst(id serial, i integer) distributed replicated;
 create table t_replicate_src(i integer) distributed replicated;
 insert into t_replicate_src select i from generate_series(1, 5) i;
-explain (costs off) insert into t_replicate_dst (i) select i from t_replicate_src;
-                    QUERY PLAN                     
----------------------------------------------------
- Insert on t_replicate_dst
+explain (costs off, verbose) insert into t_replicate_dst (i) select i from t_replicate_src;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Insert on rpt.t_replicate_dst
    ->  Broadcast Motion 1:3  (slice1; segments: 1)
-         ->  Seq Scan on t_replicate_src
+         Output: ((nextval('t_replicate_dst_id_seq'::regclass))::integer), t_replicate_src.i
+         ->  Seq Scan on rpt.t_replicate_src
+               Output: nextval('t_replicate_dst_id_seq'::regclass), t_replicate_src.i
  Optimizer: Postgres query optimizer
-(4 rows)
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
+(7 rows)
+
+explain (costs off, verbose) with s as (select i from t_replicate_src group by i having random() > 0) insert into t_replicate_dst (i) select i from s;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Insert on rpt.t_replicate_dst
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)
+         Output: ((nextval('t_replicate_dst_id_seq'::regclass))::integer), "*SELECT*".i
+         ->  Subquery Scan on "*SELECT*"
+               Output: nextval('t_replicate_dst_id_seq'::regclass), "*SELECT*".i
+               ->  HashAggregate
+                     Output: t_replicate_src.i
+                     Group Key: t_replicate_src.i
+                     Filter: (random() > '0'::double precision)
+                     ->  Seq Scan on rpt.t_replicate_src
+                           Output: t_replicate_src.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
+(13 rows)
 
 insert into t_replicate_dst (i) select i from t_replicate_src;
 select distinct id from gp_dist_random('t_replicate_dst') order by id;
@@ -1310,6 +1331,176 @@ select j, (select 5) AS "Uncorrelated Field" from t;
  2 |                  5
 (1 row)
 
+--
+-- Check sub-selects with distributed replicated tables and volatile functions
+--
+create table t (i int) distributed replicated;
+create table t1 (a int) distributed by (a);
+create table t2 (a int, b float) distributed replicated;
+create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
+-- ensure we make gather motion when volatile functions in subplan
+explain (costs off, verbose) select (select f(i) from t);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Result
+   Output: $0
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Gather Motion 1:1  (slice1; segments: 1)
+           Output: (f(i))
+           ->  Seq Scan on rpt.t
+                 Output: f(i)
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(9 rows)
+
+explain (costs off, verbose) select (select f(i) from t group by f(i));
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Result
+   Output: $0
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Gather Motion 1:1  (slice1; segments: 1)
+           Output: (f(i))
+           ->  HashAggregate
+                 Output: (f(i))
+                 Group Key: f(t.i)
+                 ->  Seq Scan on rpt.t
+                       Output: i, f(i)
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(12 rows)
+
+explain (costs off, verbose) select (select i from t group by i having f(i) > 0);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Result
+   Output: $0
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Gather Motion 1:1  (slice1; segments: 1)
+           Output: i
+           ->  HashAggregate
+                 Output: i
+                 Group Key: t.i
+                 Filter: (f(t.i) > 0)
+                 ->  Seq Scan on rpt.t
+                       Output: i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(13 rows)
+
+-- ensure we do not make broadcast motion
+explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: t1.a
+   ->  Seq Scan on rpt.t1
+         Output: t1.a
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice1; segments: 1)
+           ->  GroupAggregate
+                 Output: random(), t.i
+                 Group Key: t.i
+                 ->  Result
+                       Output: t.i
+                       Filter: (t.i = t1.a)
+                       ->  Materialize
+                             Output: t.i, t.i
+                             ->  Seq Scan on rpt.t
+                                   Output: t.i, t.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(18 rows)
+
+explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: t1.a
+   ->  Seq Scan on rpt.t1
+         Output: t1.a
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice1; segments: 1)
+           ->  Result
+                 Output: random()
+                 Filter: (t.i = t1.a)
+                 ->  Materialize
+                       Output: t.i
+                       ->  Seq Scan on rpt.t
+                             Output: t.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(15 rows)
+
+-- ensure we make broadcast motion when volatile function in deleting motion flow
+explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Insert on rpt.t2
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)
+         Output: t.i, (random())
+         ->  Seq Scan on rpt.t
+               Output: t.i, random()
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(7 rows)
+
+-- ensure we make broadcast motion when volatile function in correlated subplan qual
+explain (costs off, verbose) select * from t1 where a in (select f(i) from t where i=a and f(i) > 0);
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: t1.a
+   ->  Seq Scan on rpt.t1
+         Output: t1.a
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Result
+                 Output: f(t.i)
+                 ->  Result
+                       Output: t.i
+                       Filter: (t.i = t1.a)
+                       ->  Materialize
+                             Output: t.i, t.i
+                             ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                                   Output: t.i, t.i
+                                   ->  Seq Scan on rpt.t
+                                         Output: t.i, t.i
+                                         Filter: (f(t.i) > 0)
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(20 rows)
+
+-- ensure we do not break broadcast motion
+explain (costs off, verbose) select * from t1 where 1 <= ALL (select i from t group by i having random() > 0);
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: t1.a
+   ->  Result
+         Output: t1.a
+         One-Time Filter: (SubPlan 1)
+         ->  Seq Scan on rpt.t1
+               Output: t1.a
+         SubPlan 1  (slice2; segments: 3)
+           ->  Materialize
+                 Output: t.i
+                 ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                       Output: t.i
+                       ->  HashAggregate
+                             Output: t.i
+                             Group Key: t.i
+                             Filter: (random() > '0'::double precision)
+                             ->  Seq Scan on rpt.t
+                                   Output: t.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(20 rows)
+
+drop table if exists t;
+drop table if exists t1;
+drop table if exists t2;
+drop function if exists f(i int);
 -- start_ignore
 drop schema rpt cascade;
 NOTICE:  drop cascades to 13 other objects

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -532,10 +532,11 @@ select j, (select 5) AS "Uncorrelated Field" from t;
 --
 set optimizer = off;
 drop table if exists t;
-create table t (i int) distributed replicated;
-create table t1 (a int) distributed by (a);
-create table t2 (a int, b float) distributed replicated;
-create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
+create table t (i bigint) distributed replicated;
+create table t1 (a bigint) distributed by (a);
+create table t2 (a bigint, b float) distributed replicated;
+create or replace function f(i bigint) returns bigint language sql security definer as $$ select i; $$;
+create sequence seq increment by 1 minvalue 1 maxvalue 2 start 2 no cycle;
 -- ensure we make gather motion when volatile functions in subplan
 explain (costs off, verbose) select (select f(i) from t);
 explain (costs off, verbose) select (select f(i) from t group by f(i));
@@ -549,10 +550,13 @@ explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
 explain (costs off, verbose) select * from t1 where a in (select f(i) from t where i=a and f(i) > 0);
 -- ensure we do not break broadcast motion
 explain (costs off, verbose) select * from t1 where 1 <= ALL (select i from t group by i having random() > 0);
+-- ensure we make redistribute motion above scan
+explain (costs off, verbose) insert into t1 (select nextval('seq') from t);
 drop table if exists t;
 drop table if exists t1;
 drop table if exists t2;
-drop function if exists f(i int);
+drop function if exists f(i bigint);
+drop sequence if exists seq;
 reset optimizer;
 
 -- start_ignore

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -397,7 +397,8 @@ explain (costs off) select a from t_replicate_volatile union all select * from n
 create table t_replicate_dst(id serial, i integer) distributed replicated;
 create table t_replicate_src(i integer) distributed replicated;
 insert into t_replicate_src select i from generate_series(1, 5) i;
-explain (costs off) insert into t_replicate_dst (i) select i from t_replicate_src;
+explain (costs off, verbose) insert into t_replicate_dst (i) select i from t_replicate_src;
+explain (costs off, verbose) with s as (select i from t_replicate_src group by i having random() > 0) insert into t_replicate_dst (i) select i from s;
 insert into t_replicate_dst (i) select i from t_replicate_src;
 select distinct id from gp_dist_random('t_replicate_dst') order by id;
 
@@ -525,6 +526,31 @@ explain (costs off) select j, (select j) AS "Correlated Field" from t;
 select j, (select j) AS "Correlated Field" from t;
 explain (costs off) select j, (select 5) AS "Uncorrelated Field" from t;
 select j, (select 5) AS "Uncorrelated Field" from t;
+
+--
+-- Check sub-selects with distributed replicated tables and volatile functions
+--
+create table t (i int) distributed replicated;
+create table t1 (a int) distributed by (a);
+create table t2 (a int, b float) distributed replicated;
+create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
+-- ensure we make gather motion when volatile functions in subplan
+explain (costs off, verbose) select (select f(i) from t);
+explain (costs off, verbose) select (select f(i) from t group by f(i));
+explain (costs off, verbose) select (select i from t group by i having f(i) > 0);
+-- ensure we do not make broadcast motion
+explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
+explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
+-- ensure we make broadcast motion when volatile function in deleting motion flow
+explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
+-- ensure we make broadcast motion when volatile function in correlated subplan qual
+explain (costs off, verbose) select * from t1 where a in (select f(i) from t where i=a and f(i) > 0);
+-- ensure we do not break broadcast motion
+explain (costs off, verbose) select * from t1 where 1 <= ALL (select i from t group by i having random() > 0);
+drop table if exists t;
+drop table if exists t1;
+drop table if exists t2;
+drop function if exists f(i int);
 
 -- start_ignore
 drop schema rpt cascade;

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -530,6 +530,8 @@ select j, (select 5) AS "Uncorrelated Field" from t;
 --
 -- Check sub-selects with distributed replicated tables and volatile functions
 --
+set optimizer = off;
+drop table if exists t;
 create table t (i int) distributed replicated;
 create table t1 (a int) distributed by (a);
 create table t2 (a int, b float) distributed replicated;
@@ -551,6 +553,7 @@ drop table if exists t;
 drop table if exists t1;
 drop table if exists t2;
 drop function if exists f(i int);
+reset optimizer;
 
 -- start_ignore
 drop schema rpt cascade;

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -531,30 +531,29 @@ select j, (select 5) AS "Uncorrelated Field" from t;
 -- Check sub-selects with distributed replicated tables and volatile functions
 --
 set optimizer = off;
-drop table if exists t;
-create table t (i bigint) distributed replicated;
-create table t1 (a bigint) distributed by (a);
-create table t2 (a bigint, b float) distributed replicated;
+create table repl_tbl_1 (i bigint) distributed replicated;
+create table dist_tbl (a bigint) distributed by (a);
+create table repl_tbl_2 (a bigint, b float) distributed replicated;
 create or replace function f(i bigint) returns bigint language sql security definer as $$ select i; $$;
 create sequence seq increment by 1 minvalue 1 maxvalue 2 start 2 no cycle;
 -- ensure we make gather motion when volatile functions in subplan
-explain (costs off, verbose) select (select f(i) from t);
-explain (costs off, verbose) select (select f(i) from t group by f(i));
-explain (costs off, verbose) select (select i from t group by i having f(i) > 0);
+explain (costs off, verbose) select (select f(i) from repl_tbl_1);
+explain (costs off, verbose) select (select f(i) from repl_tbl_1 group by f(i));
+explain (costs off, verbose) select (select i from repl_tbl_1 group by i having f(i) > 0);
 -- ensure we do not make broadcast motion
-explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
-explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
+explain (costs off, verbose) select * from dist_tbl where a in (select random() from repl_tbl_1 where i=a group by i);
+explain (costs off, verbose) select * from dist_tbl where a in (select random() from repl_tbl_1 where i=a);
 -- ensure we make broadcast motion when volatile function in deleting motion flow
-explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
+explain (costs off, verbose) insert into repl_tbl_2 (a, b) select i, random() from repl_tbl_1;
 -- ensure we make broadcast motion when volatile function in correlated subplan qual
-explain (costs off, verbose) select * from t1 where a in (select f(i) from t where i=a and f(i) > 0);
+explain (costs off, verbose) select * from dist_tbl where a in (select f(i) from repl_tbl_1 where i=a and f(i) > 0);
 -- ensure we do not break broadcast motion
-explain (costs off, verbose) select * from t1 where 1 <= ALL (select i from t group by i having random() > 0);
+explain (costs off, verbose) select * from dist_tbl where 1 <= ALL (select i from repl_tbl_1 group by i having random() > 0);
 -- ensure we make redistribute motion above scan
-explain (costs off, verbose) insert into t1 (select nextval('seq') from t);
-drop table if exists t;
-drop table if exists t1;
-drop table if exists t2;
+explain (costs off, verbose) insert into dist_tbl (select nextval('seq') from repl_tbl_1);
+drop table if exists repl_tbl_1;
+drop table if exists dist_tbl;
+drop table if exists repl_tbl_2;
 drop function if exists f(i bigint);
 drop sequence if exists seq;
 reset optimizer;


### PR DESCRIPTION
Another bug, not mentioned in the cherry-picked commit, was also fixed by it:

INSERT INTO distributed_table SELECT nextval() FROM replicated_table can insert
more rows than expected. This occurred because the nextval() was evaluated on 
each segment, resulting in an incorrect number of rows inserted
(3 rows instead of 1 on a 3-segment cluster).

Steps to reproduce:
"set optimizer=off;
create table dist_dst (x bigint) distributed by (x);
create table repl_src (y bigint) distributed replicated;
create sequence seq increment by 1 minvalue 1 maxvalue 42 start 1 no cycle;
insert into repl_src values (1);
insert into dist_dst (select nextval('seq') from repl_src);"

The problematic plan:
 Insert on dist_dst
   ->  Seq Scan on repl_src

Volatile functions are detected at the stage of adding the Insert node,
where the correct flow is created. Pre-existing flow request from Insert node
was being lost when the flow from its child Scan (no motion needed since
the table is replicated) overrode the parent's flow.

The fix inherits parent's flow to create appropriate motion node above and restores
it to the original one after motion creation.

Resulting Correct Plan:
 Insert on dist_dst
    ->  Redistribute Motion 1:3  (slice1; segments: 1)
          Hash Key: (nextval('seq'::regclass))
          ->  Seq Scan on repl_src