### PR TITLE
drop n_mod_since_analyze

### DIFF
--- a/src/backend/commands/analyzefuncs.c
+++ b/src/backend/commands/analyzefuncs.c
@@ -16,7 +16,7 @@
 #include "utils/snapmgr.h"
 #include "miscadmin.h"
 #include "funcapi.h"
-
+#include "pgstat.h"
 /**
  * Statistics related parameters.
  */
@@ -178,6 +178,7 @@ gp_acquire_sample_rows_int(FunctionCallInfo fcinfo, Oid relOid,int32 targrows,bo
 
 		ctx->index = 0;
 		ctx->summary_sent = false;
+		pgstat_report_analyze(onerel, totalrows, totaldeadrows, true);
 
 		MemoryContextSwitchTo(oldcontext);
 	}


### PR DESCRIPTION
In Greenplum, analyze throws gp_acquire_sample_rows into segments. Assuming gp_aquire_sample_rows as analyze, we reset the counter n_mod_since_analyze, saying that we have done the analyze.