### PR TITLE
Fix pg_event_trigger_ddl_commands

### DIFF
--- a/gpcontrib/Makefile
+++ b/gpcontrib/Makefile
@@ -127,6 +127,7 @@ distclean:
 installcheck:
 	$(MAKE) -C gp_internal_tools installcheck
 	$(MAKE) -C gp_array_agg installcheck
+	$(MAKE) -C gp_aux_catalog installcheck
 	if [ "$(enable_mapreduce)" = "yes" ]; then \
 		$(MAKE) -C gpmapreduce installcheck; \
 	fi

--- a/gpcontrib/gp_aux_catalog/Makefile
+++ b/gpcontrib/gp_aux_catalog/Makefile
@@ -7,6 +7,8 @@ EXTENSION = gp_aux_catalog
 DATA = gp_aux_catalog--1.0.sql gp_aux_catalog--1.0--1.1.sql
 PGFILEDESC = "gp_aux_catalog - An auxiliar catalog extension for Greenplum"
 
+REGRESS = pg_event_trigger_ddl_commands
+
 ifdef USE_PGXS
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/gpcontrib/gp_aux_catalog/expected/pg_event_trigger_ddl_commands.out
+++ b/gpcontrib/gp_aux_catalog/expected/pg_event_trigger_ddl_commands.out
@@ -1,0 +1,94 @@
+-- Create an event trigger to output information about DDL queries
+create or replace function test_pg_event_trigger_ddl_commands()
+returns event_trigger as
+$$
+declare
+	r record;
+begin
+	for r in select * from pg_event_trigger_ddl_commands()
+	loop
+		raise notice 'classid = %, command_tag = %, object_type = %, schema_name = %, object_identity = %, in_extension = %',
+			r.classid, r.command_tag, r.object_type, r.schema_name, r.object_identity, r.in_extension;
+	end loop;
+end;
+$$ language plpgsql;
+create event trigger test_pg_event_trigger_ddl_commands
+on ddl_command_end
+execute procedure test_pg_event_trigger_ddl_commands();
+-- The following queries should work without errors when the event
+-- trigger calls pg_event_trigger_ddl_commands()
+-- Check T_IndexStmt
+create table t(i int primary key) distributed by (i);
+NOTICE:  classid = 1259, command_tag = CREATE TABLE, object_type = table, schema_name = public, object_identity = public.t, in_extension = f
+NOTICE:  classid = 1259, command_tag = CREATE INDEX, object_type = index, schema_name = public, object_identity = public.t_pkey, in_extension = f
+-- Check T_CommentStmt
+comment on column t.i is 'comment for column i';
+NOTICE:  classid = 1259, command_tag = COMMENT, object_type = table column, schema_name = public, object_identity = public.t.i, in_extension = f
+-- Check T_AlterExtensionContentsStmt
+alter extension gp_aux_catalog add table t;
+NOTICE:  classid = 3079, command_tag = ALTER EXTENSION, object_type = extension, schema_name = <NULL>, object_identity = gp_aux_catalog, in_extension = f
+alter extension gp_aux_catalog drop table t;
+NOTICE:  classid = 3079, command_tag = ALTER EXTENSION, object_type = extension, schema_name = <NULL>, object_identity = gp_aux_catalog, in_extension = f
+-- Check T_CreateTrigStmt
+create or replace function t_trigger()
+returns trigger as
+$$
+begin
+	raise notice 't_trigger';
+	return null;
+end;
+$$ language plpgsql;
+NOTICE:  classid = 1255, command_tag = CREATE FUNCTION, object_type = function, schema_name = public, object_identity = public.t_trigger(), in_extension = f
+create trigger t_trigger after insert on t for each statement
+execute procedure t_trigger();
+NOTICE:  classid = 2620, command_tag = CREATE TRIGGER, object_type = trigger, schema_name = <NULL>, object_identity = t_trigger on public.t, in_extension = f
+drop trigger t_trigger on t;
+drop function t_trigger();
+drop table t;
+-- Check T_AlterTypeStmt
+create type color as enum ('red', 'green', 'blue');
+NOTICE:  classid = 1247, command_tag = CREATE TYPE, object_type = type, schema_name = public, object_identity = public.color, in_extension = f
+alter type color set default encoding (compresstype=zlib);
+NOTICE:  classid = 1247, command_tag = ALTER TYPE, object_type = type, schema_name = public, object_identity = public.color, in_extension = f
+drop type color;
+-- Check T_CreateExternalStmt
+create external table ext_t1 (a int, b int)
+location ('file:///tmp/test.txt') format 'text';
+NOTICE:  classid = 1259, command_tag = CREATE EXTERNAL TABLE, object_type = table, schema_name = public, object_identity = public.ext_t1, in_extension = f
+drop external table ext_t1;
+-- Check T_DefineStmt, OBJECT_TSCONFIGURATION
+create text search configuration tsc_pg_event_trigger_ddl_commands (
+	copy = pg_catalog.english
+);
+NOTICE:  classid = 3602, command_tag = CREATE TEXT SEARCH CONFIGURATION, object_type = text search configuration, schema_name = public, object_identity = public.tsc_pg_event_trigger_ddl_commands, in_extension = f
+drop text search configuration tsc_pg_event_trigger_ddl_commands;
+-- Check T_DefineStmt, OBJECT_COLLATION
+create collation test0 from "C";
+NOTICE:  classid = 3456, command_tag = CREATE COLLATION, object_type = collation, schema_name = public, object_identity = public.test0, in_extension = f
+drop collation test0;
+-- Check T_DefineStmt, OBJECT_EXTPROTOCOL
+create or replace function write_to_file()
+returns int as
+'$libdir/gpextprotocol.so', 'demoprot_export' language C stable;
+NOTICE:  classid = 1255, command_tag = CREATE FUNCTION, object_type = function, schema_name = public, object_identity = public.write_to_file(), in_extension = f
+create or replace function read_from_file()
+returns int as
+'$libdir/gpextprotocol.so', 'demoprot_import' language C stable;
+NOTICE:  classid = 1255, command_tag = CREATE FUNCTION, object_type = function, schema_name = public, object_identity = public.read_from_file(), in_extension = f
+create protocol demoprot (
+	readfunc  = read_from_file,
+	writefunc = write_to_file
+);
+NOTICE:  classid = 7175, command_tag = CREATE PROTOCOL, object_type = protocol, schema_name = <NULL>, object_identity = protocol demoprot, in_extension = f
+drop protocol demoprot;
+drop function read_from_file();
+drop function write_to_file();
+-- Check T_AlterDomainStmt
+create domain con as int;
+NOTICE:  classid = 1247, command_tag = CREATE DOMAIN, object_type = type, schema_name = public, object_identity = public.con, in_extension = f
+alter domain con add constraint t check (value < 34);
+NOTICE:  classid = 1247, command_tag = ALTER DOMAIN, object_type = type, schema_name = public, object_identity = public.con, in_extension = f
+drop domain con;
+-- Cleanup
+drop event trigger test_pg_event_trigger_ddl_commands;
+drop function test_pg_event_trigger_ddl_commands();

