### PR TITLE
Add submit & done query info hooks for consistency

### DIFF
--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -463,10 +463,6 @@ ExecCreateTableAs(CreateTableAsStmt *stmt, const char *queryString,
 				GetResqueueName(GetResQueueId()),
 				GetResqueuePriority(GetResQueueId()));
 	}
-
-	/* GPDB hook for collecting query info */
-	if (query_info_collect_hook)
-		(*query_info_collect_hook)(METRICS_QUERY_SUBMIT, queryDesc);
 	
 	if (into->skipData)
 	{
@@ -480,6 +476,10 @@ ExecCreateTableAs(CreateTableAsStmt *stmt, const char *queryString,
 	}
 	else
 	{
+		/* GPDB hook for collecting query info */
+		if (query_info_collect_hook)
+			(*query_info_collect_hook)(METRICS_QUERY_SUBMIT, queryDesc);
+
 		queryDesc->plannedstmt->query_mem = ResourceManagerGetQueryMemoryLimit(queryDesc->plannedstmt);
 
 		/* call ExecutorStart to prepare the plan for execution */

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -44,6 +44,7 @@
 #include "tcop/tcopprot.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
+#include "utils/metrics_utils.h"
 #include "utils/rel.h"
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
@@ -477,6 +478,10 @@ refresh_matview_datafill(DestReceiver *dest, Query *query,
 				GetResqueueName(GetResQueueId()),
 				GetResqueuePriority(GetResQueueId()));
 	}
+
+	/* GPDB hook for collecting query info */
+	if (query_info_collect_hook)
+		(*query_info_collect_hook)(METRICS_QUERY_SUBMIT, queryDesc);
 
 	RestoreOidAssignments(saved_dispatch_oids);
 

--- a/src/backend/commands/portalcmds.c
+++ b/src/backend/commands/portalcmds.c
@@ -34,6 +34,7 @@
 #include "port/atomics.h"
 #include "tcop/pquery.h"
 #include "utils/memutils.h"
+#include "utils/metrics_utils.h"
 #include "utils/snapmgr.h"
 
 #include "cdb/cdbendpoint.h"
@@ -385,6 +386,10 @@ PortalCleanup(Portal portal)
 			}
 			PG_END_TRY();
 			CurrentResourceOwner = saveResourceOwner;
+		} else {
+			/* GPDB hook for collecting query info */
+			if (queryDesc->yagp_query_key && query_info_collect_hook)
+				(*query_info_collect_hook)(METRICS_QUERY_ERROR, queryDesc);
 		}
 	}
 


### PR DESCRIPTION
Modification places:

1. Abort in transaction
user types `BEGIN` -> user does something -> system aborts for some reason (syntax error, etc.).
`query_info_collect_hook(METRICS_QUERY_ERROR)` is not called later during abort for a previously declared cursor (e.g., `DECLARE c CURSOR FOR ...`) if an error occurs during a `FETCH`.

2. Don't call `query_info_collect_hook(METRICS_QUERY_SUBMIT)` for `skipData` queries because they don't go through executor (e.g., `CREATE TABLE ... WITH NO DATA` / `CREATE MATERIALIZED VIEW ... WITH NO DATA`).

3. `query_info_collect_hook(METRICS_QUERY_SUBMIT)` is missing for `REFRESH MATERIALIZED VIEW`.
