### PR TITLE
Add fts maintenance mode for cluster/DC maintenance

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -149,6 +149,17 @@ int gp_fts_mark_mirror_down_grace_period = 30;
 int			gp_fts_replication_attempt_count = 10;
 
 /*
+ * Turn FTS off completely.
+ * Useful when cluster array has or is about to have known hardware issues which
+ * are a) temporary and b) likely will lead to a broken gp_segment_configuration.
+ * E.g, a whole DC went down and is about to restart or network temporarily became
+ * unreliable. In those situations we might opt to preserve gp_segment_configuration
+ * in the last known stable state instead of breaking it and manually recovering
+ * afterwards.
+*/
+bool		gp_fts_maintenance = false;
+
+/*
  * Polling interval for the dtx recovery. Checking in dtx recovery starts every
  * time this expires.
  */

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -344,11 +344,13 @@ void FtsLoop()
 		if (SIMPLE_FAULT_INJECTOR("fts_probe") == FaultInjectorTypeSkip)
 			skipFtsProbe = true;
 
-		if (skipFtsProbe || !has_mirrors)
+		if (skipFtsProbe || !has_mirrors || gp_fts_maintenance) 
 		{
 			elogif(gp_log_fts >= GPVARS_VERBOSITY_VERBOSE, LOG,
 				   "skipping FTS probes due to %s",
-				   !has_mirrors ? "no mirrors" : "fts_probe fault");
+				   skipFtsProbe 
+				   	? "fts_probe fault" 
+					: (gp_fts_maintenance ? "fts maintenance mode" : "no mirrors"));
 
 		}
 		else

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3447,7 +3447,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 
 		{
 		{"gp_fts_maintenance", PGC_SIGHUP, GP_ARRAY_TUNING,
-		 gettext_noop("Don't run FTS probes, the clustar ARRAY has known issues"),
+		 gettext_noop("Don't run FTS probes, the cluster ARRAY has known issues"),
 		 NULL
 		},
 		&gp_fts_maintenance,

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3445,6 +3445,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 		NULL, NULL, NULL
 	},
 
+		{
+		{"gp_fts_maintenance", PGC_SIGHUP, GP_ARRAY_TUNING,
+		 gettext_noop("Don't run FTS probes, the clustar ARRAY has known issues"),
+		 NULL
+		},
+		&gp_fts_maintenance,
+		false,
+		NULL, NULL, NULL
+	},
+
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, false, NULL, NULL

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -315,6 +315,7 @@ extern int	gp_fts_probe_timeout; /* GUC var - specifies probe timeout for FTS */
 extern int	gp_fts_probe_interval; /* GUC var - specifies polling interval for FTS */
 extern int	gp_fts_mark_mirror_down_grace_period;
 extern int	gp_fts_replication_attempt_count; /* GUC var - specifies replication max attempt count for FTS */
+extern bool gp_fts_maintenance; /* GUC var - turns off FTS for cluster maintenance */
 extern int	gp_dtx_recovery_interval;
 extern int	gp_dtx_recovery_prepared_period;
 

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -204,6 +204,7 @@
 		"gp_fts_retry_interval",
 		"gp_fts_probe_timeout",
 		"gp_fts_replication_attempt_count",
+		"gp_fts_maintenance",
 		"gp_gang_creation_retry_count",
 		"gp_gang_creation_retry_non_recovery",
 		"gp_gang_creation_retry_timer",

