### PR TITLE
Speedup buffer pool initialization

### DIFF
--- a/src/backend/storage/buffer/buf_init.c
+++ b/src/backend/storage/buffer/buf_init.c
@@ -101,7 +101,6 @@ ProtectMemoryPoolBuffers()
 void
 InitBufferPool(void)
 {
-    Size bufferBlocksTotalSize = mul_size((Size)NBuffers, (Size) BLCKSZ);
 	bool		foundBufs,
 				foundDescs;
 
@@ -111,10 +110,7 @@ InitBufferPool(void)
 
 	BufferBlocks = (char *)
 		ShmemInitStruct("Buffer Blocks",
-						bufferBlocksTotalSize, &foundBufs);
-
-	/* GPDB: Init the buffer memory to something to help check for bugs */
-	memset(BufferBlocks,0xFE,bufferBlocksTotalSize);
+						NBuffers * (Size) BLCKSZ, &foundBufs);
 
 	if (foundDescs || foundBufs)
 	{


### PR DESCRIPTION
If the `shared_buffers` GUC value was too high, then filling of buffer memory with 0xFE bytes took significant time.  There is no need to fill buffer memory right after its allocation. So the memory initialization is rolled back.

cherry-picked from 567d61507e8e8a8187e7507f3a7cd246ec15ffd0