### PR TITLE
Allow ON MASTER for external file protocol

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -1592,7 +1592,7 @@ create_external_scan_uri_list(ExtTableEntry *ext, bool *ismasteronly)
 	 * protocols only */
 	on_clause = (char *) strVal(linitial(ext->execlocations));
 	if ((strcmp(on_clause, "MASTER_ONLY") == 0)
-		&& using_location && (uri->protocol != URI_CUSTOM)) {
+		&& using_location && (uri->protocol != URI_CUSTOM && uri->protocol != URI_FILE)) {
 		ereport(ERROR, (errcode(ERRCODE_INVALID_TABLE_DEFINITION),
 				errmsg("\'ON MASTER\' is not supported by this protocol yet")));
 	}
@@ -1670,6 +1670,12 @@ create_external_scan_uri_list(ExtTableEntry *ext, bool *ismasteronly)
 			found_candidate = false;
 			found_match = false;
 
+			if ((strcmp(on_clause, "MASTER_ONLY") == 0) && uri->protocol == URI_FILE)
+			{
+				found_match = true;
+				segdb_file_map[0] = pstrdup(uri_str);
+				*ismasteronly = true;
+			}
 			/*
 			 * look through our segment database list and try to find a
 			 * database that can handle this uri.

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -1388,7 +1388,18 @@ SELECT COUNT(*) FROM gp_read_error_log('exttab_heap_join_1');
 DROP EXTERNAL TABLE IF EXISTS exttab_with_on_master;
 -- end_ignore
 
--- Create external table with on clause
+-- Create external table on master
+-- good, should fetch data from master
+CREATE EXTERNAL TABLE ext_nation_on_master ( N_NATIONKEY  INTEGER ,
+                            N_NAME       CHAR(25) ,
+                            N_REGIONKEY  INTEGER ,
+                            N_COMMENT    VARCHAR(152))
+location ('file://@hostname@@abs_srcdir@/data/nation.tbl' ) ON MASTER
+FORMAT 'text' (delimiter '|');
+SELECT gp_segment_id, * FROM ext_nation_on_master ORDER BY N_NATIONKEY DESC LIMIT 5;
+DROP EXTERNAL TABLE IF EXISTS ext_nation_on_master;
+
+-- bad, should error
 CREATE EXTERNAL TABLE exttab_with_on_master( i int, j text )
 LOCATION ('file://@hostname@@abs_srcdir@/data/exttab_few_errors.data') ON MASTER FORMAT 'TEXT' (DELIMITER '|');
 

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -1385,6 +1385,7 @@ SELECT COUNT(*) FROM gp_read_error_log('exttab_heap_join_1');
 \! rm @abs_srcdir@/data/tableless.csv
 
 -- start_ignore
+DROP EXTERNAL TABLE IF EXISTS ext_nation_on_master;
 DROP EXTERNAL TABLE IF EXISTS exttab_with_on_master;
 -- end_ignore
 

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -2680,6 +2680,8 @@ SELECT COUNT(*) FROM gp_read_error_log('exttab_heap_join_1');
 
 \! rm @abs_srcdir@/data/tableless.csv
 -- start_ignore
+DROP EXTERNAL TABLE IF EXISTS ext_nation_on_master;
+NOTICE:  table "ext_nation_on_master" does not exist, skipping
 DROP EXTERNAL TABLE IF EXISTS exttab_with_on_master;
 NOTICE:  table "exttab_with_on_master" does not exist, skipping
 -- end_ignore

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -2683,11 +2683,31 @@ SELECT COUNT(*) FROM gp_read_error_log('exttab_heap_join_1');
 DROP EXTERNAL TABLE IF EXISTS exttab_with_on_master;
 NOTICE:  table "exttab_with_on_master" does not exist, skipping
 -- end_ignore
--- Create external table with on clause
+-- Create external table on master
+-- good, should fetch data from master
+CREATE EXTERNAL TABLE ext_nation_on_master ( N_NATIONKEY  INTEGER ,
+                            N_NAME       CHAR(25) ,
+                            N_REGIONKEY  INTEGER ,
+                            N_COMMENT    VARCHAR(152))
+location ('file://@hostname@@abs_srcdir@/data/nation.tbl' ) ON MASTER
+FORMAT 'text' (delimiter '|');
+SELECT gp_segment_id, * FROM ext_nation_on_master ORDER BY N_NATIONKEY DESC LIMIT 5;
+ gp_segment_id | n_nationkey |          n_name           | n_regionkey |                                                   n_comment                                                    
+---------------+-------------+---------------------------+-------------+----------------------------------------------------------------------------------------------------------------
+            -1 |          24 | UNITED STATES             |           1 | y final packages. slow foxes cajole quickly. quickly silent platelets breach ironic accounts. unusual pinto be
+            -1 |          23 | UNITED KINGDOM            |           3 | eans boost carefully special requests. accounts are. carefull
+            -1 |          22 | RUSSIA                    |           3 |  requests against the platelets use never according to the quickly regular pint
+            -1 |          21 | VIETNAM                   |           2 | hely enticingly express accounts. even, final 
+            -1 |          20 | SAUDI ARABIA              |           4 | ts. silent requests haggle. closely express packages sleep across the blithely
+(5 rows)
+
+DROP EXTERNAL TABLE IF EXISTS ext_nation_on_master;
+-- bad, should error
 CREATE EXTERNAL TABLE exttab_with_on_master( i int, j text )
 LOCATION ('file://@hostname@@abs_srcdir@/data/exttab_few_errors.data') ON MASTER FORMAT 'TEXT' (DELIMITER '|');
 SELECT * FROM exttab_with_on_master;
-ERROR:  'ON MASTER' is not supported by this protocol yet
+ERROR:  invalid input syntax for integer: "error_0"
+CONTEXT:  External table exttab_with_on_master, line 3 of file://@hostname@@abs_srcdir@/data/exttab_few_errors.data, column i
 DROP EXTERNAL TABLE IF EXISTS exttab_with_on_master;
 -- start_ignore
 DROP EXTERNAL TABLE IF EXISTS exttab_with_option_empty;


### PR DESCRIPTION
## What does this PR do?
Allows LOCATION ... ON MASTER syntax for file:// protocol in external tables.

## Additional Context
The syntax was already there but it is not supported for any ext table protocols except CUSTOM. I've added support for local files. My motivation is use this mechanism as yet another way to read logs from the local filesystem. It's already possible with EXECUTE in external web tables, but for security reasons we prohibit it completely in our installations.
Something like this:

```sql
CREATE READABLE EXTERNAL TABLE pg_log_tbl_master 
(                                    
    logtime timestamp with time zone,
    loguser text,
    logdatabase text,
    logpid text,
    logthread text,
    loghost text,
    logport text,                           
    logsessiontime timestamp with time zone,
    logtransaction int,
    logsession text,
    logcmdcount text,
    logsegment text,
    logslice text,
    logdistxact text,
    loglocalxact text,
    logsubxact text,
    logseverity text,
    logstate text,
    logmessage text,
    logdetail text,
    loghint text,
    logquery text,
    logquerypos int,
    logcontext text,
    logdebug text,
    logcursorpos int,
    logfunction text,
    logfile text,
    logline int,
    logstack text
)                                                                      
LOCATION (
    'file://my_local_cloudberry_build/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0/pg_log/*.csv' 
) ON MASTER
FORMAT 'CSV' (DELIMITER AS ',' NULL AS '' QUOTE AS '"');
```