--- a/src/test/isolation2/expected/fts_maintenance.out
+++ b/src/test/isolation2/expected/fts_maintenance.out
@@ -1,0 +1,117 @@
+-- Faster FTS probes
+-- Let FTS detect/declare failure sooner
+!\retcode gpconfig -c gp_fts_probe_interval -v 10 --masteronly;
+(exited with code 0)
+!\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;
+(exited with code 0)
+
+!\retcode gpconfig -c gp_fts_maintenance -v on --skipvalidation --masteronly;
+(exited with code 0)
+!\retcode gpstop -u;
+(exited with code 0)
+
+include: helpers/server_helpers.sql;
+CREATE
+
+create table fts_mnt_tbl(i integer);
+CREATE
+insert into fts_mnt_tbl select i from generate_series(1, 100)i;
+INSERT 100
+
+-- no segment down.
+select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 0     
+(1 row)
+
+-- Kill a mirror segment
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=1), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+-- Take a nap to make sure FTS would notice a failed segment
+select pg_sleep(0.2);
+ pg_sleep 
+----------
+          
+(1 row)
+
+-- Still no segmens down
+select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 0     
+(1 row)
+
+-- Even after a manual probe?
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 0     
+(1 row)
+
+-- Try read - non blocking
+1:select count(*) from fts_mnt_tbl;
+ count 
+-------
+ 100   
+(1 row)
+
+-- Try write - blocking
+1&:insert into fts_mnt_tbl select i from generate_series(101, 200)i;  <waiting ...>
+
+-- Try recovereseg - noop
+!\retcode gprecoverseg -a;
+(exited with code 0)
+
+-- Still no segmens down
+select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 0     
+(1 row)
+
+-- Still blocking
+2&:insert into fts_mnt_tbl select i from generate_series(201, 300)i;  <waiting ...>
+
+-- Turn maintenance off
+!\retcode gpconfig -c gp_fts_maintenance -v off --skipvalidation --masteronly;
+(exited with code 0)
+!\retcode gpstop -u;
+(exited with code 1)
+
+-- writes unblock
+1<:  <... completed>
+INSERT 100
+2<:  <... completed>
+INSERT 100
+
+-- gpsegment configuration changes
+select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 1     
+(1 row)
+
+-- gpsecoverseg works
+!\retcode gprecoverseg -a;
+(exited with code 0)
+
+-- gpsegment configuration changes
+select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 0     
+(1 row)
+
+!\retcode gprecoverseg -ar;
+(exited with code 0)
+

--- a/src/test/isolation2/expected/fts_maintenance.out
+++ b/src/test/isolation2/expected/fts_maintenance.out
@@ -4,7 +4,8 @@
 (exited with code 0)
 !\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;
 (exited with code 0)
-
+!\retcode gpconfig -c statement_timeout -v 2min;
+(exited with code 0)
 !\retcode gpconfig -c gp_fts_maintenance -v on --skipvalidation --masteronly;
 (exited with code 0)
 !\retcode gpstop -u;
@@ -13,10 +14,17 @@
 include: helpers/server_helpers.sql;
 CREATE
 
+-- Helper function
+CREATE or REPLACE FUNCTION wait_until_segments_are_down(num_segs int) RETURNS bool AS $$ declare retries int; /* in func */ begin /* in func */ retries := 40; /* in func */ loop /* in func */ if (select count(*) = num_segs from gp_segment_configuration where status = 'd') then /* in func */ return true; /* in func */ end if; /* in func */ if retries <= 0 then /* in func */ return false; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ retries := retries - 1; /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql execute on master;
+CREATE
+
 create table fts_mnt_tbl(i integer);
 CREATE
 insert into fts_mnt_tbl select i from generate_series(1, 100)i;
 INSERT 100
+
+-- CASE#1: mirror get's down when fts is in maintenance and is recovered
+-- when maintenance is removed
 
 -- no segment down.
 select count(*) from gp_segment_configuration where status = 'd';
@@ -33,10 +41,10 @@ select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' a
 (1 row)
 
 -- Take a nap to make sure FTS would notice a failed segment
-select pg_sleep(0.2);
- pg_sleep 
-----------
-          
+select wait_until_segments_are_down(1);
+ wait_until_segments_are_down 
+------------------------------
+ f                            
 (1 row)
 
 -- Still no segmens down
@@ -66,7 +74,7 @@ select count(*) from gp_segment_configuration where status = 'd';
 (1 row)
 
 -- Try write - blocking
-1&:insert into fts_mnt_tbl select i from generate_series(101, 200)i;  <waiting ...>
+2&:insert into fts_mnt_tbl select i from generate_series(101, 200)i;  <waiting ...>
 
 -- Try recovereseg - noop
 !\retcode gprecoverseg -a;
@@ -80,7 +88,7 @@ select count(*) from gp_segment_configuration where status = 'd';
 (1 row)
 
 -- Still blocking
