### PR TITLE
Add -c/--restore-target-wal to pg_rewind

### DIFF
--- a/src/bin/pg_rewind/parsexlog.c
+++ b/src/bin/pg_rewind/parsexlog.c
@@ -28,6 +28,7 @@
 #include "logging.h"
 
 #include <unistd.h>
+#include <sys/stat.h>
 
 #include "access/bitmap.h"
 #include "access/heapam_xlog.h"
@@ -43,6 +44,10 @@
 #include "commands/tablespace.h"
 #include "commands/sequence.h"
 #include "cdb/cdbappendonlyxlog.h"
+#include "filemap.h"
+#include "pg_rewind.h"
+
+#include "common/archive.h"
 
 static void extractPageInfo(XLogRecord *record);
 
@@ -52,6 +57,7 @@ static char xlogfpath[MAXPGPATH];
 
 typedef struct XLogPageReadPrivate
 {
+	const char *restoreCommand;
 	const char *datadir;
 	TimeLineID	tli;
 } XLogPageReadPrivate;
@@ -61,6 +67,109 @@ static int SimpleXLogPageRead(XLogReaderState *xlogreader,
 				   int reqLen, XLogRecPtr targetRecPtr, char *readBuf,
 				   TimeLineID *pageTLI);
 
+
+
+
+/*
+ * RWRestoreArchivedFile
+ *
+ * Attempt to retrieve the specified file from off-line archival storage.
+ * If successful, return a file descriptor of the restored file, else
+ * return -1.
+ *
+ * For fixed-size files, the caller may pass the expected size as an
+ * additional crosscheck on successful recovery.  If the file size is not
+ * known, set expectedSize = 0.
+ */
+int
+RWRestoreArchivedFile(const char *path, const char *xlogfname,
+					off_t expectedSize, const char *restoreCommand)
+{
+	char		xlogpath[MAXPGPATH];
+	char	   *xlogRestoreCmd;
+	int			rc;
+	struct stat stat_buf;
+
+	snprintf(xlogpath, MAXPGPATH, "%s/" XLOGDIR "/%s", path, xlogfname);
+
+	xlogRestoreCmd = BuildRestoreCommand(restoreCommand, xlogpath,
+										 xlogfname, NULL);
+	if (xlogRestoreCmd == NULL)
+	{
+		pg_fatal("could not use restore_command with %%r alias");
+		exit(1);
+	}
+
+	/*
+	 * Execute restore_command, which should copy the missing file from
+	 * archival storage.
+	 */
+	rc = system(xlogRestoreCmd);
+	pfree(xlogRestoreCmd);
+
+	if (rc == 0)
+	{
+		/*
+		 * Command apparently succeeded, but let's make sure the file is
+		 * really there now and has the correct size.
+		 */
+		if (stat(xlogpath, &stat_buf) == 0)
+		{
+			if (expectedSize > 0 && stat_buf.st_size != expectedSize)
+			{
+				pg_fatal("unexpected file size for \"%s\": %lu instead of %lu",
+							 xlogfname, (unsigned long) stat_buf.st_size,
+							 (unsigned long) expectedSize);
+				exit(1);
+			}
+			else
+			{
+				int			xlogfd = open(xlogpath, O_RDONLY | PG_BINARY, 0);
+
+				if (xlogfd < 0)
+				{
+					pg_fatal("could not open file \"%s\" restored from archive: %m",
+								 xlogpath);
+					exit(1);
+				}
+				else
+					return xlogfd;
+			}
+		}
+		else
+		{
+			if (errno != ENOENT)
+			{
+				pg_fatal("could not stat file \"%s\": %m",
+							 xlogpath);
+				exit(1);
+			}
+		}
+	}
+
+	/*
+	 * If the failure was due to a signal, then it would be misleading to
+	 * return with a failure at restoring the file.  So just bail out and
+	 * exit.  Hard shell errors such as "command not found" are treated as
+	 * fatal too.
+	 */
+	if (wait_result_is_any_signal(rc, true))
+	{
+		pg_fatal("restore_command failed due to the signal: %s",
+					 wait_result_to_str(rc));
+		exit(1);
+	}
+
+	/*
+	 * The file is not available, so just let the caller decide what to do
+	 * next.
+	 */
+	pg_log(PG_FATAL, "could not restore file \"%s\" from archive",
+				 xlogfname);
+	return -1;
+}
+
+
 /*
  * Read WAL from the datadir/pg_xlog, starting from 'startpoint' on timeline
  * 'tli', until 'endpoint'. Make note of the data blocks touched by the WAL
@@ -68,7 +177,7 @@ static int SimpleXLogPageRead(XLogReaderState *xlogreader,
  */
 void
 extractPageMap(const char *datadir, XLogRecPtr startpoint, TimeLineID tli,
-			   XLogRecPtr endpoint)
+			   XLogRecPtr endpoint, const char *restoreCommand)
 {
 	XLogRecord *record;
 	XLogReaderState *xlogreader;
@@ -77,6 +186,7 @@ extractPageMap(const char *datadir, XLogRecPtr startpoint, TimeLineID tli,
 
 	private.datadir = datadir;
 	private.tli = tli;
+	private.restoreCommand = restoreCommand;
 	xlogreader = XLogReaderAllocate(&SimpleXLogPageRead, &private);
 	if (xlogreader == NULL)
 		pg_fatal("out of memory\n");
@@ -161,7 +271,7 @@ readOneRecord(const char *datadir, XLogRecPtr ptr, TimeLineID tli)
 void
 findLastCheckpoint(const char *datadir, XLogRecPtr forkptr, TimeLineID tli,
 				   XLogRecPtr *lastchkptrec, TimeLineID *lastchkpttli,
-				   XLogRecPtr *lastchkptredo)
+				   XLogRecPtr *lastchkptredo, const char *restoreCommand)
 {
 	/* Walk backwards, starting from the given record */
 	XLogRecord *record;
@@ -181,6 +291,7 @@ findLastCheckpoint(const char *datadir, XLogRecPtr forkptr, TimeLineID tli,
 
 	private.datadir = datadir;
 	private.tli = tli;
+	private.restoreCommand = restoreCommand;
 	xlogreader = XLogReaderAllocate(&SimpleXLogPageRead, &private);
 	if (xlogreader == NULL)
 		pg_fatal("out of memory\n");
@@ -263,6 +374,7 @@ SimpleXLogPageRead(XLogReaderState *xlogreader, XLogRecPtr targetPagePtr,
 	if (xlogreadfd < 0)
 	{
 		char		xlogfname[MAXFNAMELEN];
+		char		path[MAXPGPATH];
 
 		XLogFileName(xlogfname, private->tli, xlogreadsegno);
 
@@ -272,9 +384,29 @@ SimpleXLogPageRead(XLogReaderState *xlogreader, XLogRecPtr targetPagePtr,
 
 		if (xlogreadfd < 0)
 		{
-			printf(_("could not open file \"%s\": %s\n"), xlogfpath,
-				   strerror(errno));
-			return -1;
+			/*
+			 * If we have no restore_command to execute, then exit.
+			 */
+			if (private->restoreCommand == NULL)
+			{
+				pg_log(PG_FATAL, "could not open file \"%s\": %m", xlogfpath);
+				return -1;
+			}
+
+			/*
+			 * Since we have restore_command, then try to retrieve missing WAL
+			 * file from the archive.
+			 */
+			xlogreadfd = RWRestoreArchivedFile(path,
+											 xlogfname,
+											 XLogSegSize,
+											 private->restoreCommand);
+
+			if (xlogreadfd < 0)
+				return -1;
+			else
+				pg_log(PG_DEBUG, "using file \"%s\" restored from archive",
+							 xlogfpath);
 		}
 	}
 

--- a/src/bin/pg_rewind/parsexlog.c
+++ b/src/bin/pg_rewind/parsexlog.c
@@ -83,7 +83,7 @@ static int SimpleXLogPageRead(XLogReaderState *xlogreader,
  */
 int
 RWRestoreArchivedFile(const char *path, const char *xlogfname,
-					off_t expectedSize, const char *restoreCommand)
+					off_t expectedSize, const char *restoreCommand, int segindx)
 {
 	char		xlogpath[MAXPGPATH];
 	char	   *xlogRestoreCmd;
@@ -93,7 +93,7 @@ RWRestoreArchivedFile(const char *path, const char *xlogfname,
 	snprintf(xlogpath, MAXPGPATH, "%s/" XLOGDIR "/%s", path, xlogfname);
 
 	xlogRestoreCmd = BuildRestoreCommand(restoreCommand, xlogpath,
-										 xlogfname, NULL);
+										 xlogfname, NULL, segindx);
 	if (xlogRestoreCmd == NULL)
 	{
 		pg_fatal("could not use restore_command with %%r alias");
@@ -393,6 +393,12 @@ SimpleXLogPageRead(XLogReaderState *xlogreader, XLogRecPtr targetPagePtr,
 				return -1;
 			}
 
+			if (instanceSegIndx == -2) {
+
+				pg_log(PG_FATAL, "could get instance segment uid");
+				return -1;
+			}
+
 			/*
 			 * Since we have restore_command, then try to retrieve missing WAL
 			 * file from the archive.
@@ -400,7 +406,7 @@ SimpleXLogPageRead(XLogReaderState *xlogreader, XLogRecPtr targetPagePtr,
 			xlogreadfd = RWRestoreArchivedFile(path,
 											 xlogfname,
 											 XLogSegSize,
-											 private->restoreCommand);
+											 private->restoreCommand, instanceSegIndx);
 
 			if (xlogreadfd < 0)
 				return -1;

--- a/src/bin/pg_rewind/pg_rewind.c
+++ b/src/bin/pg_rewind/pg_rewind.c
@@ -23,6 +23,10 @@
 #include "access/xlog_internal.h"
 #include "catalog/catversion.h"
 #include "catalog/pg_control.h"
+#include "common/string.h"
+#include "fetch.h"
+#include "file_ops.h"
+#include "filemap.h"
 #include "getopt_long.h"
 #include "utils/palloc.h"
 #include "storage/bufpage.h"
@@ -37,6 +41,7 @@ static void digestControlFile(ControlFileData *ControlFile, char *source,
 				  size_t size);
 static void updateControlFile(ControlFileData *ControlFile);
 static void syncTargetDirectory(void);
+static void getRestoreCommand(const char *argv0);
 static void sanityChecks(void);
 static void findCommonAncestorTimeline(XLogRecPtr *recptr, TimeLineID *tli);
 static void ensureCleanShutdown(const char *argv0);
@@ -55,11 +60,13 @@ const char *progname;
 char	   *datadir_target = NULL;
 char	   *datadir_source = NULL;
 char	   *connstr_source = NULL;
+char	   *restore_command = NULL;
 
 bool		debug = false;
 bool		showprogress = false;
 bool		dry_run = false;
 bool		do_sync = true;
+bool		restore_wal = false;
 
 static void
 usage(const char *progname)
@@ -67,6 +74,8 @@ usage(const char *progname)
 	printf(_("%s resynchronizes a PostgreSQL cluster with another copy of the cluster.\n\n"), progname);
 	printf(_("Usage:\n  %s [OPTION]...\n\n"), progname);
 	printf(_("Options:\n"));
+	printf(_("  -c, --restore-target-wal       use restore_command in target config\n"
+			 "                                 to retrieve WAL files from archives\n"));
 	printf(_("  -D, --target-pgdata=DIRECTORY  existing data directory to modify\n"));
 	printf(_("      --source-pgdata=DIRECTORY  source data directory to synchronize with\n"));
 	printf(_("      --source-server=CONNSTR    source server to synchronize with\n"));
@@ -94,6 +103,7 @@ main(int argc, char **argv)
 		{"source-pgdata", required_argument, NULL, 1},
 		{"source-server", required_argument, NULL, 2},
 		{"version", no_argument, NULL, 'V'},
+		{"restore-target-wal", no_argument, NULL, 'c'},
 		{"dry-run", no_argument, NULL, 'n'},
 		{"no-sync", no_argument, NULL, 'N'},
 		{"progress", no_argument, NULL, 'P'},
@@ -132,13 +142,17 @@ main(int argc, char **argv)
 		}
 	}
 
-	while ((c = getopt_long(argc, argv, "D:nNPRS:", long_options, &option_index)) != -1)
+	while ((c = getopt_long(argc, argv, "cD:nNPRS:", long_options, &option_index)) != -1)
 	{
 		switch (c)
 		{
 			case '?':
 				fprintf(stderr, _("Try \"%s --help\" for more information.\n"), progname);
 				exit(1);
+
+			case 'c':
+				restore_wal = true;
+				break;
 
 			case 'P':
 				showprogress = true;
@@ -228,6 +242,15 @@ main(int argc, char **argv)
 	}
 #endif
 
+	/* Set mask based on PGDATA permissions */
+	if (!GetDataDirectoryCreatePerm(datadir_target))
+	{
+		pg_log(PG_FATAL, "could not read permissions of directory \"%s\": %m",
+					 datadir_target);
+		exit(1);
+	}
+
+	getRestoreCommand(argv[0]);
 	/* Connect to remote server */
 	if (connstr_source)
 		libpqConnect(connstr_source);
@@ -339,7 +362,7 @@ main(int argc, char **argv)
 	}
 
 	findLastCheckpoint(datadir_target, divergerec, lastcommontli,
-					   &chkptrec, &chkpttli, &chkptredo);
+					   &chkptrec, &chkpttli, &chkptredo, restore_command);
 	printf(_("rewinding from last common checkpoint at %X/%X on timeline %u\n"),
 		   (uint32) (chkptrec >> 32), (uint32) chkptrec,
 		   chkpttli);
@@ -362,7 +385,7 @@ main(int argc, char **argv)
 	 */
 	pg_log(PG_PROGRESS, "reading WAL in target\n");
 	extractPageMap(datadir_target, chkptrec, lastcommontli,
-				   ControlFile_target.checkPoint);
+				   ControlFile_target.checkPoint, restore_command);
 
 	/*
 	 * We have collected all information we need from both systems. Decide
@@ -822,6 +845,71 @@ syncTargetDirectory()
 	fsync_fname("recovery.conf", false);
 	fsync_fname(".", true); /* due to new file backup_label. */
 }
+
+/*
+ * Get value of GUC parameter restore_command from the target cluster.
+ *
+ * This uses a logic based on "postgres -C" to get the value from the
+ * cluster.
+ */
+static void
+getRestoreCommand(const char *argv0)
+{
+	int			rc;
+	char		postgres_exec_path[MAXPGPATH],
+				postgres_cmd[MAXPGPATH],
+				cmd_output[MAXPGPATH];
+
+	if (!restore_wal)
+		return;
+
+	/* find postgres executable */
+	rc = find_other_exec(argv0, "postgres",
+						 PG_BACKEND_VERSIONSTR,
+						 postgres_exec_path);
+
+	if (rc < 0)
+	{
+		char		full_path[MAXPGPATH];
+
+		if (find_my_exec(argv0, full_path) < 0)
+			strlcpy(full_path, progname, sizeof(full_path));
+
+		if (rc == -1)
+			pg_log(PG_FATAL, "The program \"postgres\" is needed by %s but was not found in the\n"
+						 "same directory as \"%s\".\n"
+						 "Check your installation.",
+						 progname, full_path);
+		else
+			pg_log(PG_FATAL, "The program \"postgres\" was found by \"%s\"\n"
+						 "but was not the same version as %s.\n"
+						 "Check your installation.",
+						 full_path, progname);
+		exit(1);
+	}
+
+	/*
+	 * Build a command able to retrieve the value of GUC parameter
+	 * restore_command, if set.
+	 */
+	snprintf(postgres_cmd, sizeof(postgres_cmd),
+			 "\"%s\" -D \"%s\" -C restore_command",
+			 postgres_exec_path, datadir_target);
+
+	if (!pipe_read_line(postgres_cmd, cmd_output, sizeof(cmd_output)))
+		exit(1);
+
+	(void) pg_strip_crlf(cmd_output);
+
+	if (strcmp(cmd_output, "") == 0)
+		pg_fatal("restore_command is not set on the target cluster");
+
+	restore_command = pg_strdup(cmd_output);
+
+	pg_log(PG_DEBUG, "using for rewind restore_command = \'%s\'",
+				 restore_command);
+}
+
 
 /*
  * Ensure clean shutdown of target instance by launching single-user mode

--- a/src/bin/pg_rewind/pg_rewind.c
+++ b/src/bin/pg_rewind/pg_rewind.c
@@ -62,6 +62,9 @@ char	   *datadir_source = NULL;
 char	   *connstr_source = NULL;
 char	   *restore_command = NULL;
 
+
+int instanceSegIndx = -2;
+
 bool		debug = false;
 bool		showprogress = false;
 bool		dry_run = false;
@@ -108,6 +111,7 @@ main(int argc, char **argv)
 		{"no-sync", no_argument, NULL, 'N'},
 		{"progress", no_argument, NULL, 'P'},
 		{"debug", no_argument, NULL, 3},
+		{"segindx", no_argument, NULL, 4},
 		{NULL, 0, NULL, 0}
 	};
 	int			option_index;
@@ -187,6 +191,9 @@ main(int argc, char **argv)
 				break;
 			case 2:				/* --source-server */
 				connstr_source = pg_strdup(optarg);
+				break;
+			case 4:
+				instanceSegIndx = strtoll(optarg, optarg + strlen(optarg), 10);
 				break;
 		}
 	}

--- a/src/bin/pg_rewind/pg_rewind.h
+++ b/src/bin/pg_rewind/pg_rewind.h
@@ -33,11 +33,12 @@ extern const char *progname;
 
 /* in parsexlog.c */
 extern void extractPageMap(const char *datadir, XLogRecPtr startpoint,
-			   TimeLineID tli, XLogRecPtr endpoint);
+			   TimeLineID tli, XLogRecPtr endpoint, const char *restoreCommand);
 extern void findLastCheckpoint(const char *datadir, XLogRecPtr searchptr,
 				   TimeLineID tli,
 				   XLogRecPtr *lastchkptrec, TimeLineID *lastchkpttli,
-				   XLogRecPtr *lastchkptredo);
+				   XLogRecPtr *lastchkptredo,
+				   const char *restoreCommand);
 extern XLogRecPtr readOneRecord(const char *datadir, XLogRecPtr ptr,
 			  TimeLineID tli);
 

