### PR TITLE
Add pg_rewind --no-sync

### DIFF
--- a/src/bin/pg_rewind/RewindTest.pm
+++ b/src/bin/pg_rewind/RewindTest.pm
@@ -290,6 +290,7 @@ sub run_pg_rewind
 					"--debug",
 					"--source-pgdata=$test_standby_datadir",
 					"--target-pgdata=$test_master_datadir"],
+					"--no-sync",
 				   'pg_rewind local');
 	}
 	elsif ($test_mode eq "remote")
@@ -300,6 +301,7 @@ sub run_pg_rewind
 					"--source-server",
 					"port=$port_standby dbname=postgres",
 					"--target-pgdata=$test_master_datadir"],
+					"--no-sync",
 				   'pg_rewind remote');
 	}
 	else


### PR DESCRIPTION
This is an option consistent with what pg_dump and pg_basebackup provide which is useful for leveraging the I/O effort when testing things, not to be used in a production environment.

Author: Michael Paquier
Reviewed-by: Heikki Linnakangas
Discussion: https://postgr.es/m/20180325122607.GB3707@paquier.xyz

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
