### PR TITLE
Refactor logic to remove trailing CR/LF characters from strings

### DIFF
--- a/contrib/pg_upgrade/option.c
+++ b/contrib/pg_upgrade/option.c
@@ -21,6 +21,11 @@
 #include <io.h>
 #endif
 
+#include "getopt_long.h"
+#include "common/string.h"
+
+#include "pg_upgrade.h"
+
 
 static void usage(void);
 static void check_required_directory(char **dirpath,
@@ -410,9 +415,8 @@ adjust_data_dir(ClusterInfo *cluster)
 
 	pclose(output);
 
-	/* Remove trailing newline */
-	if (strchr(cmd_output, '\n') != NULL)
-		*strchr(cmd_output, '\n') = '\0';
+	/* strip trailing newline and carriage return */
+	(void) pg_strip_crlf(cmd_output);
 
 	cluster->pgdata = pg_strdup(cmd_output);
 
@@ -471,10 +475,9 @@ get_sock_dir(ClusterInfo *cluster, bool live_check)
 					sscanf(line, "%hu", &old_cluster.port);
 				if (lineno == LOCK_FILE_LINE_SOCKET_DIR)
 				{
+					/* strip trailing newline and carriage return */
 					cluster->sockdir = pg_strdup(line);
-					/* strip off newline */
-					if (strchr(cluster->sockdir, '\n') != NULL)
-						*strchr(cluster->sockdir, '\n') = '\0';
+					(void) pg_strip_crlf(cluster->sockdir);
 				}
 			}
 			fclose(fp);

--- a/src/bin/pg_ctl/pg_ctl.c
+++ b/src/bin/pg_ctl/pg_ctl.c
@@ -36,6 +36,8 @@
 #include <sys/resource.h>
 #endif
 
+#include "catalog/pg_control.h"
+#include "common/string.h"
 #include "getopt_long.h"
 #include "miscadmin.h"
 
@@ -2357,9 +2359,8 @@ adjust_data_dir(void)
 	pclose(fd);
 	free(my_exec_path);
 
-	/* Remove trailing newline */
-	if (strchr(filename, '\n') != NULL)
-		*strchr(filename, '\n') = '\0';
+	/* strip trailing newline and carriage return */
+	(void) pg_strip_crlf(filename);
 
 	free(pg_data);
 	pg_data = pg_strdup(filename);

--- a/src/bin/pg_resetxlog/pg_resetxlog.c
+++ b/src/bin/pg_resetxlog/pg_resetxlog.c
@@ -53,6 +53,7 @@
 #include "catalog/catversion.h"
 #include "catalog/pg_control.h"
 #include "common/fe_memutils.h"
+#include "common/string.h"
 #include "storage/large_object.h"
 #include "pg_getopt.h"
 
@@ -576,7 +577,6 @@ CheckDataVersion(void)
 	const char *ver_file = "PG_VERSION";
 	FILE	   *ver_fd;
 	char		rawline[64];
-	int			len;
 
 	if ((ver_fd = fopen(ver_file, "r")) == NULL)
 	{
@@ -601,14 +601,8 @@ CheckDataVersion(void)
 		exit(1);
 	}
 
-	/* remove trailing newline, handling Windows newlines as well */
-	len = strlen(rawline);
-	if (len > 0 && rawline[len - 1] == '\n')
-	{
-		rawline[--len] = '\0';
-		if (len > 0 && rawline[len - 1] == '\r')
-			rawline[--len] = '\0';
-	}
+	/* strip trailing newline and carriage return */
+	(void) pg_strip_crlf(rawline);
 
 	if (strcmp(rawline, PG_MAJORVERSION) != 0)
 	{

--- a/src/bin/psql/prompt.c
+++ b/src/bin/psql/prompt.c
@@ -22,6 +22,7 @@
 #include "prompt.h"
 #include "settings.h"
 
+#include "common/string.h"
 
 /*--------------------------
  * get_prompt
@@ -256,8 +257,10 @@ get_prompt(promptStatus_t status)
 								buf[0] = '\0';
 							pclose(fd);
 						}
-						if (strlen(buf) > 0 && buf[strlen(buf) - 1] == '\n')
-							buf[strlen(buf) - 1] = '\0';
+
+						/* strip trailing newline and carriage return */
+						(void) pg_strip_crlf(buf);
+
 						free(file);
 						p += cmdend + 1;
 						break;

--- a/src/common/string.c
+++ b/src/common/string.c
@@ -41,3 +41,74 @@ pg_str_endswith(const char *str, const char *end)
 	str += slen - elen;
 	return strcmp(str, end) == 0;
 }
+
+
+/*
+ * strtoint --- just like strtol, but returns int not long
+ */
+int
+strtoint(const char * str, char ** endptr, int base)
+{
+	long		val;
+
+	val = strtol(str, endptr, base);
+	if (val != (int) val)
+		errno = ERANGE;
+	return (int) val;
+}
+
+
+/*
+ * pg_clean_ascii -- Replace any non-ASCII chars with a '?' char
+ *
+ * Modifies the string passed in which must be '\0'-terminated.
+ *
+ * This function exists specifically to deal with filtering out
+ * non-ASCII characters in a few places where the client can provide an almost
+ * arbitrary string (and it isn't checked to ensure it's a valid username or
+ * database name or similar) and we don't want to have control characters or other
+ * things ending up in the log file where server admins might end up with a
+ * messed up terminal when looking at them.
+ *
+ * In general, this function should NOT be used- instead, consider how to handle
+ * the string without needing to filter out the non-ASCII characters.
+ *
+ * Ultimately, we'd like to improve the situation to not require stripping out
+ * all non-ASCII but perform more intelligent filtering which would allow UTF or
+ * similar, but it's unclear exactly what we should allow, so stick to ASCII only
+ * for now.
+ */
+void
+pg_clean_ascii(char *str)
+{
+	/* Only allow clean ASCII chars in the string */
+	char	   *p;
+
+	for (p = str; *p != '\0'; p++)
+	{
+		if (*p < 32 || *p > 126)
+			*p = '?';
+	}
+}
+
+
+/*
+ * pg_strip_crlf -- Remove any trailing newline and carriage return
+ *
+ * Removes any trailing newline and carriage return characters (\r on
+ * Windows) in the input string, zero-terminating it.
+ *
+ * The passed in string must be zero-terminated.  This function returns
+ * the new length of the string.
+ */
+int
+pg_strip_crlf(char *str)
+{
+	int			len = strlen(str);
+
+	while (len > 0 && (str[len - 1] == '\n' ||
+					   str[len - 1] == '\r'))
+		str[--len] = '\0';
+
+	return len;
+}

--- a/src/include/common/string.h
+++ b/src/include/common/string.h
@@ -11,5 +11,9 @@
 #define COMMON_STRING_H
 
 extern bool pg_str_endswith(const char *str, const char *end);
+extern int	strtoint(const char * str, char ** endptr,
+					 int base);
+extern void pg_clean_ascii(char *str);
+extern int	pg_strip_crlf(char *str);
 
 #endif   /* COMMON_STRING_H */


### PR DESCRIPTION
b654714 has reworked the way trailing CR/LF characters are removed from strings.  This commit introduces a new routine in common/string.c and refactors the code so as the logic is in a single place, mostly.

Author: Michael Paquier
Reviewed-by: Bruce Momjian
Discussion: https://postgr.es/m/20190801031820.GF29334@paquier.xyz

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
