### PR TITLE
Fix event triggers for partitioned tables

### DIFF
--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -54,6 +54,7 @@
 #include "catalog/pg_trigger.h"
 #include "catalog/pg_type.h"
 #include "catalog/storage.h"
+#include "commands/event_trigger.h"
 #include "commands/tablecmds.h"
 #include "commands/trigger.h"
 #include "executor/executor.h"
@@ -261,7 +262,8 @@ relationHasUniqueIndex(Relation rel)
 void
 index_check_primary_key(Relation heapRel,
 						IndexInfo *indexInfo,
-						bool is_alter_table)
+						bool is_alter_table,
+						IndexStmt *stmt)
 {
 	List	   *cmds;
 	int			i;
@@ -334,7 +336,11 @@ index_check_primary_key(Relation heapRel,
 	 * unduly.
 	 */
 	if (cmds)
+	{
+		EventTriggerAlterTableStart((Node *) stmt);
 		AlterTableInternal(RelationGetRelid(heapRel), cmds, false);
+		EventTriggerAlterTableEnd();
+	}
 }
 
 /*

--- a/src/backend/commands/event_trigger.c
+++ b/src/backend/commands/event_trigger.c
@@ -1666,11 +1666,6 @@ EventTriggerCollectSimpleCommand(ObjectAddress address,
  * Note we don't collect the command immediately; instead we keep it in
  * currentCommand, and only when we're done processing the subcommands we will
  * add it to the command list.
- *
- * XXX -- this API isn't considering the possibility of an ALTER TABLE command
- * being called reentrantly by an event trigger function.  Do we need stackable
- * commands at this level?  Perhaps at least we should detect the condition and
- * raise an error.
  */
 void
 EventTriggerAlterTableStart(Node *parsetree)
@@ -1695,6 +1690,7 @@ EventTriggerAlterTableStart(Node *parsetree)
 	command->d.alterTable.subcmds = NIL;
 	command->parsetree = copyObject(parsetree);
 
+	command->parent = currentEventTriggerState->currentCommand;
 	currentEventTriggerState->currentCommand = command;
 
 	MemoryContextSwitchTo(oldcxt);
@@ -1735,6 +1731,7 @@ EventTriggerCollectAlterTableSubcmd(Node *subcmd, ObjectAddress address)
 		return;
 
 	Assert(IsA(subcmd, AlterTableCmd));
+	Assert(OidIsValid(currentEventTriggerState->currentCommand));
 	Assert(OidIsValid(currentEventTriggerState->currentCommand->d.alterTable.objectId));
 
 	oldcxt = MemoryContextSwitchTo(currentEventTriggerState->cxt);
@@ -1760,10 +1757,14 @@ EventTriggerCollectAlterTableSubcmd(Node *subcmd, ObjectAddress address)
 void
 EventTriggerAlterTableEnd(void)
 {
+	CollectedCommand *parent;
+
 	/* ignore if event trigger context not set, or collection disabled */
 	if (!currentEventTriggerState ||
 		currentEventTriggerState->commandCollectionInhibited)
 		return;
+
+	parent = currentEventTriggerState->currentCommand->parent;
 
 	/* If no subcommands, don't collect */
 	if (list_length(currentEventTriggerState->currentCommand->d.alterTable.subcmds) != 0)
@@ -1775,7 +1776,7 @@ EventTriggerAlterTableEnd(void)
 	else
 		pfree(currentEventTriggerState->currentCommand);
 
-	currentEventTriggerState->currentCommand = NULL;
+	currentEventTriggerState->currentCommand = parent;
 }
 
 /*

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -34,6 +34,7 @@
 #include "commands/comment.h"
 #include "commands/dbcommands.h"
 #include "commands/defrem.h"
+#include "commands/event_trigger.h"
 #include "commands/tablecmds.h"
 #include "commands/tablespace.h"
 #include "mb/pg_wchar.h"
@@ -791,7 +792,7 @@ DefineIndex(Oid relationId,
 	 * Extra checks when creating a PRIMARY KEY index.
 	 */
 	if (stmt->primary)
-		index_check_primary_key(rel, indexInfo, is_alter_table);
+		index_check_primary_key(rel, indexInfo, is_alter_table, stmt);
 
 	if ((stmt->primary || stmt->unique) && rel->rd_cdbpolicy)
 		checkPolicyForUniqueIndex(rel,

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -9265,7 +9265,7 @@ ATExecAddIndexConstraint(AlteredTableInfo *tab, Relation rel,
 
 	/* Extra checks needed if making primary key */
 	if (stmt->primary)
-		index_check_primary_key(rel, indexInfo, true);
+		index_check_primary_key(rel, indexInfo, true, stmt);
 
 	/* Note we currently don't support EXCLUSION constraints here */
 	if (stmt->primary)

--- a/src/backend/commands/view.c
+++ b/src/backend/commands/view.c
@@ -69,6 +69,8 @@ validateWithCheckOption(char *value)
  *
  * Create a view relation and use the rules system to store the query
  * for the view.
+ * 
+ * EventTriggerAlterTableStart must have been called already.
  *---------------------------------------------------------------------
  */
 static ObjectAddress
@@ -191,6 +193,7 @@ DefineVirtualRelation(RangeVar *relation, List *tlist, bool replace,
 				atcmds = lappend(atcmds, atcmd);
 			}
 
+			/* EventTriggerAlterTableStart called by ProcessUtilitySlow */
 			AlterTableInternal(viewOid, atcmds, true);
 
 			/* Make the new view columns visible */
@@ -222,6 +225,7 @@ DefineVirtualRelation(RangeVar *relation, List *tlist, bool replace,
 		atcmd->def = (Node *) options;
 		atcmds = list_make1(atcmd);
 
+		/* EventTriggerAlterTableStart called by ProcessUtilitySlow */
 		AlterTableInternal(viewOid, atcmds, true);
 
 		ObjectAddressSet(address, RelationRelationId, viewOid);

--- a/src/include/catalog/index.h
+++ b/src/include/catalog/index.h
@@ -46,7 +46,8 @@ extern bool relationHasPrimaryKey(Relation rel);
 extern bool relationHasUniqueIndex(Relation rel);
 extern void index_check_primary_key(Relation heapRel,
 						IndexInfo *indexInfo,
-						bool is_alter_table);
+						bool is_alter_table,
+						IndexStmt *stmt);
 
 extern Oid index_create(Relation heapRelation,
 			 const char *indexRelationName,

--- a/src/include/tcop/deparse_utility.h
+++ b/src/include/tcop/deparse_utility.h
@@ -44,6 +44,7 @@ typedef struct CollectedATSubcmd
 typedef struct CollectedCommand
 {
 	CollectedCommandType type;
+
 	bool		in_extension;
 	Node	   *parsetree;
 
@@ -100,6 +101,8 @@ typedef struct CollectedCommand
 			GrantObjectType objtype;
 		} defprivs;
 	} d;
+
+	struct CollectedCommand	*parent; /* when nested */
 } CollectedCommand;
 
 #endif	/* DEPARSE_UTILITY_H */

--- a/src/test/regress/expected/event_trigger.out
+++ b/src/test/regress/expected/event_trigger.out
@@ -345,23 +345,14 @@ drop table rewriteme;
 drop event trigger no_rewrite_allowed;
 drop function test_evtrig_no_rewrite();
 -- test that alter table state object is not clobbered, shouldn't crash
-create event trigger regress_event_trigger_alter_tbl on ddl_command_end
-       execute procedure test_event_trigger();
-create table part_tbl(r int) partition by range(r) (start(1) end(10) every(1));
+create event trigger regress_event_trigger_alter_tbl on ddl_command_end execute procedure test_event_trigger();
+create table part_tbl(r int) partition by range(r) (partition part1 start(1) end(2));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'r' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_1" for table "part_tbl"
-NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_2" for table "part_tbl"
-NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_3" for table "part_tbl"
-NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_4" for table "part_tbl"
-NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_5" for table "part_tbl"
-NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_6" for table "part_tbl"
-NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_7" for table "part_tbl"
-NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_8" for table "part_tbl"
-NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_9" for table "part_tbl"
+NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_part1" for table "part_tbl"
 NOTICE:  test_event_trigger: ddl_command_end CREATE TABLE
-alter table part_tbl add partition start(11) end(20);
-NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_r221828456" for table "part_tbl"
+alter table part_tbl add partition part2 start(3) end(4);
+NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_part2" for table "part_tbl"
 NOTICE:  test_event_trigger: ddl_command_end ALTER TABLE
 drop table part_tbl;
 NOTICE:  test_event_trigger: ddl_command_end DROP TABLE

--- a/src/test/regress/expected/event_trigger.out
+++ b/src/test/regress/expected/event_trigger.out
@@ -344,3 +344,25 @@ alter table rewriteme alter column foo type numeric(12,4);
 drop table rewriteme;
 drop event trigger no_rewrite_allowed;
 drop function test_evtrig_no_rewrite();
+-- test that alter table state object is not clobbered, shouldn't crash
+create event trigger regress_event_trigger_alter_tbl on ddl_command_end
+       execute procedure test_event_trigger();
+create table part_tbl(r int) partition by range(r) (start(1) end(10) every(1));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'r' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_1" for table "part_tbl"
+NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_2" for table "part_tbl"
+NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_3" for table "part_tbl"
+NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_4" for table "part_tbl"
+NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_5" for table "part_tbl"
+NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_6" for table "part_tbl"
+NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_7" for table "part_tbl"
+NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_8" for table "part_tbl"
+NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_9" for table "part_tbl"
+NOTICE:  test_event_trigger: ddl_command_end CREATE TABLE
+alter table part_tbl add partition start(11) end(20);
+NOTICE:  CREATE TABLE will create partition "part_tbl_1_prt_r221828456" for table "part_tbl"
+NOTICE:  test_event_trigger: ddl_command_end ALTER TABLE
+drop table part_tbl;
+NOTICE:  test_event_trigger: ddl_command_end DROP TABLE
+drop event trigger regress_event_trigger_alter_tbl;

--- a/src/test/regress/sql/event_trigger.sql
+++ b/src/test/regress/sql/event_trigger.sql
@@ -261,3 +261,12 @@ alter table rewriteme alter column foo type numeric(12,4);
 drop table rewriteme;
 drop event trigger no_rewrite_allowed;
 drop function test_evtrig_no_rewrite();
+
+-- test that alter table state object is not clobbered, shouldn't crash
+create event trigger regress_event_trigger_alter_tbl on ddl_command_end 
+	execute procedure test_event_trigger();
+create table part_tbl(r int) partition by range(r) (start(1) end(10) every(1));
+alter table part_tbl add partition start(11) end(20);
+
+drop table part_tbl;
+drop event trigger regress_event_trigger_alter_tbl;

--- a/src/test/regress/sql/event_trigger.sql
+++ b/src/test/regress/sql/event_trigger.sql
@@ -263,10 +263,9 @@ drop event trigger no_rewrite_allowed;
 drop function test_evtrig_no_rewrite();
 
 -- test that alter table state object is not clobbered, shouldn't crash
-create event trigger regress_event_trigger_alter_tbl on ddl_command_end 
-	execute procedure test_event_trigger();
-create table part_tbl(r int) partition by range(r) (start(1) end(10) every(1));
-alter table part_tbl add partition start(11) end(20);
+create event trigger regress_event_trigger_alter_tbl on ddl_command_end execute procedure test_event_trigger();
+create table part_tbl(r int) partition by range(r) (partition part1 start(1) end(2));
+alter table part_tbl add partition part2 start(3) end(4);
 
 drop table part_tbl;
 drop event trigger regress_event_trigger_alter_tbl;


### PR DESCRIPTION
Please see the description [here](https://github.com/postgres/postgres/commit/a2a5159ed678f0e4a0efa7e8aabbd4c03eb36843).

Repro steps:
```sql
create event trigger tr on ddl_command_end execute procedure tr_f();
create table tbl(r int) partition by range(r) (start(1) end(10) every(1));
alter table tbl add partition start(11) end(20);
```