--- a/src/bin/pg_rewind/pg_rewind.h
+++ b/src/bin/pg_rewind/pg_rewind.h
@@ -46,4 +46,7 @@ extern XLogRecPtr readOneRecord(const char *datadir, XLogRecPtr ptr,
 extern TimeLineHistoryEntry *rewind_parseTimeLineHistory(char *buffer,
 							TimeLineID targetTLI, int *nentries);
 
+
+extern int instanceSegIndx;
+
 #endif   /* PG_REWIND_H */

--- a/src/bin/pg_rewind/t/001_basic.pl
+++ b/src/bin/pg_rewind/t/001_basic.pl
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use TestLib;
-use Test::More tests => 8;
+use Test::More tests => 13;
 
 use RewindTest;
 
@@ -92,5 +92,6 @@ in master, before promotion
 # Run the test in both modes
 run_test('local');
 run_test('remote');
+run_test('archive');
 
 exit(0);

--- a/src/bin/pg_rewind/t/RewindTest.pm
+++ b/src/bin/pg_rewind/t/RewindTest.pm
@@ -1,0 +1,394 @@
+package RewindTest;
+
+# Test driver for pg_rewind. Each test consists of a cycle where a new cluster
+# is first created with initdb, and a streaming replication standby is set up
+# to follow the master. Then the master is shut down and the standby is
+# promoted, and finally pg_rewind is used to rewind the old master, using the
+# standby as the source.
+#
+# To run a test, the test script (in t/ subdirectory) calls the functions
+# in this module. These functions should be called in this sequence:
+#
+# 1. setup_cluster - creates a PostgreSQL cluster that runs as the master
+#
+# 2. start_master - starts the master server
+#
+# 3. create_standby - runs pg_basebackup to initialize a standby server, and
+#    sets it up to follow the master.
+#
+# 4. promote_standby - runs "pg_ctl promote" to promote the standby server.
+# The old master keeps running.
+#
+# 5. run_pg_rewind - stops the old master (if it's still running) and runs
+# pg_rewind to synchronize it with the now-promoted standby server.
+#
+# 6. clean_rewind_test - stops both servers used in the test, if they're
+# still running.
+#
+# The test script can use the helper functions master_psql and standby_psql
+# to run psql against the master and standby servers, respectively.
+
+use strict;
+use warnings;
+
+use Carp;
+use Config;
+use Exporter 'import';
+use File::Copy;
+use File::Path qw(rmtree);
+use IPC::Run qw(run);
+use PostgresNode;
+use RecursiveCopy;
+use TestLib;
+use Test::More;
+
+our @EXPORT = qw(
+  $node_master
+  $node_standby
+
+  master_psql
+  standby_psql
+  check_query
+
+  setup_cluster
+  start_master
+  create_standby
+  promote_standby
+  run_pg_rewind
+  clean_rewind_test
+);
+
+# Our nodes.
+our $node_master;
+our $node_standby;
+
+sub master_psql
+{
+	my $cmd = shift;
+	my $dbname = shift || 'postgres';
+
+	system_or_bail 'psql', '-q', '--no-psqlrc', '-d',
+	  $node_master->connstr($dbname), '-c', "$cmd";
+	return;
+}
+
+sub standby_psql
+{
+	my $cmd = shift;
+	my $dbname = shift || 'postgres';
+
+	system_or_bail 'psql', '-q', '--no-psqlrc', '-d',
+	  $node_standby->connstr($dbname), '-c', "$cmd";
+	return;
+}
+
+# Run a query against the master, and check that the output matches what's
+# expected
+sub check_query
+{
+	local $Test::Builder::Level = $Test::Builder::Level + 1;
+
+	my ($query, $expected_stdout, $test_name) = @_;
+	my ($stdout, $stderr);
+
+	# we want just the output, no formatting
+	my $result = run [
+		'psql', '-q', '-A', '-t', '--no-psqlrc', '-d',
+		$node_master->connstr('postgres'),
+		'-c', $query
+	  ],
+	  '>', \$stdout, '2>', \$stderr;
+
+	# We don't use ok() for the exit code and stderr, because we want this
+	# check to be just a single test.
+	if (!$result)
+	{
+		fail("$test_name: psql exit code");
+	}
+	elsif ($stderr ne '')
+	{
+		diag $stderr;
+		fail("$test_name: psql no stderr");
+	}
+	else
+	{
+		$stdout =~ s/\r//g if $Config{osname} eq 'msys';
+		is($stdout, $expected_stdout, "$test_name: query result matches");
+	}
+	return;
+}
+
+sub setup_cluster
+{
+	my $extra_name = shift;    # Used to differentiate clusters
+	my $extra      = shift;    # Extra params for initdb
+
+	# Initialize master, data checksums are mandatory
+	$node_master =
+	  get_new_node('master' . ($extra_name ? "_${extra_name}" : ''));
+
+	# Set up pg_hba.conf and pg_ident.conf for the role running
+	# pg_rewind.  This role is used for all the tests, and has
+	# minimal permissions enough to rewind from an online source.
+	$node_master->init(
+		allows_streaming => 1,
+		extra            => $extra,
+		auth_extra       => [ '--create-role', 'rewind_user' ]);
+
+	# Set wal_keep_segments to prevent WAL segment recycling after enforced
+	# checkpoints in the tests.
+	$node_master->append_conf(
+		'postgresql.conf', qq(
+wal_keep_segments = 20
+));
+	return;
+}
+
+sub start_master
+{
+	$node_master->start;
+
+	# Create custom role which is used to run pg_rewind, and adjust its
+	# permissions to the minimum necessary.
+	$node_master->safe_psql(
+		'postgres', "
+		CREATE ROLE rewind_user LOGIN;
+		GRANT EXECUTE ON function pg_catalog.pg_ls_dir(text, boolean, boolean)
+		  TO rewind_user;
+		GRANT EXECUTE ON function pg_catalog.pg_stat_file(text, boolean)
+		  TO rewind_user;
+		GRANT EXECUTE ON function pg_catalog.pg_read_binary_file(text)
+		  TO rewind_user;
+		GRANT EXECUTE ON function pg_catalog.pg_read_binary_file(text, bigint, bigint, boolean)
+		  TO rewind_user;");
+
+	#### Now run the test-specific parts to initialize the master before setting
+	# up standby
+
+	return;
+}
+
+sub create_standby
+{
+	my $extra_name = shift;
+
+	$node_standby =
+	  get_new_node('standby' . ($extra_name ? "_${extra_name}" : ''));
+	$node_master->backup('my_backup');
+	$node_standby->init_from_backup($node_master, 'my_backup');
+	my $connstr_master = $node_master->connstr();
+
+	$node_standby->append_conf(
+		"postgresql.conf", qq(
+primary_conninfo='$connstr_master'
+));
+
+	$node_standby->set_standby_mode();
+
+	# Start standby
+	$node_standby->start;
+
+	# The standby may have WAL to apply before it matches the primary.  That
+	# is fine, because no test examines the standby before promotion.
+
+	return;
+}
+
+sub promote_standby
+{
+	#### Now run the test-specific parts to run after standby has been started
+	# up standby
+
+	# Wait for the standby to receive and write all WAL.
+	$node_master->wait_for_catchup($node_standby, 'write');
+
+	# Now promote standby and insert some new data on master, this will put
+	# the master out-of-sync with the standby.
+	$node_standby->promote;
+
+	# Force a checkpoint after the promotion. pg_rewind looks at the control
+	# file to determine what timeline the server is on, and that isn't updated
+	# immediately at promotion, but only at the next checkpoint. When running
+	# pg_rewind in remote mode, it's possible that we complete the test steps
+	# after promotion so quickly that when pg_rewind runs, the standby has not
+	# performed a checkpoint after promotion yet.
+	standby_psql("checkpoint");
+
+	return;
+}
+
+sub run_pg_rewind
+{
+	my $test_mode       = shift;
+	my $master_pgdata   = $node_master->data_dir;
+	my $standby_pgdata  = $node_standby->data_dir;
+	my $standby_connstr = $node_standby->connstr('postgres');
+	my $tmp_folder      = TestLib::tempdir;
+
+	# Append the rewind-specific role to the connection string.
+	$standby_connstr = "$standby_connstr user=rewind_user";
+
+	if ($test_mode eq 'archive')
+	{
+		# pg_rewind is tested with --restore-target-wal by moving all
+		# WAL files to a secondary location.  Note that this leads to
+		# a failure in ensureCleanShutdown(), forcing to the use of
+		# --no-ensure-shutdown in this mode as the initial set of WAL
+		# files needed to ensure a clean restart is gone.  This could
+		# be improved by keeping around only a minimum set of WAL
+		# segments but that would just make the test more costly,
+		# without improving the coverage.  Hence, instead, stop
+		# gracefully the primary here.
+		$node_master->stop;
+	}
+	else
+	{
+		# Stop the master and be ready to perform the rewind.  The cluster
+		# needs recovery to finish once, and pg_rewind makes sure that it
+		# happens automatically.
+		$node_master->stop('immediate');
+	}
+
+	# At this point, the rewind processing is ready to run.
+	# We now have a very simple scenario with a few diverged WAL record.
+	# The real testing begins really now with a bifurcation of the possible
+	# scenarios that pg_rewind supports.
+
+	# Keep a temporary postgresql.conf for master node or it would be
+	# overwritten during the rewind.
+	copy(
+		"$master_pgdata/postgresql.conf",
+		"$tmp_folder/master-postgresql.conf.tmp");
+
+	# Now run pg_rewind
+	if ($test_mode eq "local")
+	{
+
+		# Do rewind using a local pgdata as source
+		# Stop the master and be ready to perform the rewind
+		$node_standby->stop;
+		command_ok(
+			[
+				'pg_rewind',
+				"--debug",
+				"--source-pgdata=$standby_pgdata",
+				"--target-pgdata=$master_pgdata",
+				"--no-sync"
+			],
+			'pg_rewind local');
+	}
+	elsif ($test_mode eq "remote")
+	{
+		# Do rewind using a remote connection as source, generating
+		# recovery configuration automatically.
+		command_ok(
+			[
+				'pg_rewind',                      "--debug",
+				"--source-server",                $standby_connstr,
+				"--target-pgdata=$master_pgdata", "--no-sync",
+				"--write-recovery-conf"
+			],
+			'pg_rewind remote');
+
+		# Check that standby.signal is here as recovery configuration
+		# was requested.
+		ok( -e "$master_pgdata/standby.signal",
+			'standby.signal created after pg_rewind');
+
+		# Now, when pg_rewind apparently succeeded with minimal permissions,
+		# add REPLICATION privilege.  So we could test that new standby
+		# is able to connect to the new master with generated config.
+		$node_standby->safe_psql('postgres',
+			"ALTER ROLE rewind_user WITH REPLICATION;");
+	}
+	elsif ($test_mode eq "archive")
+	{
+
+		# Do rewind using a local pgdata as source and specified
+		# directory with target WAL archive.  The old master has
+		# to be stopped at this point.
+
+		# Remove the existing archive directory and move all WAL
+		# segments from the old master to the archives.  These
+		# will be used by pg_rewind.
+		rmtree($node_master->archive_dir);
+		RecursiveCopy::copypath($node_master->data_dir . "/pg_wal",
+			$node_master->archive_dir);
+
+		# Fast way to remove entire directory content
+		rmtree($node_master->data_dir . "/pg_wal");
+		mkdir($node_master->data_dir . "/pg_wal");
+
+		# Make sure that directories have the right umask as this is
+		# required by a follow-up check on permissions, and better
+		# safe than sorry.
+		chmod(0700, $node_master->archive_dir);
+		chmod(0700, $node_master->data_dir . "/pg_wal");
+
+		# Add appropriate restore_command to the target cluster
+		$node_master->enable_restoring($node_master, 0);
+
+		# Stop the new master and be ready to perform the rewind.
+		$node_standby->stop;
+
+		# Note the use of --no-ensure-shutdown here.  WAL files are
+		# gone in this mode and the primary has been stopped
+		# gracefully already.
+		command_ok(
+			[
+				'pg_rewind',
+				"--debug",
+				"--source-pgdata=$standby_pgdata",
+				"--target-pgdata=$master_pgdata",
+				"--no-sync",
+				"--no-ensure-shutdown",
+				"--restore-target-wal"
+			],
+			'pg_rewind archive');
+	}
+	else
+	{
+
+		# Cannot come here normally
+		croak("Incorrect test mode specified");
+	}
+
+	# Now move back postgresql.conf with old settings
+	move(
+		"$tmp_folder/master-postgresql.conf.tmp",
+		"$master_pgdata/postgresql.conf");
+
+	chmod(
+		$node_master->group_access() ? 0640 : 0600,
+		"$master_pgdata/postgresql.conf")
+	  or BAIL_OUT(
+		"unable to set permissions for $master_pgdata/postgresql.conf");
+
+	# Plug-in rewound node to the now-promoted standby node
+	if ($test_mode ne "remote")
+	{
+		my $port_standby = $node_standby->port;
+		$node_master->append_conf(
+			'postgresql.conf', qq(
+primary_conninfo='port=$port_standby'));
+
+		$node_master->set_standby_mode();
+	}
+
+	# Restart the master to check that rewind went correctly
+	$node_master->start;
+
+	#### Now run the test-specific parts to check the result
+
+	return;
+}
+
+# Clean up after the test. Stop both servers, if they're still running.
+sub clean_rewind_test
+{
+	$node_master->teardown_node  if defined $node_master;
+	$node_standby->teardown_node if defined $node_standby;
+	return;
+}
+
+1;

--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -23,7 +23,7 @@ include $(top_builddir)/src/Makefile.global
 override CPPFLAGS := -DFRONTEND $(CPPFLAGS)
 LIBS += $(PTHREAD_LIBS)
 
-OBJS_COMMON = archive.o file_perm.c base64.o scram-common.o exec.o pgfnames.o psprintf.o \
+OBJS_COMMON = archive.o file_perm.o base64.o scram-common.o exec.o pgfnames.o psprintf.o \
 	relpath.o rmtree.o saslprep.o string.o unicode_norm.o username.o \
 	wait_error.o
 

--- a/src/common/exec.c
+++ b/src/common/exec.c
@@ -42,7 +42,6 @@
 
 static int	validate_exec(const char *path);
 static int	resolve_symlinks(char *path);
-static char *pipe_read_line(char *cmd, char *line, int maxsize);
 
 #ifdef WIN32
 static BOOL GetTokenUser(HANDLE hToken, PTOKEN_USER *ppTokenUser);
@@ -353,7 +352,7 @@ find_other_exec(const char *argv0, const char *target,
  * Executing a command in a pipe and reading the first line from it
  * is all we need.
  */
-static char *
+char *
 pipe_read_line(char *cmd, char *line, int maxsize)
 {
 #ifndef WIN32

--- a/src/include/port.h
+++ b/src/include/port.h
@@ -94,10 +94,11 @@ extern void pgfnames_cleanup(char **filenames);
 /* Portable locale initialization (in exec.c) */
 extern void set_pglocale_pgservice(const char *argv0, const char *app);
 
-/* Portable way to find binaries (in exec.c) */
+/* Portable way to find and execute binaries (in exec.c) */
 extern int	find_my_exec(const char *argv0, char *retpath);
 extern int find_other_exec(const char *argv0, const char *target,
 				const char *versionstr, char *retpath);
+extern char *pipe_read_line(char *cmd, char *line, int maxsize);
 
 /* Windows security token manipulation (in exec.c) */
 #ifdef WIN32


### PR DESCRIPTION
pg_rewind needs to copy from the source cluster to the target cluster a set of relation blocks changed from the previous checkpoint where WAL forked up to the end of WAL on the target.  Building this list of relation blocks requires a range of WAL segments that may not be present anymore on the target's pg_wal, causing pg_rewind to fail.  It is possible to work around this issue by copying manually the WAL segments needed but this may lead to some extra and actually useless work.

This commit introduces a new option allowing pg_rewind to use a restore_command while doing the rewind by grabbing the parameter value of restore_command from the target cluster configuration.  This allows the rewind operation to be more reliable, so as only the WAL segments needed by the rewind are restored from the archives.

In order to be able to do that, a new routine is added to src/common/ to allow frontend tools to restore files from archives using an already-built restore command.  This version is more simple than the backend equivalent as there is no need to handle the non-recovery case.

Author: Alexey Kondratov
Reviewed-by: Andrey Borodin, Andres Freund, Alvaro Herrera, Alexander Korotkov, Michael Paquier
Discussion: https://postgr.es/m/a3acff50-5a0d-9a2c-b3b2-ee36168955c1@postgrespro.ru

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