--- a/gpcontrib/gp_aux_catalog/sql/pg_event_trigger_ddl_commands.sql
+++ b/gpcontrib/gp_aux_catalog/sql/pg_event_trigger_ddl_commands.sql
@@ -1,0 +1,125 @@
+-- start_ignore
+create extension if not exists gp_aux_catalog;
+drop event trigger if exists test_pg_event_trigger_ddl_commands;
+drop function if exists test_pg_event_trigger_ddl_commands();
+drop type if exists color;
+drop trigger if exists t_trigger on t;
+drop function if exists t_trigger();
+drop table if exists t;
+drop external table if exists ext_t1;
+drop text search configuration if exists tsc_pg_event_trigger_ddl_commands;
+drop collation if exists test0;
+drop protocol if exists demoprot;
+drop function if exists read_from_file();
+drop function if exists write_to_file();
+drop domain if exists con;
+-- end_ignore
+
+
+-- Create an event trigger to output information about DDL queries
+create or replace function test_pg_event_trigger_ddl_commands()
+returns event_trigger as
+$$
+declare
+	r record;
+begin
+	for r in select * from pg_event_trigger_ddl_commands()
+	loop
+		raise notice 'classid = %, command_tag = %, object_type = %, schema_name = %, object_identity = %, in_extension = %',
+			r.classid, r.command_tag, r.object_type, r.schema_name, r.object_identity, r.in_extension;
+	end loop;
+end;
+$$ language plpgsql;
+
+create event trigger test_pg_event_trigger_ddl_commands
+on ddl_command_end
+execute procedure test_pg_event_trigger_ddl_commands();
+
+
+-- The following queries should work without errors when the event
+-- trigger calls pg_event_trigger_ddl_commands()
+
+-- Check T_IndexStmt
+create table t(i int primary key) distributed by (i);
+
+
+-- Check T_CommentStmt
+comment on column t.i is 'comment for column i';
+
+
+-- Check T_AlterExtensionContentsStmt
+alter extension gp_aux_catalog add table t;
+alter extension gp_aux_catalog drop table t;
+
+
+-- Check T_CreateTrigStmt
+create or replace function t_trigger()
+returns trigger as
+$$
+begin
+	raise notice 't_trigger';
+	return null;
+end;
+$$ language plpgsql;
+
+create trigger t_trigger after insert on t for each statement
+execute procedure t_trigger();
+
+drop trigger t_trigger on t;
+drop function t_trigger();
+drop table t;
+
+
+-- Check T_AlterTypeStmt
+create type color as enum ('red', 'green', 'blue');
+alter type color set default encoding (compresstype=zlib);
+drop type color;
+
+
+-- Check T_CreateExternalStmt
+create external table ext_t1 (a int, b int)
+location ('file:///tmp/test.txt') format 'text';
+
+drop external table ext_t1;
+
+
+-- Check T_DefineStmt, OBJECT_TSCONFIGURATION
+create text search configuration tsc_pg_event_trigger_ddl_commands (
+	copy = pg_catalog.english
+);
+drop text search configuration tsc_pg_event_trigger_ddl_commands;
+
+
+-- Check T_DefineStmt, OBJECT_COLLATION
+create collation test0 from "C";
+drop collation test0;
+
+
+-- Check T_DefineStmt, OBJECT_EXTPROTOCOL
+create or replace function write_to_file()
+returns int as
+'$libdir/gpextprotocol.so', 'demoprot_export' language C stable;
+
+create or replace function read_from_file()
+returns int as
+'$libdir/gpextprotocol.so', 'demoprot_import' language C stable;
+
+create protocol demoprot (
+	readfunc  = read_from_file,
+	writefunc = write_to_file
+);
+
+drop protocol demoprot;
+drop function read_from_file();
+drop function write_to_file();
+
+
+-- Check T_AlterDomainStmt
+create domain con as int;
+alter domain con add constraint t check (value < 34);
+drop domain con;
+
+
+-- Cleanup
+drop event trigger test_pg_event_trigger_ddl_commands;
+drop function test_pg_event_trigger_ddl_commands();

