### PR TITLE
fix ERRORDATA_STACK_SIZE from TeardownTCPInterconnect()

### DIFF
--- a/src/test/isolation2/expected/tcp_ic_teardown.out
+++ b/src/test/isolation2/expected/tcp_ic_teardown.out
@@ -58,5 +58,37 @@ SELECT gp_inject_fault('doSendStopMessageTCP', 'reset', dbid) FROM gp_segment_co
 -- After 6s have elapsed (enough to have covered the timed wait of 3s, we should
 -- have consequently ERRORed out on the motion sender side)
 1<:  <... completed>
-ERROR:  timed out waiting for response from motion receiver during TCP interconnect teardown  (seg1 slice1 192.168.0.148:7003 pid=654372)
+ERROR:  timed out waiting for response from motion receiver during TCP interconnect teardown  (seg1 slice1 2a02:6b8:c1d:2d02:0:696:bcf5:0:6003 pid=2549819)
 DETAIL:  1 connection(s) with pending response after 3 seconds
+
+-- Tests the fix for the issue where TeardownTCPInterconnect could
+-- erreport(ERROR) during abort cleanup, causing infinite error recursion
+-- until ERRORDATA_STACK_SIZE is exceeded.
+CREATE TABLE tcp_teardown_error(i int);
+CREATE
+INSERT INTO tcp_teardown_error SELECT generate_series(1, 5);
+INSERT 5
+
+SELECT gp_inject_fault('tcp_teardown_invalid_slice_index', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+
+-- Should not see ERRORDATA_STACK_SIZE
+SELECT count(*) FROM tcp_teardown_error;
+ERROR:  Interconnect Error: Unexpected Motion Node Id: -1 (size 10). This means a motion node that wasn't setup is requesting interconnect resources.
+
+SELECT gp_inject_fault('tcp_teardown_invalid_slice_index', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+DROP TABLE tcp_teardown_error;
+DROP


### PR DESCRIPTION
Fixes `ERRORDATA_STACK_SIZE` exceeded caused by `TeardownTCPInterconnect()` erroring during abort, resulting in an error loop.

The loop goes until error stack size limit is exceeded, panicking, see below:
```gdb
errordata:
$1 =   {
   [0] = {
    ...
    message = 0x250b648 "ERRORDATA_STACK_SIZE exceeded",
    ...
    stacktracearray =  {[0] = 0xb4efaf <errstart+655>,
      [1] = 0x6f6b5f <elog_start+4290400143>,
      [2] = 0x791a36 <AbortCurrentTransaction+38>,
      [3] = 0xa56102 <PostgresMain+834>,
      [4] = 0x9f4ea8 <ServerLoop+3912>,
      [5] = 0x9f5e31 <PostmasterMain+3345>,
      [6] = 0x726fe2 <main+1090>,
      [7] = 0x7fd1d305a840 <__libc_start_main+240>,
      [8] = 0x732e59 <_start+41>,
      [9] = 0x0 <repeats 21 times>},
   },
   ...
   [i] = {
    ...
    message = 0x250b7a8 "Interconnect Error: Unexpected Motion Node Id: 1 (size 10). This means a motion node that wasn't setup is requesting interconnect resources.",
    ...
    stacktracearray =  {
      [0] = 0xb4efaf <errstart+655>,
      [1] = 0x6fb701 <TeardownTCPInterconnect+4290005505>, # 2nd call of getChunkTransportState macro
      [2] = 0xbb2161 <TeardownInterconnect+81>,
      [3] = 0xbb21c9 <interconnect_abort_callback+73>,
      [4] = 0xb7d4c5 <ResourceOwnerReleaseInternal+165>,
      [5] = 0xb7d45e <ResourceOwnerReleaseInternal+62>,
      [6] = 0xb7d9ae <ResourceOwnerRelease+142>,
      [7] = 0x78efac <AbortTransaction+540>,
      [8] = 0x791a65 <AbortCurrentTransaction+85>,
      [9] = 0xa56102 <PostgresMain+834>,
      [10] = 0x9f4ea8 <ServerLoop+3912>,
      [11] = 0x9f5e31 <PostmasterMain+3345>,
      [12] = 0x726fe2 <main+1090>,
      [13] = 0x7fd1d305a840 <__libc_start_main+240>,
      [14] = 0x732e59 <_start+41>,
      [15] = 0x0 <repeats 15 times>}
  },
  ...
```