### PR TITLE
cherry-pick zstd fix + add guc for off changes (#158)

### DIFF
--- a/configure
+++ b/configure
@@ -13025,50 +13025,50 @@ fi
 fi
 
 if test "$with_zstd" = yes; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ZSTD_compressCCtx in -lzstd" >&5
-$as_echo_n "checking for ZSTD_compressCCtx in -lzstd... " >&6; }
-if ${ac_cv_lib_zstd_ZSTD_compressCCtx+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for ZSTD_compressCCtx in -l:libzstd.a" >&5
+printf %s "checking for ZSTD_compressCCtx in -l:libzstd.a... " >&6; }
+if test ${ac_cv_lib__libzstd_a_ZSTD_compressCCtx+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lzstd  $LIBS"
+LIBS="-l:libzstd.a  $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
-#ifdef __cplusplus
-extern "C"
-#endif
 char ZSTD_compressCCtx ();
 int
-main ()
+main (void)
 {
 return ZSTD_compressCCtx ();
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_zstd_ZSTD_compressCCtx=yes
-else
-  ac_cv_lib_zstd_ZSTD_compressCCtx=no
+if ac_fn_c_try_link "$LINENO"
+then :
+  ac_cv_lib__libzstd_a_ZSTD_compressCCtx=yes
+else $as_nop
+  ac_cv_lib__libzstd_a_ZSTD_compressCCtx=no
 fi
-rm -f core conftest.err conftest.$ac_objext \
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
     conftest$ac_exeext conftest.$ac_ext
 LIBS=$ac_check_lib_save_LIBS
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_zstd_ZSTD_compressCCtx" >&5
-$as_echo "$ac_cv_lib_zstd_ZSTD_compressCCtx" >&6; }
-if test "x$ac_cv_lib_zstd_ZSTD_compressCCtx" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_LIBZSTD 1
-_ACEOF
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib__libzstd_a_ZSTD_compressCCtx" >&5
+printf "%s\n" "$ac_cv_lib__libzstd_a_ZSTD_compressCCtx" >&6; }
+if test "x$ac_cv_lib__libzstd_a_ZSTD_compressCCtx" = xyes
+then :
 
-  LIBS="-lzstd $LIBS"
+	LIBS="-l:libzstd.a $LIBS"
 
-else
+printf "%s\n" "#define HAVE_LIBZSTD 1" >>confdefs.h
+
+
+else $as_nop
   as_fn_error $? "zstd library not found
 If you have libzstd already installed, see config.log for details on the
 failure.  It is possible the compiler isn't looking in the proper directory.

--- a/configure.in
+++ b/configure.in
@@ -1452,7 +1452,7 @@ Use --without-zlib to disable zlib support.])])
 fi
 
 if test "$with_zstd" = yes; then
-  AC_CHECK_LIB(zstd, ZSTD_compressCCtx, [],
+  AC_CHECK_LIB(:libzstd.a, ZSTD_compressCCtx, [],
                [AC_MSG_ERROR([zstd library not found
 If you have libzstd already installed, see config.log for details on the
 failure.  It is possible the compiler isn't looking in the proper directory.

--- a/docker/test/run_tests.sh
+++ b/docker/test/run_tests.sh
@@ -75,7 +75,6 @@ gpconfig -c shared_preload_libraries -v yezzey
 if [ "${TEST_CGROUP}" = "true" ]; then
     gpconfig -c gp_resource_manager -v "group"
 fi
-
 gpstop -a -i && gpstart -a
 
 createdb $USER

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -159,7 +159,7 @@ bool		gp_enable_exchange_default_partition = false;
 int			dtx_phase2_retry_count = 0;
 bool		gp_log_suboverflow_statement = false;
 bool        gp_use_synchronize_seqscans_catalog_vacuum_full = false;
-
+bool 		gp_enable_zstd_memory_accounting = true;
 bool		log_dispatch_stats = false;
 bool		gp_keep_partition_children_locks = false;
 
@@ -3410,9 +3410,21 @@ struct config_bool ConfigureNamesBool_gp[] =
 		 NULL
 		},
 		&gp_use_synchronize_seqscans_catalog_vacuum_full,
+		true,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"gp_enable_zstd_memory_accounting", PGC_USERSET, COMPAT_OPTIONS_PREVIOUS,
+		 gettext_noop("Enables normal memory counting in zstd (not using malloc)"),
+		 NULL
+		},
+		&gp_enable_zstd_memory_accounting,
 		false,
 		NULL, NULL, NULL
 	},
+
+	
 
 	{
 		{"gp_external_fail_on_eof", PGC_USERSET, EXTERNAL_TABLES,

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -300,6 +300,7 @@ extern bool gp_enable_exchange_default_partition;
 extern int  dtx_phase2_retry_count;
 extern bool gp_log_suboverflow_statement;
 extern bool gp_use_synchronize_seqscans_catalog_vacuum_full;
+extern bool gp_enable_zstd_memory_accounting;
 
 /* WAL replication debug gucs */
 extern bool debug_walrepl_snd;

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -131,3 +131,4 @@
 		"gp_resgroup_debug_wait_queue",
 		"gp_log_resqueue_priority_sleep_time",
 		"yc_allow_copy_to_program",
+		"gp_enable_zstd_memory_accounting",


### PR DESCRIPTION
* ADBDEV-3774 Use custom allocators for zstd (#566)

gpdb uses zstd to compress workfiles, but it can't control memory allocation within zstd. Meanwhile, zstd allocates as much memory as it needs which results in ambiguous error message in a case of memory exhaustion and can make OOM killer stop gpdb processes with force. This patch forces zstd to use our custom allocator which can keep track of allocated memory. Since this zstd feature is experimental and its api can change, we also had to link zstd statically.

* Add GUC