--- a/src/backend/catalog/objectaddress.c
+++ b/src/backend/catalog/objectaddress.c
@@ -2745,6 +2745,10 @@ getObjectTypeDescription(const ObjectAddress *object)
 			appendStringInfoString(&buffer, "event trigger");
 			break;
 
+		case OCLASS_EXTPROTOCOL:
+			appendStringInfoString(&buffer, "protocol");
+			break;
+
 		default:
 			appendStringInfo(&buffer, "unrecognized %u", object->classId);
 			break;
@@ -3507,6 +3511,11 @@ getObjectIdentity(const ObjectAddress *object)
 				ReleaseSysCache(tup);
 				break;
 			}
+
+		case OCLASS_EXTPROTOCOL:
+			appendStringInfo(&buffer, "protocol %s",
+							 ExtProtocolGetNameByOid(object->objectId));
+			break;
 
 		default:
 			appendStringInfo(&buffer, "unrecognized object %u %u %d",

--- a/src/backend/catalog/pg_extprotocol.c
+++ b/src/backend/catalog/pg_extprotocol.c
@@ -45,7 +45,7 @@ static char *func_type_to_name(ExtPtcFuncType ftype);
 /*
  * ExtProtocolCreate
  */
-Oid
+ObjectAddress
 ExtProtocolCreate(const char *protocolName,
 				  List *readfuncName,
 				  List *writefuncName,
@@ -180,7 +180,7 @@ ExtProtocolCreate(const char *protocolName,
 	/* dependency on extension */
 	recordDependencyOnCurrentExtension(&myself, false);
 
-	return protOid;
+	return myself;
 }
 
 /*

--- a/src/backend/commands/extprotocolcmds.c
+++ b/src/backend/commands/extprotocolcmds.c
@@ -42,7 +42,7 @@
 /*
  *	DefineExtprotocol
  */
-void
+ObjectAddress
 DefineExtProtocol(List *name, List *parameters, bool trusted)
 {
 	char	   *protName;
@@ -50,7 +50,7 @@ DefineExtProtocol(List *name, List *parameters, bool trusted)
 	List	   *writefuncName = NIL;
 	List	   *validatorfuncName = NIL;
 	ListCell   *pl;
-	Oid			protOid;
+	ObjectAddress address;
 
 	if (!superuser())
 		ereport(ERROR,
@@ -88,7 +88,7 @@ DefineExtProtocol(List *name, List *parameters, bool trusted)
 	/*
 	 * Most of the argument-checking is done inside of ExtProtocolCreate
 	 */
-	protOid = ExtProtocolCreate(protName,			/* protocol name */
+	address = ExtProtocolCreate(protName,			/* protocol name */
 								readfuncName,		/* read function name */
 								writefuncName,		/* write function name */
 								validatorfuncName, 	/* validator function name */
@@ -110,6 +110,8 @@ DefineExtProtocol(List *name, List *parameters, bool trusted)
 									GetAssignedOidsForDispatch(),
 									NULL);
 	}
+
+	return address;
 }
 
 /*

--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -60,7 +60,7 @@ static Datum optionsListToArray(List *options);
 * to leave it intact and do another dispatch.
 * ----------------------------------------------------------------
 */
-extern void
+extern ObjectAddress
 DefineExternalRelation(CreateExternalStmt *createExtStmt)
 {
 	CreateStmt *createStmt = makeNode(CreateStmt);
@@ -84,6 +84,7 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 	bool		isweb = createExtStmt->isweb;
 	bool		shouldDispatch = (Gp_role == GP_ROLE_DISPATCH &&
 								  IsNormalProcessingMode());
+	ObjectAddress address;
 
 	/*
 	 * now set the parameters for keys/inheritance etc. Most of these are
@@ -389,7 +390,7 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 	/*
 	 * create a pg_exttable entry for this external table.
 	 */
-	InsertExtTableEntry(reloid,
+	address = InsertExtTableEntry(reloid,
 						iswritable,
 						issreh,
 						formattype,
@@ -425,6 +426,8 @@ DefineExternalRelation(CreateExternalStmt *createExtStmt)
 									GetAssignedOidsForDispatch(),
 									NULL);
 	}
+
+	return address;
 }
 
 

--- a/src/backend/commands/typecmds.c
+++ b/src/backend/commands/typecmds.c
@@ -3875,7 +3875,7 @@ AlterTypeArray(Oid typeOid, Oid arrayOid)
  *
  * ALTER TYPE <typname> SET DEFAULT ENCODING (...)
  */
-void
+ObjectAddress
 AlterType(AlterTypeStmt *stmt)
 {
 	TypeName   *typname;
@@ -3883,6 +3883,7 @@ AlterType(AlterTypeStmt *stmt)
 	Oid			arrtypid;
 	Datum		typoptions;
 	List	   *encoding;
+	ObjectAddress address;
 
 	/* Make a TypeName so we can use standard type lookup machinery */
 	typname = makeTypeNameFromNameList(stmt->typeName);
@@ -3928,6 +3929,9 @@ AlterType(AlterTypeStmt *stmt)
 									DF_NEED_TWO_PHASE,
 									NIL,
 									NULL);
+
+	ObjectAddressSet(address, TypeRelationId, typid);
+	return address;
 }
 
 /*

--- a/src/include/catalog/pg_extprotocol.h
+++ b/src/include/catalog/pg_extprotocol.h
@@ -16,6 +16,7 @@
 #define PG_EXTPROTOCOL_H
 
 #include "catalog/genbki.h"
+#include "catalog/objectaddress.h"
 #include "nodes/pg_list.h"
 #include "utils/acl.h"
 
@@ -75,7 +76,7 @@ typedef enum ExtPtcFuncType
 	
 } ExtPtcFuncType;
 
-extern Oid
+extern ObjectAddress
 ExtProtocolCreate(const char *protocolName,
 				  List *readfuncName,
 				  List *writefuncName,

--- a/src/include/catalog/pg_exttable.h
+++ b/src/include/catalog/pg_exttable.h
@@ -17,6 +17,7 @@
 #define PG_EXTTABLE_H
 
 #include "catalog/genbki.h"
+#include "catalog/objectaddress.h"
 #include "nodes/pg_list.h"
 
 /*
@@ -102,7 +103,7 @@ extern void ValidateExtTableOptions(List *options);
 
 extern bool NeedErrorLogPersistent(List *options);
 
-extern void InsertExtTableEntry(Oid 	tbloid,
+extern ObjectAddress InsertExtTableEntry(Oid 	tbloid,
 					bool 	iswritable,
 					bool	issreh,
 					char	formattype,

--- a/src/include/commands/extprotocolcmds.h
+++ b/src/include/commands/extprotocolcmds.h
@@ -11,7 +11,7 @@
 
 #include "nodes/pg_list.h"
 
-extern void DefineExtProtocol(List *name, List *parameters, bool trusted);
+extern ObjectAddress DefineExtProtocol(List *name, List *parameters, bool trusted);
 extern void RemoveExtProtocolById(Oid protOid);
 
 #endif   /* EXTPROTOCOLCMDS_H */

--- a/src/include/commands/tablecmds.h
+++ b/src/include/commands/tablecmds.h
@@ -51,7 +51,7 @@ extern const char *synthetic_sql;
 
 extern ObjectAddress DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId, ObjectAddress *typaddress, char relstorage, bool dispatch, bool useChangedOpts, GpPolicy *intoPolicy);
 
-extern void	DefineExternalRelation(CreateExternalStmt *stmt);
+extern ObjectAddress DefineExternalRelation(CreateExternalStmt *stmt);
 
 extern void EvaluateDeferredStatements(List *deferredStmts);
 

--- a/src/include/commands/typecmds.h
+++ b/src/include/commands/typecmds.h
@@ -55,6 +55,6 @@ extern Oid AlterTypeNamespaceInternal(Oid typeOid, Oid nspOid,
 						   ObjectAddresses *objsMoved);
 extern void AlterTypeArray(Oid typeOid, Oid arrayOid);
 
-extern void AlterType(AlterTypeStmt *stmt);
+extern ObjectAddress AlterType(AlterTypeStmt *stmt);
 
 #endif   /* TYPECMDS_H */


### PR DESCRIPTION
The function issued the "invalid non-zero objectSubId for object class" error
when an event trigger fired after the following utility query types:
T_IndexStmt, T_CommentStmt, T_AlterExtensionContentsStmt, T_CreateTrigStmt,
T_AlterTypeStmt, T_CreateExternalStmt, T_DefineStmt, T_AlterDomainStmt (see
tests from the patch). The reason of the error was that the address variable had
not been initialized before it was added to the list in
EventTriggerCollectSimpleCommand.

Add initialization for commandCollected, because the variable was never set to
false, but EventTriggerCollectSimpleCommand should be called when
commandCollected is false.
Add initialization for address and secondaryObject to make sure that the same
error will never happen. When empty address is added to the list, this address
is skipped without error.

------------------

The patch is needed to fix pg_audit tests. These tests contain query:
```
CREATE TABLE public.test
(
        id INT,
        name TEXT,
        description TEXT,
        CONSTRAINT test_pkey PRIMARY KEY (id)
) DISTRIBUTED BY (id);
```
The table  is not created without the patch after `create extension pgaudit; set pgaudit.log = 'all'; set pgaudit.log_client = on; set pgaudit.log_level = 'notice';` .