-2&:insert into fts_mnt_tbl select i from generate_series(201, 300)i;  <waiting ...>
+3&:insert into fts_mnt_tbl select i from generate_series(201, 300)i;  <waiting ...>
 
 -- Turn maintenance off
 !\retcode gpconfig -c gp_fts_maintenance -v off --skipvalidation --masteronly;
@@ -89,9 +97,9 @@ select count(*) from gp_segment_configuration where status = 'd';
 (exited with code 1)
 
 -- writes unblock
-1<:  <... completed>
-INSERT 100
 2<:  <... completed>
+INSERT 100
+3<:  <... completed>
 INSERT 100
 
 -- gpsegment configuration changes
@@ -112,6 +120,288 @@ select count(*) from gp_segment_configuration where status = 'd';
  0     
 (1 row)
 
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>
+
+-- CASE#2: mirror get's down when fts is in maintenance and is successfully recovered
+-- with cluster restart
 !\retcode gprecoverseg -ar;
 (exited with code 0)
+!\retcode gpconfig -c gp_fts_maintenance -v on --skipvalidation --masteronly;
+(exited with code 0)
+!\retcode gpstop -u;
+(exited with code 0)
 
+-- Kill a mirror segment
+select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=1), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+-- Take a nap to make sure FTS would notice a failed segment
+select wait_until_segments_are_down(1);
+ wait_until_segments_are_down 
+------------------------------
+ f                            
+(1 row)
+
+-- Lets check that after restart our cluster is working fine
+!\retcode gpstop -ra -M fast;
+(exited with code 0)
+
+-- both operations should be not blocking
+4:select count(*) from fts_mnt_tbl;
+ count 
+-------
+ 300   
+(1 row)
+5:insert into fts_mnt_tbl select i from generate_series(301, 400)i;
+INSERT 100
+
+6:show gp_fts_maintenance;
+ gp_fts_maintenance 
+--------------------
+ on                 
+(1 row)
+
+-- CASE#3: mirror get's down when fts is in maintenance and is restarted manually
+
+-- Kill a mirror segment
+7:select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=1), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+-- Take a nap to make sure FTS would notice a failed segment
+8:select wait_until_segments_are_down(1);
+ wait_until_segments_are_down 
+------------------------------
+ f                            
+(1 row)
+9:select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- should block
+10&:insert into fts_mnt_tbl select i from generate_series(401, 500)i;  <waiting ...>
+
+-- revive the mirror
+11:select pg_ctl_start(datadir, port) from gp_segment_configuration where role = 'm' and content = 1;
+ pg_ctl_start     
+------------------
+ server starting
+ 
+(1 row)
+
+-- should unblock
+10<:  <... completed>
+INSERT 100
+
+4q: ... <quitting>
+5q: ... <quitting>
+6q: ... <quitting>
+7q: ... <quitting>
+8q: ... <quitting>
+9q: ... <quitting>
+10q: ... <quitting>
+11q: ... <quitting>
+
+-- CASE#4: mirror is killed when fts is in maintenance and cannot start. GP stil does not mark it as down
+-- in gp_segment_configuration
+
+-- Kill a mirror segment
+12:select pg_ctl((select datadir from gp_segment_configuration c where c.role='m' and c.content=1), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+-- Guarantee that it won't start. Surely there is a better way which I didn't find
+!\retcode rm -r `psql -Aqt -d postgres -c "select datadir from gp_segment_configuration where role = 'm' and content=1"` 
+13:select gp_request_fts_probe_scan();
+(exited with code 2)
+
+-- gp segment configuration does not change
+14:select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 0     
+(1 row)
+
+-- Lets check that after restart our maintenance is working fine
+!\retcode gpstop -ra -M fast;
+(exited with code 2)
+
+-- gp segment configuration still does not change
+15:select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 0     
+(1 row)
+
+-- Try read - non blocking
+16:select count(*) from fts_mnt_tbl;
+ count 
+-------
+ 500   
+(1 row)
+
+-- Try write - blocking
+17&:insert into fts_mnt_tbl select i from generate_series(501, 600)i;  <waiting ...>
+
+-- noop
+!\retcode gprecoverseg -Fa;
+(exited with code 0)
+
+-- Turn maintenance off
+!\retcode gpconfig -c gp_fts_maintenance -v off --skipvalidation --masteronly;
+(exited with code 0)
+!\retcode gpstop -u;
+(exited with code 1)
+
+-- should recover
+17<:  <... completed>
+INSERT 100
+-- fts detected the failed segment
+19:select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 1     
+(1 row)
+!\retcode gprecoverseg -Fa;
+(exited with code 0)
+
+-- all good
+20:select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 0     
+(1 row)
+
+12q: ... <quitting>
+13q: FAILED:  Sessions not started cannot be quit
+14q: ... <quitting>
+15q: ... <quitting>
+16q: ... <quitting>
+17q: ... <quitting>
+19q: ... <quitting>
+20q: ... <quitting>
+
+-- CASE#5: primary get's down when fts is in maintenance and reads/writes get errors. gprecoverseg only fixes
+-- the problem when fts maintenance is lifted
+
+!\retcode gpconfig -c gp_fts_maintenance -v on --skipvalidation --masteronly;
+(exited with code 0)
+!\retcode gpstop -u;
+(exited with code 0)
+
+-- no segment down.
+21:select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 0     
+(1 row)
+
+-- Kill a mirror segment
+22:select pg_ctl((select datadir from gp_segment_configuration c where c.role='p' and c.content=1), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+-- Take a nap to make sure FTS would notice a failed segment
+23:select wait_until_segments_are_down(1);
+ wait_until_segments_are_down 
+------------------------------
+ f                            
+(1 row)
+
+-- Still no segmens down
+24:select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 0     
+(1 row)
+
+-- Try read - non blocking, failing
+25:select count(*) from fts_mnt_tbl;
+ERROR:  failed to acquire resources on one or more segments
+DETAIL:  could not connect to server: Connection refused
+	Is the server running on host "127.0.1.1" and accepting
+	TCP/IP connections on port 6003?
+ (seg1 127.0.1.1:6003)
+
+-- Try write - non blocking, failing
+26:insert into fts_mnt_tbl select i from generate_series(601, 700)i;
+ERROR:  failed to acquire resources on one or more segments
+DETAIL:  could not connect to server: Connection refused
+	Is the server running on host "127.0.1.1" and accepting
+	TCP/IP connections on port 6003?
+ (seg1 127.0.1.1:6003)
+
+-- Try recovereseg - noop
+!\retcode gprecoverseg -a;
+(exited with code 2)
+
+-- Still no segmens down
+27:select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 0     
+(1 row)
+
+-- Still failing
+28:select count(*) from fts_mnt_tbl;
+ERROR:  failed to acquire resources on one or more segments
+DETAIL:  could not connect to server: Connection refused
+	Is the server running on host "127.0.1.1" and accepting
+	TCP/IP connections on port 6003?
+ (seg1 127.0.1.1:6003)
+
+-- Turn maintenance off
+!\retcode gpconfig -c gp_fts_maintenance -v off --skipvalidation --masteronly;
+(exited with code 0)
+!\retcode gpstop -u;
+(exited with code 1)
+
+-- gpsegment configuration changes
+29:select wait_until_segments_are_down(1);
+ wait_until_segments_are_down 
+------------------------------
+ t                            
+(1 row)
+30:select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 1     
+(1 row)
+
+-- gpsecoverseg works
+!\retcode gprecoverseg -Fa;
+(exited with code 0)
+!\retcode gprecoverseg -ra;
+(exited with code 0)
+31:select count(*) from gp_segment_configuration where status = 'd';
+ count 
+-------
+ 0     
+(1 row)
+
+32:drop table fts_mnt_tbl;
+DROP
+
+!\retcode gpconfig -r gp_fts_probe_retries --masteronly;
+(exited with code 0)
+!\retcode gpconfig -r gp_fts_probe_interval --skipvalidation --masteronly;
+(exited with code 0)
+!\retcode gpconfig -r gp_fts_maintenance --skipvalidation --masteronly;
+(exited with code 0)
+!\retcode gpconfig -r statement_timeout;
+(exited with code 0)
+!\retcode gpstop -u;
+(exited with code 0)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -259,6 +259,7 @@ test: segwalrep/hintbit_throttle
 test: fts_manual_probe
 test: fts_session_reset
 test: fts_segment_reset
+test: fts_maintenance
 
 # Reindex tests
 test: reindex/abort_reindex

--- a/src/test/isolation2/sql/fts_maintenance.sql
+++ b/src/test/isolation2/sql/fts_maintenance.sql
@@ -2,14 +2,38 @@
 -- Let FTS detect/declare failure sooner 
 !\retcode gpconfig -c gp_fts_probe_interval -v 10 --masteronly;
 !\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;
-
+!\retcode gpconfig -c statement_timeout -v 2min;
 !\retcode gpconfig -c gp_fts_maintenance -v on --skipvalidation --masteronly;
 !\retcode gpstop -u;
 
 include: helpers/server_helpers.sql;
 
+-- Helper function
+CREATE or REPLACE FUNCTION wait_until_segments_are_down(num_segs int)
+RETURNS bool AS
+$$
+declare
+retries int; /* in func */
+begin /* in func */
+  retries := 40; /* in func */
+  loop /* in func */
+    if (select count(*) = num_segs from gp_segment_configuration where status = 'd') then /* in func */
+      return true; /* in func */
+    end if; /* in func */
+    if retries <= 0 then /* in func */
+      return false; /* in func */
+    end if; /* in func */
+    perform pg_sleep(0.1); /* in func */
+    retries := retries - 1; /* in func */
+  end loop; /* in func */
+end; /* in func */
+$$ language plpgsql execute on master;
+
 create table fts_mnt_tbl(i integer);
 insert into fts_mnt_tbl select i from generate_series(1, 100)i;
+
+-- CASE#1: mirror get's down when fts is in maintenance and is recovered
+-- when maintenance is removed
 
 -- no segment down.
 select count(*) from gp_segment_configuration where status = 'd';
@@ -19,7 +43,7 @@ select pg_ctl((select datadir from gp_segment_configuration c
 where c.role='m' and c.content=1), 'stop');
 
 -- Take a nap to make sure FTS would notice a failed segment
-select pg_sleep(0.2);
+select wait_until_segments_are_down(1);
 
 -- Still no segmens down
 select count(*) from gp_segment_configuration where status = 'd';
@@ -32,7 +56,7 @@ select count(*) from gp_segment_configuration where status = 'd';
 1:select count(*) from fts_mnt_tbl;
 
 -- Try write - blocking
-1&:insert into fts_mnt_tbl select i from generate_series(101, 200)i;
+2&:insert into fts_mnt_tbl select i from generate_series(101, 200)i;
 
 -- Try recovereseg - noop
 !\retcode gprecoverseg -a;
@@ -41,15 +65,15 @@ select count(*) from gp_segment_configuration where status = 'd';
 select count(*) from gp_segment_configuration where status = 'd';
 
 -- Still blocking
-2&:insert into fts_mnt_tbl select i from generate_series(201, 300)i;
+3&:insert into fts_mnt_tbl select i from generate_series(201, 300)i;
 
 -- Turn maintenance off
 !\retcode gpconfig -c gp_fts_maintenance -v off --skipvalidation --masteronly;
 !\retcode gpstop -u;
 
 -- writes unblock
-1<:
 2<:
+3<:
 
 -- gpsegment configuration changes
 select count(*) from gp_segment_configuration where status = 'd';
@@ -60,5 +84,163 @@ select count(*) from gp_segment_configuration where status = 'd';
 -- gpsegment configuration changes
 select count(*) from gp_segment_configuration where status = 'd';
 
-!\retcode gprecoverseg -ar;
+1q:
+2q:
+3q:
 
+-- CASE#2: mirror get's down when fts is in maintenance and is successfully recovered
+-- with cluster restart
+!\retcode gprecoverseg -ar;
+!\retcode gpconfig -c gp_fts_maintenance -v on --skipvalidation --masteronly;
+!\retcode gpstop -u;
+
+-- Kill a mirror segment
+select pg_ctl((select datadir from gp_segment_configuration c
+where c.role='m' and c.content=1), 'stop');
+
+-- Take a nap to make sure FTS would notice a failed segment
+select wait_until_segments_are_down(1);
+
+-- Lets check that after restart our cluster is working fine
+!\retcode gpstop -ra -M fast;
+
+-- both operations should be not blocking
+4:select count(*) from fts_mnt_tbl;
+5:insert into fts_mnt_tbl select i from generate_series(301, 400)i;
+
+6:show gp_fts_maintenance;
+
+-- CASE#3: mirror get's down when fts is in maintenance and is restarted manually
+
+-- Kill a mirror segment
+7:select pg_ctl((select datadir from gp_segment_configuration c
+where c.role='m' and c.content=1), 'stop');
+
+-- Take a nap to make sure FTS would notice a failed segment
+8:select wait_until_segments_are_down(1);
+9:select gp_request_fts_probe_scan();
+
+-- should block
+10&:insert into fts_mnt_tbl select i from generate_series(401, 500)i;
+
+-- revive the mirror
+11:select pg_ctl_start(datadir, port) from gp_segment_configuration where role = 'm' and content = 1;
+
+-- should unblock
+10<:
+
+4q:
+5q:
+6q:
+7q:
+8q:
+9q:
+10q:
+11q:
+
+-- CASE#4: mirror is killed when fts is in maintenance and cannot start. GP stil does not mark it as down
+-- in gp_segment_configuration
+
+-- Kill a mirror segment
+12:select pg_ctl((select datadir from gp_segment_configuration c
+where c.role='m' and c.content=1), 'stop');
+
+-- Guarantee that it won't start. Surely there is a better way which I didn't find
+!\retcode rm -r `psql -Aqt -d postgres -c "select datadir from gp_segment_configuration where role = 'm' and content=1"`
+
+13:select gp_request_fts_probe_scan();
+
+-- gp segment configuration does not change
+14:select count(*) from gp_segment_configuration where status = 'd';
+
+-- Lets check that after restart our maintenance is working fine
+!\retcode gpstop -ra -M fast;
+
+-- gp segment configuration still does not change
+15:select count(*) from gp_segment_configuration where status = 'd';
+
+-- Try read - non blocking
+16:select count(*) from fts_mnt_tbl;
+
+-- Try write - blocking
+17&:insert into fts_mnt_tbl select i from generate_series(501, 600)i;
+
+-- noop
+!\retcode gprecoverseg -Fa;
+
+-- Turn maintenance off
+!\retcode gpconfig -c gp_fts_maintenance -v off --skipvalidation --masteronly;
+!\retcode gpstop -u;
+
+-- should recover
+17<:
+-- fts detected the failed segment
+19:select count(*) from gp_segment_configuration where status = 'd';
+!\retcode gprecoverseg -Fa;
+
+-- all good
+20:select count(*) from gp_segment_configuration where status = 'd';
+
+12q:
+13q:
+14q:
+15q:
+16q:
+17q:
+19q:
+20q:
+
+-- CASE#5: primary get's down when fts is in maintenance and reads/writes get errors. gprecoverseg only fixes
+-- the problem when fts maintenance is lifted
+
+!\retcode gpconfig -c gp_fts_maintenance -v on --skipvalidation --masteronly;
+!\retcode gpstop -u;
+
+-- no segment down.
+21:select count(*) from gp_segment_configuration where status = 'd';
+
+-- Kill a mirror segment
+22:select pg_ctl((select datadir from gp_segment_configuration c
+where c.role='p' and c.content=1), 'stop');
+
+-- Take a nap to make sure FTS would notice a failed segment
+23:select wait_until_segments_are_down(1);
+
+-- Still no segmens down
+24:select count(*) from gp_segment_configuration where status = 'd';
+
+-- Try read - non blocking, failing
+25:select count(*) from fts_mnt_tbl;
+
+-- Try write - non blocking, failing
+26:insert into fts_mnt_tbl select i from generate_series(601, 700)i;
+
+-- Try recovereseg - noop
+!\retcode gprecoverseg -a;
+
+-- Still no segmens down
+27:select count(*) from gp_segment_configuration where status = 'd';
+
+-- Still failing
+28:select count(*) from fts_mnt_tbl;
+
+-- Turn maintenance off
+!\retcode gpconfig -c gp_fts_maintenance -v off --skipvalidation --masteronly;
+!\retcode gpstop -u;
+
+-- gpsegment configuration changes
+29:select wait_until_segments_are_down(1);
+30:select count(*) from gp_segment_configuration where status = 'd';
+
+-- gpsecoverseg works
+!\retcode gprecoverseg -Fa;
+!\retcode gprecoverseg -ra;
+31:select count(*) from gp_segment_configuration where status = 'd';
+
+32:drop table fts_mnt_tbl;
+
+!\retcode gpconfig -r gp_fts_probe_retries --masteronly;
+!\retcode gpconfig -r gp_fts_probe_interval --skipvalidation --masteronly;
+!\retcode gpconfig -r gp_fts_maintenance --skipvalidation --masteronly;
+!\retcode gpconfig -r statement_timeout;
+!\retcode gpstop -u;

--- a/src/test/isolation2/sql/fts_maintenance.sql
+++ b/src/test/isolation2/sql/fts_maintenance.sql
@@ -1,0 +1,64 @@
+-- Faster FTS probes
+-- Let FTS detect/declare failure sooner 
+!\retcode gpconfig -c gp_fts_probe_interval -v 10 --masteronly;
+!\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;
+
+!\retcode gpconfig -c gp_fts_maintenance -v on --skipvalidation --masteronly;
+!\retcode gpstop -u;
+
+include: helpers/server_helpers.sql;
+
+create table fts_mnt_tbl(i integer);
+insert into fts_mnt_tbl select i from generate_series(1, 100)i;
+
+-- no segment down.
+select count(*) from gp_segment_configuration where status = 'd';
+
+-- Kill a mirror segment
+select pg_ctl((select datadir from gp_segment_configuration c
+where c.role='m' and c.content=1), 'stop');
+
+-- Take a nap to make sure FTS would notice a failed segment
+select pg_sleep(0.2);
+
+-- Still no segmens down
+select count(*) from gp_segment_configuration where status = 'd';
+
+-- Even after a manual probe?
+select gp_request_fts_probe_scan();
+select count(*) from gp_segment_configuration where status = 'd';
+
+-- Try read - non blocking
+1:select count(*) from fts_mnt_tbl;
+
+-- Try write - blocking
+1&:insert into fts_mnt_tbl select i from generate_series(101, 200)i;
+
+-- Try recovereseg - noop
+!\retcode gprecoverseg -a;
+
+-- Still no segmens down
+select count(*) from gp_segment_configuration where status = 'd';
+
+-- Still blocking
+2&:insert into fts_mnt_tbl select i from generate_series(201, 300)i;
+
+-- Turn maintenance off
+!\retcode gpconfig -c gp_fts_maintenance -v off --skipvalidation --masteronly;
+!\retcode gpstop -u;
+
+-- writes unblock
+1<:
+2<:
+
+-- gpsegment configuration changes
+select count(*) from gp_segment_configuration where status = 'd';
+
+-- gpsecoverseg works
+!\retcode gprecoverseg -a;
+
+-- gpsegment configuration changes
+select count(*) from gp_segment_configuration where status = 'd';
+
+!\retcode gprecoverseg -ar;
+


### PR DESCRIPTION
This change adds a gp_fts_maintenance GUC and allows turning FTS off completely. Useful when expecting problems in DC or recovering from a DC failure.

When FTS is turned off, the failures are handled this way:

- a mirror failure will result in read-only cluster, but FTS won't change gp_segment_configuration. If a mirror[s] is started either with pg_ctl or with cluster restart, no gprecoverseg is needed - the cluster will just continue working as if nothing happened
- a primary segment failure results in cluster that is not available for both reading and writing. Again, no changed in gp_segment_configuration. Again, either restart or pg_ctl can start the failed segments and cluster will continue operating
- if there is a double fault during fts maintenance (i.e., mirror and primary with the same content are down), cluster can be fixed with either manual start of segments, or whole cluster restart. **HOWEVER** if double fault is still present during cluster start, gpstart will fail. Which is the expected begaviour. Again, no changes in gp_segment_configuration will occur.

The idea is that as soon as the infrastructure is stable, we can turn maintenance off and run gprecoverseg -Fa if necessary.