### PR TITLE
Do not call log dml which empty stack

### DIFF
--- a/gpcontrib/pgaudit/pgaudit.c
+++ b/gpcontrib/pgaudit/pgaudit.c
@@ -1314,7 +1314,7 @@ pgaudit_ExecutorCheckPerms_hook(List *rangeTabls, bool abort)
     auditOid = get_role_oid(auditRole, true);
 
     /* Log DML if the audit role is valid or session logging is enabled */
-    if ((auditOid != InvalidOid || auditLogBitmap != 0) &&
+    if ((auditOid != InvalidOid || auditLogBitmap != 0) &&  auditEventStack &&
         !IsAbortedTransactionBlockState())
         log_select_dml(auditOid, rangeTabls);
 


### PR DESCRIPTION
auditEventStack in created in executor start hook. GPOPRCA call ExecutorCheckPerms_hook before execution start(in planner phase), thus sigsegv. Fix by checking current stask in hook.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
