### PR TITLE
Change ownership back to gpadmin

### DIFF
--- a/.github/workflows/build-gpdb.yml
+++ b/.github/workflows/build-gpdb.yml
@@ -672,6 +672,9 @@ jobs:
               exit 1
             fi
 
+            # Change ownership back to gpadmin - it is needed for future tests
+            chown -R gpadmin:gpadmin /opt/greenplum-db-6
+
             echo "Installation completed successfully"
             dpkg-query -s greenplum-db-6
             echo "Installed files:"


### PR DESCRIPTION
We need gpadmin ownership of /opt/greenplum-db-6 in order to install new binaries for testing.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
