### PR TITLE
Move routine building restore_command to src/common/

### DIFF
--- a/src/backend/access/transam/xlogarchive.c
+++ b/src/backend/access/transam/xlogarchive.c
@@ -22,6 +22,7 @@
 
 #include "access/xlog.h"
 #include "access/xlog_internal.h"
+#include "common/archive.h"
 #include "miscadmin.h"
 #include "postmaster/startup.h"
 #include "replication/walsender.h"
@@ -60,19 +61,14 @@ RestoreArchivedFile(char *path, const char *xlogfname,
 					bool cleanupEnabled)
 {
 	char		xlogpath[MAXPGPATH];
-	char		xlogRestoreCmd[MAXPGPATH];
+	char	   *xlogRestoreCmd;
 	char		lastRestartPointFname[MAXPGPATH];
-	char	   *dp;
-	char	   *endp;
-	const char *sp;
 	int			rc;
 	bool		signaled;
 	struct stat stat_buf;
 	XLogSegNo	restartSegNo;
 	XLogRecPtr	restartRedoPtr;
 	TimeLineID	restartTli;
-
-	char        contentid[12];  /* sign, 10 digits and '\0' */
 
 	/* In standby mode, restore_command might not be supplied */
 	if (recoveryRestoreCommand == NULL)
@@ -151,66 +147,13 @@ RestoreArchivedFile(char *path, const char *xlogfname,
 	else
 		XLogFileName(lastRestartPointFname, 0, 0L);
 
-	/*
-	 * construct the command to be executed
-	 */
-	dp = xlogRestoreCmd;
-	endp = xlogRestoreCmd + MAXPGPATH - 1;
-	*endp = '\0';
-
-	for (sp = recoveryRestoreCommand; *sp; sp++)
-	{
-		if (*sp == '%')
-		{
-			switch (sp[1])
-			{
-				case 'p':
-					/* %p: relative path of target file */
-					sp++;
-					StrNCpy(dp, xlogpath, endp - dp);
-					make_native_path(dp);
-					dp += strlen(dp);
-					break;
-				case 'f':
-					/* %f: filename of desired file */
-					sp++;
-					StrNCpy(dp, xlogfname, endp - dp);
-					dp += strlen(dp);
-					break;
-				case 'r':
-					/* %r: filename of last restartpoint */
-					sp++;
-					StrNCpy(dp, lastRestartPointFname, endp - dp);
-					dp += strlen(dp);
-					break;
-				case 'c':
-					/* GPDB: %c: contentId of segment */
-					Assert(GpIdentity.segindex != UNINITIALIZED_GP_IDENTITY_VALUE);
-					sp++;
-					pg_ltoa(GpIdentity.segindex, contentid);
-					StrNCpy(dp, contentid, endp - dp);
-					dp += strlen(dp);
-					break;
-				case '%':
-					/* convert %% to a single % */
-					sp++;
-					if (dp < endp)
-						*dp++ = *sp;
-					break;
-				default:
-					/* otherwise treat the % as not special */
-					if (dp < endp)
-						*dp++ = *sp;
-					break;
-			}
-		}
-		else
-		{
-			if (dp < endp)
-				*dp++ = *sp;
-		}
-	}
-	*dp = '\0';
+	/* Build the restore command to execute */
+	xlogRestoreCmd = BuildRestoreCommand(recoveryRestoreCommand,
+										 xlogpath, xlogfname,
+										 lastRestartPointFname);
+	if (xlogRestoreCmd == NULL)
+		elog(ERROR, "could not build restore command \"%s\"",
+			 recoveryRestoreCommand);
 
 	ereport(DEBUG3,
 			(errmsg_internal("executing restore command \"%s\"",
@@ -227,6 +170,7 @@ RestoreArchivedFile(char *path, const char *xlogfname,
 	rc = system(xlogRestoreCmd);
 
 	PostRestoreCommand();
+	pfree(xlogRestoreCmd);
 
 	if (rc == 0)
 	{

--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -23,7 +23,7 @@ include $(top_builddir)/src/Makefile.global
 override CPPFLAGS := -DFRONTEND $(CPPFLAGS)
 LIBS += $(PTHREAD_LIBS)
 
-OBJS_COMMON = base64.o scram-common.o exec.o pgfnames.o psprintf.o \
+OBJS_COMMON = archive.o base64.o scram-common.o exec.o pgfnames.o psprintf.o \
 	relpath.o rmtree.o saslprep.o string.o unicode_norm.o username.o \
 	wait_error.o
 

--- a/src/common/archive.c
+++ b/src/common/archive.c
@@ -1,0 +1,130 @@
+/*-------------------------------------------------------------------------
+ *
+ * archive.c
+ *	  Common WAL archive routines
+ *
+ * Portions Copyright (c) 1996-2020, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ *
+ * IDENTIFICATION
+ *	  src/common/archive.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "common/archive.h"
+#include "lib/stringinfo.h"
+
+/* GPDB */
+#include "cdb/cdbvars.h"
+#include "utils/builtins.h"
+
+/*
+ * BuildRestoreCommand
+ *
+ * Builds a restore command to retrieve a file from WAL archives, replacing
+ * the supported aliases with values supplied by the caller as defined by
+ * the GUC parameter restore_command: xlogpath for %p, xlogfname for %f and
+ * lastRestartPointFname for %r.
+ *
+ * The result is a palloc'd string for the restore command built.  The
+ * caller is responsible for freeing it.  If any of the required arguments
+ * is NULL and that the corresponding alias is found in the command given
+ * by the caller, then NULL is returned.
+ */
+char *
+BuildRestoreCommand(const char *restoreCommand,
+					const char *xlogpath,
+					const char *xlogfname,
+					const char *lastRestartPointFname)
+{
+	StringInfoData result;
+	const char *sp;
+
+	char        contentid[12];  /* sign, 10 digits and '\0' */
+
+	/*
+	 * Build the command to be executed.
+	 */
+	initStringInfo(&result);
+
+	for (sp = restoreCommand; *sp; sp++)
+	{
+		if (*sp == '%')
+		{
+			switch (sp[1])
+			{
+				case 'p':
+					{
+						char	   *nativePath;
+
+						/* %p: relative path of target file */
+						if (xlogpath == NULL)
+						{
+							pfree(result.data);
+							return NULL;
+						}
+						sp++;
+
+						/*
+						 * This needs to use a placeholder to not modify the
+						 * input with the conversion done via
+						 * make_native_path().
+						 */
+						nativePath = pstrdup(xlogpath);
+						make_native_path(nativePath);
+						appendStringInfoString(&result,
+											   nativePath);
+						pfree(nativePath);
+						break;
+					}
+				case 'f':
+					/* %f: filename of desired file */
+					if (xlogfname == NULL)
+					{
+						pfree(result.data);
+						return NULL;
+					}
+					sp++;
+					appendStringInfoString(&result, xlogfname);
+					break;
+				case 'r':
+					/* %r: filename of last restartpoint */
+					if (lastRestartPointFname == NULL)
+					{
+						pfree(result.data);
+						return NULL;
+					}
+					sp++;
+					appendStringInfoString(&result,
+										   lastRestartPointFname);
+					break;
+				case 'c':
+					/* GPDB: %c: contentId of segment */
+					Assert(GpIdentity.segindex != UNINITIALIZED_GP_IDENTITY_VALUE);
+					sp++;
+					pg_ltoa(GpIdentity.segindex, contentid);
+					appendStringInfoString(&result, contentid);
+					break;
+				case '%':
+					/* convert %% to a single % */
+					sp++;
+					appendStringInfoChar(&result, *sp);
+					break;
+				default:
+					/* otherwise treat the % as not special */
+					appendStringInfoChar(&result, *sp);
+					break;
+			}
+		}
+		else
+		{
+			appendStringInfoChar(&result, *sp);
+		}
+	}
+
+	return result.data;
+}

--- a/src/include/common/archive.h
+++ b/src/include/common/archive.h
@@ -1,0 +1,21 @@
+/*-------------------------------------------------------------------------
+ *
+ * archive.h
+ *	  Common WAL archive routines
+ *
+ * Portions Copyright (c) 1996-2020, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * src/include/common/archive.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef ARCHIVE_H
+#define ARCHIVE_H
+
+extern char *BuildRestoreCommand(const char *restoreCommand,
+								 const char *xlogpath,	/* %p */
+								 const char *xlogfname, /* %f */
+								 const char *lastRestartPointFname);	/* %r */
+
+#endif							/* ARCHIVE_H */

--- a/src/tools/msvc/Mkvcbuild.pm
+++ b/src/tools/msvc/Mkvcbuild.pm
@@ -79,6 +79,7 @@ sub mkvcbuild
 	push(@pgportfiles, 'rint.c') if ($vsVersion < '12.00');
 
 	our @pgcommonallfiles = qw(
+	  archive.c
 	  base64.c exec.c pgfnames.c psprintf.c relpath.c rmtree.c
 	  saslprep.c scram-common.c string.c unicode_norm.c username.c wait_error.c);
 


### PR DESCRIPTION
restore_command has only been used until now by the backend, but there is a pending patch for pg_rewind to make use of that in the frontend.

Author: Alexey Kondratov
Reviewed-by: Andrey Borodin, Andres Freund, Alvaro Herrera, Alexander Korotkov, Michael Paquier
Discussion: https://postgr.es/m/a3acff50-5a0d-9a2c-b3b2-ee36168955c1@postgrespro.ru

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
