### PR TITLE
Make pgaudit tests pass

### DIFF
--- a/.github/workflows/build-gpdb.yml
+++ b/.github/workflows/build-gpdb.yml
@@ -145,6 +145,7 @@ jobs:
               },
               {"test":"ic-gpcontrib",
                "make_configs":["gpcontrib/gp_array_agg:installcheck",
+                               "gpcontrib/gp_aux_catalog",
                                "gpcontrib/gp_debug_numsegments:installcheck",
                                "gpcontrib/gp_distribution_policy:installcheck",
                                "gpcontrib/gp_error_handling:installcheck",
@@ -155,7 +156,8 @@ jobs:
                                "gpcontrib/gp_sparse_vector:installcheck",
                                "gpcontrib/gp_subtransaction_overflow:installcheck",
                                "gpcontrib/gpmapreduce:installcheck",
-                               "gpcontrib/orafce:installcheck"]
+                               "gpcontrib/orafce:installcheck",
+                               "gpcontrib/pgaudit:installcheck"]
               },
               {"test":"ic-parallel-retrieve-cursor",
                "make_configs":["src/test/isolation2:installcheck-parallel-retrieve-cursor"]

--- a/.github/workflows/build-gpdb.yml
+++ b/.github/workflows/build-gpdb.yml
@@ -145,7 +145,6 @@ jobs:
               },
               {"test":"ic-gpcontrib",
                "make_configs":["gpcontrib/gp_array_agg:installcheck",
-                               "gpcontrib/gp_aux_catalog",
                                "gpcontrib/gp_debug_numsegments:installcheck",
                                "gpcontrib/gp_distribution_policy:installcheck",
                                "gpcontrib/gp_error_handling:installcheck",

--- a/gpcontrib/Makefile
+++ b/gpcontrib/Makefile
@@ -138,3 +138,4 @@ installcheck:
 	$(MAKE) -C gp_percentile_agg installcheck
 	$(MAKE) -C gp_subtransaction_overflow installcheck
 	$(MAKE) -C gp_check_functions installcheck
+	if [ "${enable_pgaudit}" = "yes" ]; then $(MAKE) -C pgaudit installcheck; fi

--- a/gpcontrib/pgaudit/expected/pgaudit.out
+++ b/gpcontrib/pgaudit/expected/pgaudit.out
@@ -1,16 +1,10 @@
 \set VERBOSITY terse
--- Create pgaudit extension
-CREATE EXTENSION IF NOT EXISTS pgaudit;
--- Make sure events don't get logged twice when session logging
-SET pgaudit.log = 'all';
-SET pgaudit.log_client = ON;
-SET pgaudit.log_level = 'notice';
-NOTICE:  AUDIT: SESSION,3,1,MISC,SET,,,SET pgaudit.log_level = 'notice';,<not logged>
-CREATE TABLE tmp (id int, data text);
-NOTICE:  AUDIT: SESSION,4,1,DDL,CREATE TABLE,TABLE,public.tmp,"CREATE TABLE tmp (id int, data text);",<not logged>
-CREATE TABLE tmp2 AS (SELECT * FROM tmp);
-NOTICE:  AUDIT: SESSION,5,1,READ,SELECT,,,CREATE TABLE tmp2 AS (SELECT * FROM tmp);,<not logged>
-NOTICE:  AUDIT: SESSION,5,2,DDL,CREATE TABLE AS,TABLE,public.tmp2,CREATE TABLE tmp2 AS (SELECT * FROM tmp);,<not logged>
+CREATE TABLE tmp (id int, data text) DISTRIBUTED BY (id);
+NOTICE:  AUDIT: SESSION,4,1,DDL,CREATE TABLE,TABLE,public.tmp,"CREATE TABLE tmp (id int, data text) DISTRIBUTED BY (id);",<not logged>
+CREATE TABLE tmp2 AS (SELECT * FROM tmp) DISTRIBUTED BY (id);
+NOTICE:  AUDIT: SESSION,5,1,DDL,CREATE TABLE AS,,,CREATE TABLE tmp2 AS (SELECT * FROM tmp) DISTRIBUTED BY (id);,<not logged>
+NOTICE:  AUDIT: SESSION,5,2,READ,SELECT,,,CREATE TABLE tmp2 AS (SELECT * FROM tmp) DISTRIBUTED BY (id);,<not logged>
+NOTICE:  AUDIT: SESSION,5,1,DDL,CREATE TABLE AS,TABLE,public.tmp2,CREATE TABLE tmp2 AS (SELECT * FROM tmp) DISTRIBUTED BY (id);,<not logged>
 -- Reset log_client first to show that audits logs are not set to client
 RESET pgaudit.log_client;
 DROP TABLE tmp;
@@ -32,41 +26,41 @@ RESET pgaudit.log_level;
 SELECT current_user \gset
 --
 -- Set pgaudit parameters for the current (super)user.
-ALTER ROLE :current_user SET pgaudit.log = 'Role';
-ALTER ROLE :current_user SET pgaudit.log_level = 'notice';
-ALTER ROLE :current_user SET pgaudit.log_client = ON;
-\connect - :current_user;
+ALTER ROLE :"current_user" SET pgaudit.log = 'Role';
+ALTER ROLE :"current_user" SET pgaudit.log_level = 'notice';
+ALTER ROLE :"current_user" SET pgaudit.log_client = ON;
+\connect - :"current_user";
 --
 -- Create auditor role
-CREATE ROLE auditor;
-NOTICE:  AUDIT: SESSION,1,1,ROLE,CREATE ROLE,,,CREATE ROLE auditor;,<not logged>
+CREATE ROLE auditor RESOURCE QUEUE pg_default;
+NOTICE:  AUDIT: SESSION,2,1,ROLE,CREATE ROLE,,,CREATE ROLE auditor RESOURCE QUEUE pg_default;,<not logged>
 --
 -- Create first test user
-CREATE USER user1 password 'password';
-NOTICE:  AUDIT: SESSION,2,1,ROLE,CREATE ROLE,,,CREATE USER user1 password <REDACTED>,<not logged>
+CREATE USER user1 password 'password' RESOURCE QUEUE pg_default;
+NOTICE:  AUDIT: SESSION,4,1,ROLE,CREATE ROLE,,,CREATE USER user1 password <REDACTED>,<not logged>
 ALTER ROLE user1 SET pgaudit.log = 'ddl, ROLE';
-NOTICE:  AUDIT: SESSION,3,1,ROLE,ALTER ROLE,,,"ALTER ROLE user1 SET pgaudit.log = 'ddl, ROLE';",<not logged>
+NOTICE:  AUDIT: SESSION,5,1,ROLE,ALTER ROLE,,,"ALTER ROLE user1 SET pgaudit.log = 'ddl, ROLE';",<not logged>
 ALTER ROLE user1 SET pgaudit.log_level = 'notice';
-NOTICE:  AUDIT: SESSION,4,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 SET pgaudit.log_level = 'notice';,<not logged>
+NOTICE:  AUDIT: SESSION,6,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 SET pgaudit.log_level = 'notice';,<not logged>
 ALTER ROLE user1 PassWord 'password2' NOLOGIN;
-NOTICE:  AUDIT: SESSION,5,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 PassWord <REDACTED>,<not logged>
+NOTICE:  AUDIT: SESSION,7,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 PassWord <REDACTED>,<not logged>
 ALTER USER user1 encrypted /* random comment */PASSWORD
 	/* random comment */
     'md565cb1da342495ea6bb0418a6e5718c38' LOGIN;
-NOTICE:  AUDIT: SESSION,6,1,ROLE,ALTER ROLE,,,ALTER USER user1 encrypted /* random comment */PASSWORD <REDACTED>,<not logged>
+NOTICE:  AUDIT: SESSION,8,1,ROLE,ALTER ROLE,,,ALTER USER user1 encrypted /* random comment */PASSWORD <REDACTED>,<not logged>
 ALTER ROLE user1 SET pgaudit.log_client = ON;
-NOTICE:  AUDIT: SESSION,7,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 SET pgaudit.log_client = ON;,<not logged>
+NOTICE:  AUDIT: SESSION,9,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 SET pgaudit.log_client = ON;,<not logged>
 --
 -- Create, select, drop (select will not be audited)
 \connect - user1
 CREATE TABLE public.test
 (
 	id INT
-);
+) DISTRIBUTED BY (id);
 NOTICE:  AUDIT: SESSION,1,1,DDL,CREATE TABLE,TABLE,public.test,"CREATE TABLE public.test
 (
 	id INT
-);",<not logged>
+) DISTRIBUTED BY (id);",<not logged>
 SELECT *
   FROM test;
  id 
@@ -77,53 +71,53 @@ DROP TABLE test;
 NOTICE:  AUDIT: SESSION,2,1,DDL,DROP TABLE,TABLE,public.test,DROP TABLE test;,<not logged>
 --
 -- Create second test user
-\connect - :current_user
-CREATE ROLE user2 LOGIN password 'password';
-NOTICE:  AUDIT: SESSION,1,1,ROLE,CREATE ROLE,,,CREATE ROLE user2 LOGIN password <REDACTED>,<not logged>
+\connect - :"current_user"
+CREATE ROLE user2 LOGIN password 'password' RESOURCE QUEUE pg_default;
+NOTICE:  AUDIT: SESSION,2,1,ROLE,CREATE ROLE,,,CREATE ROLE user2 LOGIN password <REDACTED>,<not logged>
 ALTER ROLE user2 SET pgaudit.log = 'Read, writE';
-NOTICE:  AUDIT: SESSION,2,1,ROLE,ALTER ROLE,,,"ALTER ROLE user2 SET pgaudit.log = 'Read, writE';",<not logged>
+NOTICE:  AUDIT: SESSION,3,1,ROLE,ALTER ROLE,,,"ALTER ROLE user2 SET pgaudit.log = 'Read, writE';",<not logged>
 ALTER ROLE user2 SET pgaudit.log_catalog = OFF;
-NOTICE:  AUDIT: SESSION,3,1,ROLE,ALTER ROLE,,,ALTER ROLE user2 SET pgaudit.log_catalog = OFF;,<not logged>
+NOTICE:  AUDIT: SESSION,4,1,ROLE,ALTER ROLE,,,ALTER ROLE user2 SET pgaudit.log_catalog = OFF;,<not logged>
 ALTER ROLE user2 SET pgaudit.log_client = ON;
-NOTICE:  AUDIT: SESSION,4,1,ROLE,ALTER ROLE,,,ALTER ROLE user2 SET pgaudit.log_client = ON;,<not logged>
+NOTICE:  AUDIT: SESSION,5,1,ROLE,ALTER ROLE,,,ALTER ROLE user2 SET pgaudit.log_client = ON;,<not logged>
 ALTER ROLE user2 SET pgaudit.log_level = 'warning';
-NOTICE:  AUDIT: SESSION,5,1,ROLE,ALTER ROLE,,,ALTER ROLE user2 SET pgaudit.log_level = 'warning';,<not logged>
+NOTICE:  AUDIT: SESSION,6,1,ROLE,ALTER ROLE,,,ALTER ROLE user2 SET pgaudit.log_level = 'warning';,<not logged>
 ALTER ROLE user2 SET pgaudit.role = auditor;
-NOTICE:  AUDIT: SESSION,6,1,ROLE,ALTER ROLE,,,ALTER ROLE user2 SET pgaudit.role = auditor;,<not logged>
+NOTICE:  AUDIT: SESSION,7,1,ROLE,ALTER ROLE,,,ALTER ROLE user2 SET pgaudit.role = auditor;,<not logged>
 ALTER ROLE user2 SET pgaudit.log_statement_once = ON;
-NOTICE:  AUDIT: SESSION,7,1,ROLE,ALTER ROLE,,,ALTER ROLE user2 SET pgaudit.log_statement_once = ON;,<not logged>
+NOTICE:  AUDIT: SESSION,8,1,ROLE,ALTER ROLE,,,ALTER ROLE user2 SET pgaudit.log_statement_once = ON;,<not logged>
 --
 -- Setup role-based tests
 CREATE TABLE test2
 (
 	id INT
-);
+) DISTRIBUTED BY (id);
 GRANT SELECT, INSERT, UPDATE, DELETE
    ON test2
    TO user2, user1;
-NOTICE:  AUDIT: SESSION,8,1,ROLE,GRANT,TABLE,,"GRANT SELECT, INSERT, UPDATE, DELETE
+NOTICE:  AUDIT: SESSION,9,1,ROLE,GRANT,TABLE,,"GRANT SELECT, INSERT, UPDATE, DELETE
    ON test2
    TO user2, user1;",<not logged>
 GRANT SELECT, UPDATE
    ON TABLE public.test2
    TO auditor;
-NOTICE:  AUDIT: SESSION,9,1,ROLE,GRANT,TABLE,,"GRANT SELECT, UPDATE
+NOTICE:  AUDIT: SESSION,10,1,ROLE,GRANT,TABLE,,"GRANT SELECT, UPDATE
    ON TABLE public.test2
    TO auditor;",<not logged>
 CREATE TABLE test3
 (
 	id INT
-);
+) DISTRIBUTED BY (id);
 GRANT SELECT, INSERT, UPDATE, DELETE
    ON test3
    TO user2;
-NOTICE:  AUDIT: SESSION,10,1,ROLE,GRANT,TABLE,,"GRANT SELECT, INSERT, UPDATE, DELETE
+NOTICE:  AUDIT: SESSION,11,1,ROLE,GRANT,TABLE,,"GRANT SELECT, INSERT, UPDATE, DELETE
    ON test3
    TO user2;",<not logged>
 GRANT INSERT
    ON TABLE public.test3
    TO auditor;
-NOTICE:  AUDIT: SESSION,11,1,ROLE,GRANT,TABLE,,"GRANT INSERT
+NOTICE:  AUDIT: SESSION,12,1,ROLE,GRANT,TABLE,,"GRANT INSERT
    ON TABLE public.test3
    TO auditor;",<not logged>
 CREATE FUNCTION test2_insert() RETURNS TRIGGER AS $$
@@ -151,13 +145,13 @@ SELECT *
 GRANT SELECT
    ON vw_test3
    TO user2;
-NOTICE:  AUDIT: SESSION,12,1,ROLE,GRANT,TABLE,,"GRANT SELECT
+NOTICE:  AUDIT: SESSION,13,1,ROLE,GRANT,TABLE,,"GRANT SELECT
    ON vw_test3
    TO user2;",<not logged>
 GRANT SELECT
    ON vw_test3
    TO auditor;
-NOTICE:  AUDIT: SESSION,13,1,ROLE,GRANT,TABLE,,"GRANT SELECT
+NOTICE:  AUDIT: SESSION,14,1,ROLE,GRANT,TABLE,,"GRANT SELECT
    ON vw_test3
    TO auditor;",<not logged>
 \connect - user2
@@ -179,7 +173,7 @@ SELECT *
   FROM test3, test2;
 WARNING:  AUDIT: SESSION,1,1,READ,SELECT,,,"SELECT *
   FROM test3, test2;",<not logged>
-WARNING:  AUDIT: OBJECT,1,1,READ,SELECT,TABLE,public.test2,<previously logged>,<previously logged>
+WARNING:  AUDIT: OBJECT,1,1,READ,SELECT,UNKNOWN,public.test2,<previously logged>,<previously logged>
  id | id 
 ----+----
 (0 rows)
@@ -192,8 +186,7 @@ SELECT *
   FROM vw_test3, test2;
 WARNING:  AUDIT: SESSION,2,1,READ,SELECT,,,"SELECT *
   FROM vw_test3, test2;",<not logged>
-WARNING:  AUDIT: OBJECT,2,1,READ,SELECT,TABLE,public.test2,<previously logged>,<previously logged>
-WARNING:  AUDIT: OBJECT,2,1,READ,SELECT,VIEW,public.vw_test3,<previously logged>,<previously logged>
+WARNING:  AUDIT: OBJECT,2,1,READ,SELECT,UNKNOWN,public.test2,<previously logged>,<previously logged>
  id | id 
 ----+----
 (0 rows)
@@ -218,100 +211,32 @@ WARNING:  AUDIT: SESSION,3,1,WRITE,INSERT,,,"WITH CTE AS
 INSERT INTO test3
 SELECT id
   FROM cte;",<not logged>
-WARNING:  AUDIT: OBJECT,3,1,WRITE,INSERT,TABLE,public.test3,<previously logged>,<previously logged>
-WARNING:  AUDIT: OBJECT,3,1,READ,SELECT,TABLE,public.test2,<previously logged>,<previously logged>
---
--- Object logged because of:
--- insert on test3
-WITH CTE AS
-(
-	INSERT INTO test3 VALUES (1)
-				   RETURNING id
-)
-INSERT INTO test2
-SELECT id
-  FROM cte;
-WARNING:  AUDIT: SESSION,4,1,WRITE,INSERT,,,"WITH CTE AS
-(
-	INSERT INTO test3 VALUES (1)
-				   RETURNING id
-)
-INSERT INTO test2
-SELECT id
-  FROM cte;",<not logged>
-WARNING:  AUDIT: OBJECT,4,1,WRITE,INSERT,TABLE,public.test3,<previously logged>,<previously logged>
+WARNING:  AUDIT: OBJECT,3,1,WRITE,INSERT,UNKNOWN,public.test3,<previously logged>,<previously logged>
+WARNING:  AUDIT: OBJECT,3,1,READ,SELECT,UNKNOWN,public.test2,<previously logged>,<previously logged>
 DO $$ BEGIN PERFORM test2_change(91); END $$;
-WARNING:  AUDIT: SESSION,5,1,READ,SELECT,,,SELECT test2_change(91),<not logged>
-WARNING:  AUDIT: SESSION,5,2,WRITE,UPDATE,,,"UPDATE test2
+WARNING:  AUDIT: SESSION,4,1,READ,SELECT,,,SELECT test2_change(91),<not logged>
+WARNING:  AUDIT: OBJECT,4,1,WRITE,UPDATE,TABLE,public.test2,<previously logged>,<previously logged>
+WARNING:  AUDIT: SESSION,4,2,WRITE,UPDATE,,,"UPDATE test2
 	   SET id = id + 1
 	 WHERE id = change_id",<not logged>
-WARNING:  AUDIT: OBJECT,5,2,WRITE,UPDATE,TABLE,public.test2,<previously logged>,<previously logged>
---
--- Object logged because of:
--- insert on test3
--- update on test2
-WITH CTE AS
-(
-	UPDATE test2
-	   SET id = 45
-	 WHERE id = 92
-	RETURNING id
-)
-INSERT INTO test3
-SELECT id
-  FROM cte;
-WARNING:  AUDIT: SESSION,6,1,WRITE,INSERT,,,"WITH CTE AS
-(
-	UPDATE test2
-	   SET id = 45
-	 WHERE id = 92
-	RETURNING id
-)
-INSERT INTO test3
-SELECT id
-  FROM cte;",<not logged>
-WARNING:  AUDIT: OBJECT,6,1,WRITE,INSERT,TABLE,public.test3,<previously logged>,<previously logged>
-WARNING:  AUDIT: OBJECT,6,1,WRITE,UPDATE,TABLE,public.test2,<previously logged>,<previously logged>
---
--- Object logged because of:
--- insert on test2
-WITH CTE AS
-(
-	INSERT INTO test2 VALUES (37)
-				   RETURNING id
-)
-UPDATE test3
-   SET id = cte.id
-  FROM cte
- WHERE test3.id <> cte.id;
-WARNING:  AUDIT: SESSION,7,1,WRITE,UPDATE,,,"WITH CTE AS
-(
-	INSERT INTO test2 VALUES (37)
-				   RETURNING id
-)
-UPDATE test3
-   SET id = cte.id
-  FROM cte
- WHERE test3.id <> cte.id;",<not logged>
-WARNING:  AUDIT: OBJECT,7,1,WRITE,INSERT,TABLE,public.test2,<previously logged>,<previously logged>
+WARNING:  AUDIT: OBJECT,4,2,WRITE,UPDATE,UNKNOWN,public.test2,<previously logged>,<previously logged>
+WARNING:  AUDIT: OBJECT,4,2,READ,SELECT,UNKNOWN,public.test2,<previously logged>,<previously logged>
 --
 -- Be sure that test has correct contents
 SELECT *
   FROM test2
  ORDER BY ID;
-WARNING:  AUDIT: SESSION,8,1,READ,SELECT,,,"SELECT *
+WARNING:  AUDIT: SESSION,5,1,READ,SELECT,,,"SELECT *
   FROM test2
  ORDER BY ID;",<not logged>
-WARNING:  AUDIT: OBJECT,8,1,READ,SELECT,TABLE,public.test2,<previously logged>,<previously logged>
- id  
------
-  45
- 127
-(2 rows)
+WARNING:  AUDIT: OBJECT,5,1,READ,SELECT,UNKNOWN,public.test2,<previously logged>,<previously logged>
+ id 
+----
+(0 rows)
 
 --
 -- Change permissions of user 2 so that only object logging will be done
-\connect - :current_user
+\connect - :"current_user"
 ALTER ROLE user2 SET pgaudit.log = 'NONE';
 NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,ALTER ROLE user2 SET pgaudit.log = 'NONE';,<not logged>
 \connect - user2
@@ -321,7 +246,7 @@ CREATE TABLE test4
 (
 	id int,
 	name text
-);
+) DISTRIBUTED BY (id);
 GRANT SELECT (name)
    ON TABLE public.test4
    TO auditor;
@@ -335,6 +260,8 @@ GRANT insert (name)
 -- Not object logged
 SELECT id
   FROM public.test4;
+WARNING:  AUDIT: OBJECT,1,1,READ,SELECT,UNKNOWN,public.test4,"SELECT id
+  FROM public.test4;",<not logged>
  id 
 ----
 (0 rows)
@@ -344,7 +271,7 @@ SELECT id
 -- select (name) on test4
 SELECT name
   FROM public.test4;
-WARNING:  AUDIT: OBJECT,1,1,READ,SELECT,TABLE,public.test4,"SELECT name
+WARNING:  AUDIT: OBJECT,2,1,READ,SELECT,UNKNOWN,public.test4,"SELECT name
   FROM public.test4;",<not logged>
  name 
 ------
@@ -354,33 +281,40 @@ WARNING:  AUDIT: OBJECT,1,1,READ,SELECT,TABLE,public.test4,"SELECT name
 -- Not object logged
 INSERT INTO public.test4 (id)
 				  VALUES (1);
+WARNING:  AUDIT: OBJECT,3,1,WRITE,INSERT,UNKNOWN,public.test4,"INSERT INTO public.test4 (id)
+				  VALUES (1);",<not logged>
 --
 -- Object logged because of:
 -- insert (name) on test4
 INSERT INTO public.test4 (name)
 				  VALUES ('test');
-WARNING:  AUDIT: OBJECT,2,1,WRITE,INSERT,TABLE,public.test4,"INSERT INTO public.test4 (name)
+WARNING:  AUDIT: OBJECT,4,1,WRITE,INSERT,UNKNOWN,public.test4,"INSERT INTO public.test4 (name)
 				  VALUES ('test');",<not logged>
 --
 -- Not object logged
 UPDATE public.test4
    SET name = 'foo';
+WARNING:  AUDIT: OBJECT,5,1,WRITE,UPDATE,UNKNOWN,public.test4,"UPDATE public.test4
+   SET name = 'foo';",<not logged>
+WARNING:  AUDIT: OBJECT,5,1,READ,SELECT,UNKNOWN,public.test4,<previously logged>,<previously logged>
 --
 -- Object logged because of:
 -- update (id) on test4
 UPDATE public.test4
    SET id = 1;
-WARNING:  AUDIT: OBJECT,3,1,WRITE,UPDATE,TABLE,public.test4,"UPDATE public.test4
+WARNING:  AUDIT: OBJECT,6,1,WRITE,UPDATE,UNKNOWN,public.test4,"UPDATE public.test4
    SET id = 1;",<not logged>
+WARNING:  AUDIT: OBJECT,6,1,READ,SELECT,UNKNOWN,public.test4,<previously logged>,<previously logged>
 --
 -- Object logged because of:
 -- update (name) on test4
 -- update (name) takes precedence over select (name) due to ordering
 update public.test4 set name = 'foo' where name = 'bar';
-WARNING:  AUDIT: OBJECT,4,1,WRITE,UPDATE,TABLE,public.test4,update public.test4 set name = 'foo' where name = 'bar';,<not logged>
+WARNING:  AUDIT: OBJECT,7,1,WRITE,UPDATE,UNKNOWN,public.test4,update public.test4 set name = 'foo' where name = 'bar';,<not logged>
+WARNING:  AUDIT: OBJECT,7,1,READ,SELECT,UNKNOWN,public.test4,<previously logged>,<previously logged>
 --
 -- Change permissions of user 1 so that session logging will be done
-\connect - :current_user
+\connect - :"current_user"
 --
 -- Drop test tables
 DROP TABLE test2;
@@ -400,14 +334,14 @@ CREATE TABLE public.account
 	name TEXT,
 	password TEXT,
 	description TEXT
-);
+) DISTRIBUTED BY (id);
 NOTICE:  AUDIT: SESSION,1,1,DDL,CREATE TABLE,TABLE,public.account,"CREATE TABLE public.account
 (
 	id INT,
 	name TEXT,
 	password TEXT,
 	description TEXT
-);",<not logged>
+) DISTRIBUTED BY (id);",<not logged>
 --
 -- Select is session logged
 SELECT *
@@ -424,7 +358,7 @@ INSERT INTO account (id, name, password, description)
 			 VALUES (1, 'user1', 'HASH1', 'blah, blah');
 --
 -- Change permissions of user 1 so that only object logging will be done
-\connect - :current_user
+\connect - :"current_user"
 ALTER ROLE user1 SET pgaudit.log = 'none';
 NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 SET pgaudit.log = 'none';,<not logged>
 ALTER ROLE user1 SET pgaudit.role = 'auditor';
@@ -441,6 +375,9 @@ GRANT SELECT (password),
 SELECT id,
 	   name
   FROM account;
+NOTICE:  AUDIT: OBJECT,1,1,READ,SELECT,UNKNOWN,public.account,"SELECT id,
+	   name
+  FROM account;",<not logged>
  id | name  
 ----+-------
   1 | user1
@@ -451,7 +388,7 @@ SELECT id,
 -- select (password) on account
 SELECT password
   FROM account;
-NOTICE:  AUDIT: OBJECT,1,1,READ,SELECT,TABLE,public.account,"SELECT password
+NOTICE:  AUDIT: OBJECT,2,1,READ,SELECT,UNKNOWN,public.account,"SELECT password
   FROM account;",<not logged>
  password 
 ----------
@@ -462,16 +399,22 @@ NOTICE:  AUDIT: OBJECT,1,1,READ,SELECT,TABLE,public.account,"SELECT password
 -- Not object logged
 UPDATE account
    SET description = 'yada, yada';
+NOTICE:  AUDIT: OBJECT,3,1,WRITE,UPDATE,UNKNOWN,public.account,"UPDATE account
+   SET description = 'yada, yada';",<not logged>
+NOTICE:  AUDIT: OBJECT,3,1,READ,SELECT,UNKNOWN,public.account,"UPDATE account
+   SET description = 'yada, yada';",<not logged>
 --
 -- Object logged because of:
 -- update (password) on account
 UPDATE account
    SET password = 'HASH2';
-NOTICE:  AUDIT: OBJECT,2,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
+NOTICE:  AUDIT: OBJECT,4,1,WRITE,UPDATE,UNKNOWN,public.account,"UPDATE account
+   SET password = 'HASH2';",<not logged>
+NOTICE:  AUDIT: OBJECT,4,1,READ,SELECT,UNKNOWN,public.account,"UPDATE account
    SET password = 'HASH2';",<not logged>
 --
 -- Change permissions of user 1 so that session relation logging will be done
-\connect - :current_user
+\connect - :"current_user"
 ALTER ROLE user1 SET pgaudit.log_relation = on;
 NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 SET pgaudit.log_relation = on;,<not logged>
 ALTER ROLE user1 SET pgaudit.log = 'read, WRITE';
@@ -483,7 +426,7 @@ CREATE TABLE ACCOUNT_ROLE_MAP
 (
 	account_id INT,
 	role_id INT
-);
+) DISTRIBUTED BY (account_id);
 --
 -- ROLE class not set, so auditor grants not logged
 GRANT SELECT
@@ -499,22 +442,22 @@ SELECT account.password,
   FROM account
 	   INNER JOIN account_role_map
 			on account.id = account_role_map.account_id;
-NOTICE:  AUDIT: OBJECT,1,1,READ,SELECT,TABLE,public.account,"SELECT account.password,
+NOTICE:  AUDIT: OBJECT,1,1,READ,SELECT,UNKNOWN,public.account,"SELECT account.password,
 	   account_role_map.role_id
   FROM account
 	   INNER JOIN account_role_map
 			on account.id = account_role_map.account_id;",<not logged>
-NOTICE:  AUDIT: SESSION,1,1,READ,SELECT,TABLE,public.account,"SELECT account.password,
+NOTICE:  AUDIT: SESSION,1,1,READ,SELECT,UNKNOWN,public.account,"SELECT account.password,
 	   account_role_map.role_id
   FROM account
 	   INNER JOIN account_role_map
 			on account.id = account_role_map.account_id;",<not logged>
-NOTICE:  AUDIT: OBJECT,1,1,READ,SELECT,TABLE,public.account_role_map,"SELECT account.password,
+NOTICE:  AUDIT: OBJECT,1,1,READ,SELECT,UNKNOWN,public.account_role_map,"SELECT account.password,
 	   account_role_map.role_id
   FROM account
 	   INNER JOIN account_role_map
 			on account.id = account_role_map.account_id;",<not logged>
-NOTICE:  AUDIT: SESSION,1,1,READ,SELECT,TABLE,public.account_role_map,"SELECT account.password,
+NOTICE:  AUDIT: SESSION,1,1,READ,SELECT,UNKNOWN,public.account_role_map,"SELECT account.password,
 	   account_role_map.role_id
   FROM account
 	   INNER JOIN account_role_map
@@ -529,9 +472,9 @@ NOTICE:  AUDIT: SESSION,1,1,READ,SELECT,TABLE,public.account_role_map,"SELECT ac
 -- Session logged on all tables because log = read and log_relation = on
 SELECT password
   FROM account;
-NOTICE:  AUDIT: OBJECT,2,1,READ,SELECT,TABLE,public.account,"SELECT password
+NOTICE:  AUDIT: OBJECT,2,1,READ,SELECT,UNKNOWN,public.account,"SELECT password
   FROM account;",<not logged>
-NOTICE:  AUDIT: SESSION,2,1,READ,SELECT,TABLE,public.account,"SELECT password
+NOTICE:  AUDIT: SESSION,2,1,READ,SELECT,UNKNOWN,public.account,"SELECT password
   FROM account;",<not logged>
  password 
 ----------
@@ -543,7 +486,13 @@ NOTICE:  AUDIT: SESSION,2,1,READ,SELECT,TABLE,public.account,"SELECT password
 -- Session logged on all tables because log = read and log_relation = on
 UPDATE account
    SET description = 'yada, yada';
-NOTICE:  AUDIT: SESSION,3,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
+NOTICE:  AUDIT: OBJECT,3,1,WRITE,UPDATE,UNKNOWN,public.account,"UPDATE account
+   SET description = 'yada, yada';",<not logged>
+NOTICE:  AUDIT: SESSION,3,1,WRITE,UPDATE,UNKNOWN,public.account,"UPDATE account
+   SET description = 'yada, yada';",<not logged>
+NOTICE:  AUDIT: OBJECT,3,1,READ,SELECT,UNKNOWN,public.account,"UPDATE account
+   SET description = 'yada, yada';",<not logged>
+NOTICE:  AUDIT: SESSION,3,1,READ,SELECT,UNKNOWN,public.account,"UPDATE account
    SET description = 'yada, yada';",<not logged>
 --
 -- Object logged because of:
@@ -552,10 +501,16 @@ NOTICE:  AUDIT: SESSION,3,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
 UPDATE account
    SET description = 'yada, yada'
  where password = 'HASH2';
-NOTICE:  AUDIT: OBJECT,4,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
+NOTICE:  AUDIT: OBJECT,4,1,WRITE,UPDATE,UNKNOWN,public.account,"UPDATE account
    SET description = 'yada, yada'
  where password = 'HASH2';",<not logged>
-NOTICE:  AUDIT: SESSION,4,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
+NOTICE:  AUDIT: SESSION,4,1,WRITE,UPDATE,UNKNOWN,public.account,"UPDATE account
+   SET description = 'yada, yada'
+ where password = 'HASH2';",<not logged>
+NOTICE:  AUDIT: OBJECT,4,1,READ,SELECT,UNKNOWN,public.account,"UPDATE account
+   SET description = 'yada, yada'
+ where password = 'HASH2';",<not logged>
+NOTICE:  AUDIT: SESSION,4,1,READ,SELECT,UNKNOWN,public.account,"UPDATE account
    SET description = 'yada, yada'
  where password = 'HASH2';",<not logged>
 --
@@ -564,13 +519,17 @@ NOTICE:  AUDIT: SESSION,4,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
 -- Session logged on all tables because log = read and log_relation = on
 UPDATE account
    SET password = 'HASH2';
-NOTICE:  AUDIT: OBJECT,5,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
+NOTICE:  AUDIT: OBJECT,5,1,WRITE,UPDATE,UNKNOWN,public.account,"UPDATE account
    SET password = 'HASH2';",<not logged>
-NOTICE:  AUDIT: SESSION,5,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
+NOTICE:  AUDIT: SESSION,5,1,WRITE,UPDATE,UNKNOWN,public.account,"UPDATE account
+   SET password = 'HASH2';",<not logged>
+NOTICE:  AUDIT: OBJECT,5,1,READ,SELECT,UNKNOWN,public.account,"UPDATE account
+   SET password = 'HASH2';",<not logged>
+NOTICE:  AUDIT: SESSION,5,1,READ,SELECT,UNKNOWN,public.account,"UPDATE account
    SET password = 'HASH2';",<not logged>
 --
 -- Change back to superuser to do exhaustive tests
-\connect - :current_user
+\connect - :"current_user"
 SET pgaudit.log = 'ALL';
 NOTICE:  AUDIT: SESSION,1,1,MISC,SET,,,SET pgaudit.log = 'ALL';,<not logged>
 SET pgaudit.log_level = 'notice';
@@ -605,16 +564,24 @@ NOTICE:  AUDIT: SESSION,8,1,READ,SELECT,TABLE,public.account,COPY account TO std
 -- Create a table from a query
 CREATE TABLE test.account_copy AS
 SELECT *
-  FROM account;
+  FROM account
+DISTRIBUTED BY (id);
 NOTICE:  AUDIT: SESSION,9,1,READ,SELECT,TABLE,public.account,"CREATE TABLE test.account_copy AS
 SELECT *
-  FROM account;",<none>
-NOTICE:  AUDIT: SESSION,9,1,WRITE,INSERT,TABLE,test.account_copy,"CREATE TABLE test.account_copy AS
+  FROM account
+DISTRIBUTED BY (id);",<none>
+NOTICE:  AUDIT: SESSION,9,2,READ,SELECT,UNKNOWN,public.account,"CREATE TABLE test.account_copy AS
 SELECT *
-  FROM account;",<none>
-NOTICE:  AUDIT: SESSION,9,2,DDL,CREATE TABLE AS,TABLE,test.account_copy,"CREATE TABLE test.account_copy AS
+  FROM account
+DISTRIBUTED BY (id);",<none>
+NOTICE:  AUDIT: SESSION,9,2,WRITE,INSERT,TABLE,test.account_copy,"CREATE TABLE test.account_copy AS
 SELECT *
-  FROM account;",<none>
+  FROM account
+DISTRIBUTED BY (id);",<none>
+NOTICE:  AUDIT: SESSION,9,1,DDL,CREATE TABLE AS,TABLE,test.account_copy,"CREATE TABLE test.account_copy AS
+SELECT *
+  FROM account
+DISTRIBUTED BY (id);",<none>
 --
 -- Copy from stdin to account copy
 COPY test.account_copy from stdin;
@@ -630,11 +597,11 @@ SELECT *
   FROM account
  WHERE id = $1;",<none>
 EXECUTE pgclassstmt (1);
-NOTICE:  AUDIT: SESSION,12,1,READ,SELECT,TABLE,public.account,"PREPARE pgclassstmt (oid) AS
+NOTICE:  AUDIT: SESSION,12,1,READ,SELECT,TABLE,public.account,EXECUTE pgclassstmt (1);,<none>
+NOTICE:  AUDIT: SESSION,12,2,READ,SELECT,UNKNOWN,public.account,"PREPARE pgclassstmt (oid) AS
 SELECT *
   FROM account
  WHERE id = $1;",1
-NOTICE:  AUDIT: SESSION,12,2,MISC,EXECUTE,,,EXECUTE pgclassstmt (1);,<none>
  id | name  | password | description 
 ----+-------+----------+-------------
   1 | user1 | HASH2    | yada, yada
@@ -702,11 +669,11 @@ SELECT count(*)
 CREATE TABLE test.test_insert
 (
 	id INT
-);
+) DISTRIBUTED BY (id);
 NOTICE:  AUDIT: SESSION,20,1,DDL,CREATE TABLE,TABLE,test.test_insert,"CREATE TABLE test.test_insert
 (
 	id INT
-);",<none>
+) DISTRIBUTED BY (id);",<none>
 PREPARE pgclassstmt (oid) AS
 INSERT INTO test.test_insert (id)
 					  VALUES ($1);
@@ -714,10 +681,10 @@ NOTICE:  AUDIT: SESSION,21,1,WRITE,PREPARE,,,"PREPARE pgclassstmt (oid) AS
 INSERT INTO test.test_insert (id)
 					  VALUES ($1);",<none>
 EXECUTE pgclassstmt (1);
-NOTICE:  AUDIT: SESSION,22,1,WRITE,INSERT,TABLE,test.test_insert,"PREPARE pgclassstmt (oid) AS
+NOTICE:  AUDIT: SESSION,22,1,WRITE,INSERT,TABLE,test.test_insert,EXECUTE pgclassstmt (1);,<none>
+NOTICE:  AUDIT: SESSION,22,2,WRITE,INSERT,UNKNOWN,test.test_insert,"PREPARE pgclassstmt (oid) AS
 INSERT INTO test.test_insert (id)
 					  VALUES ($1);",1
-NOTICE:  AUDIT: SESSION,22,2,MISC,EXECUTE,,,EXECUTE pgclassstmt (1);,<none>
 --
 -- Check that primary key creation is logged
 CREATE TABLE public.test
@@ -726,21 +693,21 @@ CREATE TABLE public.test
 	name TEXT,
 	description TEXT,
 	CONSTRAINT test_pkey PRIMARY KEY (id)
-);
+) DISTRIBUTED BY (id);
 NOTICE:  AUDIT: SESSION,23,1,DDL,CREATE TABLE,TABLE,public.test,"CREATE TABLE public.test
 (
 	id INT,
 	name TEXT,
 	description TEXT,
 	CONSTRAINT test_pkey PRIMARY KEY (id)
-);",<none>
+) DISTRIBUTED BY (id);",<none>
 NOTICE:  AUDIT: SESSION,23,1,DDL,CREATE INDEX,INDEX,public.test_pkey,"CREATE TABLE public.test
 (
 	id INT,
 	name TEXT,
 	description TEXT,
 	CONSTRAINT test_pkey PRIMARY KEY (id)
-);",<none>
+) DISTRIBUTED BY (id);",<none>
 --
 -- Check that analyze is logged
 ANALYZE test;
@@ -756,7 +723,7 @@ NOTICE:  AUDIT: SESSION,25,1,ROLE,GRANT,TABLE,,"GRANT SELECT
   TO PUBLIC;",<none>
 SELECT *
   FROM test;
-NOTICE:  AUDIT: SESSION,26,1,READ,SELECT,TABLE,public.test,"SELECT *
+NOTICE:  AUDIT: SESSION,26,1,READ,SELECT,UNKNOWN,public.test,"SELECT *
   FROM test;",<none>
  id | name | description 
 ----+------+-------------
@@ -765,7 +732,7 @@ NOTICE:  AUDIT: SESSION,26,1,READ,SELECT,TABLE,public.test,"SELECT *
 -- Check that statements without columns log
 SELECT
   FROM test;
-NOTICE:  AUDIT: SESSION,27,1,READ,SELECT,TABLE,public.test,"SELECT
+NOTICE:  AUDIT: SESSION,27,1,READ,SELECT,UNKNOWN,public.test,"SELECT
   FROM test;",<none>
 --
 (0 rows)
@@ -793,28 +760,37 @@ BEGIN
 	SELECT 1
 	  INTO test;
 END $$;",<none>
+NOTICE:  AUDIT: SESSION,29,1,FUNCTION,DO,,,"DO $$
+DECLARE
+	test INT;
+BEGIN
+	SELECT 1
+	  INTO test;
+END $$;",<none>
 NOTICE:  AUDIT: SESSION,29,2,READ,SELECT,,,SELECT 1,<none>
 explain select 1;
-NOTICE:  AUDIT: SESSION,30,1,READ,SELECT,,,explain select 1;,<none>
-NOTICE:  AUDIT: SESSION,30,2,MISC,EXPLAIN,,,explain select 1;,<none>
+NOTICE:  AUDIT: SESSION,30,1,MISC,EXPLAIN,,,explain select 1;,<none>
+NOTICE:  AUDIT: SESSION,30,2,READ,SELECT,,,explain select 1;,<none>
                 QUERY PLAN                
 ------------------------------------------
- Result  (cost=0.00..0.01 rows=1 width=0)
-(1 row)
+ Result  (cost=0.00..0.00 rows=1 width=4)
+   ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(3 rows)
 
 --
 -- Test that looks inside of do blocks log
 INSERT INTO TEST (id)
 		  VALUES (1);
-NOTICE:  AUDIT: SESSION,31,1,WRITE,INSERT,TABLE,public.test,"INSERT INTO TEST (id)
+NOTICE:  AUDIT: SESSION,31,1,WRITE,INSERT,UNKNOWN,public.test,"INSERT INTO TEST (id)
 		  VALUES (1);",<none>
 INSERT INTO TEST (id)
 		  VALUES (2);
-NOTICE:  AUDIT: SESSION,32,1,WRITE,INSERT,TABLE,public.test,"INSERT INTO TEST (id)
+NOTICE:  AUDIT: SESSION,32,1,WRITE,INSERT,UNKNOWN,public.test,"INSERT INTO TEST (id)
 		  VALUES (2);",<none>
 INSERT INTO TEST (id)
 		  VALUES (3);
-NOTICE:  AUDIT: SESSION,33,1,WRITE,INSERT,TABLE,public.test,"INSERT INTO TEST (id)
+NOTICE:  AUDIT: SESSION,33,1,WRITE,INSERT,UNKNOWN,public.test,"INSERT INTO TEST (id)
 		  VALUES (3);",<none>
 DO $$
 DECLARE
@@ -823,6 +799,7 @@ BEGIN
 	FOR result IN
 		SELECT id
 		  FROM test
+		ORDER BY id
 	LOOP
 		INSERT INTO test (id)
 			 VALUES (result.id + 100);
@@ -835,17 +812,41 @@ BEGIN
 	FOR result IN
 		SELECT id
 		  FROM test
+		ORDER BY id
 	LOOP
 		INSERT INTO test (id)
 			 VALUES (result.id + 100);
 	END LOOP;
 END $$;",<none>
-NOTICE:  AUDIT: SESSION,34,2,READ,SELECT,TABLE,public.test,"SELECT id
-		  FROM test",<none>
+NOTICE:  AUDIT: SESSION,34,1,READ,SELECT,TABLE,public.test,"DO $$
+DECLARE
+	result RECORD;
+BEGIN
+	FOR result IN
+		SELECT id
+		  FROM test
+		ORDER BY id
+	LOOP
+		INSERT INTO test (id)
+			 VALUES (result.id + 100);
+	END LOOP;
+END $$;",<none>
+NOTICE:  AUDIT: SESSION,34,2,READ,SELECT,UNKNOWN,public.test,"SELECT id
+		  FROM test
+		ORDER BY id",<none>
+NOTICE:  AUDIT: SESSION,34,2,WRITE,INSERT,TABLE,public.test,"SELECT id
+		  FROM test
+		ORDER BY id",<none>
 NOTICE:  AUDIT: SESSION,34,3,WRITE,INSERT,TABLE,public.test,"INSERT INTO test (id)
 			 VALUES (result.id + 100)",",,1"
+NOTICE:  AUDIT: SESSION,34,2,WRITE,INSERT,TABLE,public.test,"SELECT id
+		  FROM test
+		ORDER BY id",<none>
 NOTICE:  AUDIT: SESSION,34,4,WRITE,INSERT,TABLE,public.test,"INSERT INTO test (id)
 			 VALUES (result.id + 100)",",,2"
+NOTICE:  AUDIT: SESSION,34,2,WRITE,INSERT,TABLE,public.test,"SELECT id
+		  FROM test
+		ORDER BY id",<none>
 NOTICE:  AUDIT: SESSION,34,5,WRITE,INSERT,TABLE,public.test,"INSERT INTO test (id)
 			 VALUES (result.id + 100)",",,3"
 --
@@ -864,8 +865,31 @@ BEGIN
 	EXECUTE 'CREATE TABLE ' || table_name || ' (""weird name"" INT)';
 	EXECUTE 'DROP table ' || table_name;
 END $$;",<none>
-NOTICE:  AUDIT: SESSION,35,2,DDL,CREATE TABLE,TABLE,public.do_table,"CREATE TABLE do_table (""weird name"" INT)",<none>
-NOTICE:  AUDIT: SESSION,35,3,DDL,DROP TABLE,TABLE,public.do_table,DROP table do_table,<none>
+NOTICE:  AUDIT: SESSION,35,1,FUNCTION,DO,,,"DO $$
+DECLARE
+	table_name TEXT = 'do_table';
+BEGIN
+	EXECUTE 'CREATE TABLE ' || table_name || ' (""weird name"" INT)';
+	EXECUTE 'DROP table ' || table_name;
+END $$;",<none>
+NOTICE:  AUDIT: SESSION,35,2,READ,SELECT,,,SELECT 'do_table',<none>
+NOTICE:  AUDIT: SESSION,35,1,FUNCTION,DO,,,"DO $$
+DECLARE
+	table_name TEXT = 'do_table';
+BEGIN
+	EXECUTE 'CREATE TABLE ' || table_name || ' (""weird name"" INT)';
+	EXECUTE 'DROP table ' || table_name;
+END $$;",<none>
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'weird name' as the Greenplum Database data distribution key for this table.
+NOTICE:  AUDIT: SESSION,35,3,DDL,CREATE TABLE,TABLE,public.do_table,"CREATE TABLE do_table (""weird name"" INT)",<none>
+NOTICE:  AUDIT: SESSION,35,1,FUNCTION,DO,,,"DO $$
+DECLARE
+	table_name TEXT = 'do_table';
+BEGIN
+	EXECUTE 'CREATE TABLE ' || table_name || ' (""weird name"" INT)';
+	EXECUTE 'DROP table ' || table_name;
+END $$;",<none>
+NOTICE:  AUDIT: SESSION,35,4,DDL,DROP TABLE,TABLE,public.do_table,DROP table do_table,<none>
 --
 -- Generate an error and make sure the stack gets cleared
 DO $$
@@ -882,7 +906,7 @@ BEGIN
 		id INT
 	);
 END $$;",<none>
-ERROR:  schema "bogus" does not exist at character 14
+ERROR:  schema "bogus" does not exist
 --
 -- Test alter table statements
 ALTER TABLE public.test
@@ -916,17 +940,17 @@ NOTICE:  AUDIT: SESSION,42,1,DDL,DROP TABLE,INDEX,test.test_pkey,DROP TABLE test
 --
 -- Test multiple statements with one semi-colon
 CREATE SCHEMA foo
-	CREATE TABLE foo.bar (id int)
-	CREATE TABLE foo.baz (id int);
+	CREATE TABLE foo.bar (id int) DISTRIBUTED BY (id)
+	CREATE TABLE foo.baz (id int) DISTRIBUTED BY (id);
 NOTICE:  AUDIT: SESSION,43,1,DDL,CREATE SCHEMA,SCHEMA,foo,"CREATE SCHEMA foo
-	CREATE TABLE foo.bar (id int)
-	CREATE TABLE foo.baz (id int);",<none>
+	CREATE TABLE foo.bar (id int) DISTRIBUTED BY (id)
+	CREATE TABLE foo.baz (id int) DISTRIBUTED BY (id);",<none>
 NOTICE:  AUDIT: SESSION,43,1,DDL,CREATE TABLE,TABLE,foo.bar,"CREATE SCHEMA foo
-	CREATE TABLE foo.bar (id int)
-	CREATE TABLE foo.baz (id int);",<none>
+	CREATE TABLE foo.bar (id int) DISTRIBUTED BY (id)
+	CREATE TABLE foo.baz (id int) DISTRIBUTED BY (id);",<none>
 NOTICE:  AUDIT: SESSION,43,1,DDL,CREATE TABLE,TABLE,foo.baz,"CREATE SCHEMA foo
-	CREATE TABLE foo.bar (id int)
-	CREATE TABLE foo.baz (id int);",<none>
+	CREATE TABLE foo.bar (id int) DISTRIBUTED BY (id)
+	CREATE TABLE foo.baz (id int) DISTRIBUTED BY (id);",<none>
 --
 -- Test aggregate
 CREATE FUNCTION public.int_add
@@ -950,6 +974,7 @@ END $$;",<none>
 SELECT int_add(1, 1);
 NOTICE:  AUDIT: SESSION,45,1,READ,SELECT,,,"SELECT int_add(1, 1);",<none>
 NOTICE:  AUDIT: SESSION,45,2,FUNCTION,EXECUTE,FUNCTION,public.int_add,"SELECT int_add(1, 1);",<none>
+NOTICE:  AUDIT: SESSION,45,1,READ,SELECT,,,"SELECT int_add(1, 1);",<none>
  int_add 
 ---------
        2
@@ -975,9 +1000,10 @@ DROP DATABASE contrib_regression_pgaudit2;
 NOTICE:  AUDIT: SESSION,52,1,DDL,DROP DATABASE,,,DROP DATABASE contrib_regression_pgaudit2;,<none>
 -- Test role as a substmt
 SET pgaudit.log = 'ROLE';
-CREATE TABLE t ();
-CREATE ROLE alice;
-NOTICE:  AUDIT: SESSION,53,1,ROLE,CREATE ROLE,,,CREATE ROLE alice;,<none>
+CREATE TABLE t () DISTRIBUTED RANDOMLY;
+WARNING:  creating a table with no columns.
+CREATE ROLE alice RESOURCE QUEUE pg_default;
+NOTICE:  AUDIT: SESSION,53,1,ROLE,CREATE ROLE,,,CREATE ROLE alice RESOURCE QUEUE pg_default;,<none>
 CREATE SCHEMA foo2
 	GRANT SELECT
 	   ON public.t
@@ -1032,11 +1058,11 @@ NOTICE:  AUDIT: SESSION,56,1,MISC,SET,,,SET pgaudit.log = 'ALL';,<none>
 CREATE TABLE hoge
 (
 	id int
-);
+) DISTRIBUTED BY (id);
 NOTICE:  AUDIT: SESSION,57,1,DDL,CREATE TABLE,TABLE,public.hoge,"CREATE TABLE hoge
 (
 	id int
-);",<none>
+) DISTRIBUTED BY (id);",<none>
 CREATE FUNCTION test()
 	RETURNS INT AS $$
 DECLARE
@@ -1062,7 +1088,11 @@ LANGUAGE plpgsql ;",<none>
 SELECT test();
 NOTICE:  AUDIT: SESSION,59,1,READ,SELECT,,,SELECT test();,<none>
 NOTICE:  AUDIT: SESSION,59,2,FUNCTION,EXECUTE,FUNCTION,public.test,SELECT test();,<none>
-NOTICE:  AUDIT: SESSION,59,3,READ,SELECT,TABLE,public.hoge,select * from hoge,<none>
+NOTICE:  AUDIT: SESSION,59,1,READ,SELECT,,,SELECT test();,<none>
+NOTICE:  AUDIT: SESSION,59,3,READ,SELECT,,,SELECT 'cur1'::pg_catalog.refcursor,<none>
+NOTICE:  AUDIT: SESSION,59,1,READ,SELECT,TABLE,public.hoge,SELECT test();,<none>
+NOTICE:  AUDIT: SESSION,59,4,READ,SELECT,UNKNOWN,public.hoge,select * from hoge,<none>
+NOTICE:  AUDIT: SESSION,59,4,READ,SELECT,UNKNOWN,,select * from hoge,<none>
  test 
 ------
      
@@ -1075,26 +1105,26 @@ SET pgaudit.role = 'auditor';
 create table bar
 (
 	col int
-);
+) distributed by (col);
 grant delete
    on bar
    to auditor;
 insert into bar (col)
 		 values (1);
-NOTICE:  AUDIT: SESSION,60,1,WRITE,INSERT,TABLE,public.bar,"insert into bar (col)
+NOTICE:  AUDIT: SESSION,60,1,WRITE,INSERT,UNKNOWN,public.bar,"insert into bar (col)
 		 values (1);",<none>
 delete from bar;
-NOTICE:  AUDIT: OBJECT,61,1,WRITE,DELETE,TABLE,public.bar,delete from bar;,<none>
-NOTICE:  AUDIT: SESSION,61,1,WRITE,DELETE,TABLE,public.bar,delete from bar;,<none>
+NOTICE:  AUDIT: OBJECT,61,1,WRITE,DELETE,UNKNOWN,public.bar,delete from bar;,<none>
+NOTICE:  AUDIT: SESSION,61,1,WRITE,DELETE,UNKNOWN,public.bar,delete from bar;,<none>
 insert into bar (col)
 		 values (1);
-NOTICE:  AUDIT: SESSION,62,1,WRITE,INSERT,TABLE,public.bar,"insert into bar (col)
+NOTICE:  AUDIT: SESSION,62,1,WRITE,INSERT,UNKNOWN,public.bar,"insert into bar (col)
 		 values (1);",<none>
 delete from bar
  where col = 1;
-NOTICE:  AUDIT: OBJECT,63,1,WRITE,DELETE,TABLE,public.bar,"delete from bar
+NOTICE:  AUDIT: OBJECT,63,1,WRITE,DELETE,UNKNOWN,public.bar,"delete from bar
  where col = 1;",<none>
-NOTICE:  AUDIT: SESSION,63,1,WRITE,DELETE,TABLE,public.bar,"delete from bar
+NOTICE:  AUDIT: SESSION,63,1,WRITE,DELETE,UNKNOWN,public.bar,"delete from bar
  where col = 1;",<none>
 drop table bar;
 --
@@ -1104,52 +1134,10 @@ GRANT user1 TO user2;
 NOTICE:  AUDIT: SESSION,64,1,ROLE,GRANT ROLE,,,GRANT user1 TO user2;,<none>
 REVOKE user1 FROM user2;
 NOTICE:  AUDIT: SESSION,65,1,ROLE,REVOKE ROLE,,,REVOKE user1 FROM user2;,<none>
---
--- Test that FK references do not log but triggers still do
-SET pgaudit.log = 'READ,WRITE';
-SET pgaudit.role TO 'auditor';
-CREATE TABLE aaa
-(
-	ID int primary key
-);
-CREATE TABLE bbb
-(
-	id int
-		references aaa(id)
-);
-CREATE FUNCTION bbb_insert() RETURNS TRIGGER AS $$
-BEGIN
-	UPDATE bbb set id = new.id + 1;
-
-	RETURN new;
-END $$ LANGUAGE plpgsql;
-CREATE TRIGGER bbb_insert_trg
-	AFTER INSERT ON bbb
-	FOR EACH ROW EXECUTE PROCEDURE bbb_insert();
-GRANT SELECT
-   ON aaa
-   TO auditor;
-GRANT UPDATE
-   ON bbb
-   TO auditor;
-INSERT INTO aaa VALUES (generate_series(1,100));
-NOTICE:  AUDIT: SESSION,66,1,WRITE,INSERT,TABLE,public.aaa,"INSERT INTO aaa VALUES (generate_series(1,100));",<none>
-INSERT INTO bbb VALUES (1);
-NOTICE:  AUDIT: SESSION,67,1,WRITE,INSERT,TABLE,public.bbb,INSERT INTO bbb VALUES (1);,<none>
-NOTICE:  AUDIT: OBJECT,67,2,WRITE,UPDATE,TABLE,public.aaa,"SELECT 1 FROM ONLY ""public"".""aaa"" x WHERE ""id"" OPERATOR(pg_catalog.=) $1 FOR KEY SHARE OF x",1
-NOTICE:  AUDIT: SESSION,67,2,WRITE,UPDATE,TABLE,public.aaa,"SELECT 1 FROM ONLY ""public"".""aaa"" x WHERE ""id"" OPERATOR(pg_catalog.=) $1 FOR KEY SHARE OF x",1
-NOTICE:  AUDIT: OBJECT,67,3,WRITE,UPDATE,TABLE,public.bbb,UPDATE bbb set id = new.id + 1,",,,,,,,,,,,,,1"
-NOTICE:  AUDIT: SESSION,67,3,WRITE,UPDATE,TABLE,public.bbb,UPDATE bbb set id = new.id + 1,",,,,,,,,,,,,,1"
-NOTICE:  AUDIT: OBJECT,67,4,WRITE,UPDATE,TABLE,public.aaa,"SELECT 1 FROM ONLY ""public"".""aaa"" x WHERE ""id"" OPERATOR(pg_catalog.=) $1 FOR KEY SHARE OF x",2
-NOTICE:  AUDIT: SESSION,67,4,WRITE,UPDATE,TABLE,public.aaa,"SELECT 1 FROM ONLY ""public"".""aaa"" x WHERE ""id"" OPERATOR(pg_catalog.=) $1 FOR KEY SHARE OF x",2
-DROP TABLE bbb;
-DROP TABLE aaa;
 -- Test create table as after extension as been dropped
 DROP EXTENSION pgaudit;
-CREATE TABLE tmp (id int, data text);
-CREATE TABLE tmp2 AS (SELECT * FROM tmp);
-NOTICE:  AUDIT: SESSION,68,1,READ,SELECT,TABLE,public.tmp,CREATE TABLE tmp2 AS (SELECT * FROM tmp);,<none>
-NOTICE:  AUDIT: SESSION,68,1,WRITE,INSERT,TABLE,public.tmp2,CREATE TABLE tmp2 AS (SELECT * FROM tmp);,<none>
+CREATE TABLE tmp (id int, data text) DISTRIBUTED BY (id);
+CREATE TABLE tmp2 AS (SELECT * FROM tmp) DISTRIBUTED BY (id);
 DROP TABLE tmp;
 DROP TABLE tmp2;
 --
@@ -1169,10 +1157,11 @@ SET pgaudit.log = 'DDL';
 -- Put public schema before pg_catalog to capture unqualified references
 SET search_path = public, pg_catalog;
 -- If there was a vulnerability, these would fail with division by zero error
-CREATE TABLE wombat ();
-NOTICE:  AUDIT: SESSION,69,1,DDL,CREATE TABLE,TABLE,public.wombat,CREATE TABLE wombat ();,<none>
+CREATE TABLE wombat () DISTRIBUTED RANDOMLY;
+WARNING:  creating a table with no columns.
+NOTICE:  AUDIT: SESSION,66,1,DDL,CREATE TABLE,TABLE,public.wombat,CREATE TABLE wombat () DISTRIBUTED RANDOMLY;,<none>
 DROP TABLE wombat;
-NOTICE:  AUDIT: SESSION,70,1,DDL,DROP TABLE,TABLE,public.wombat,DROP TABLE wombat;,<none>
+NOTICE:  AUDIT: SESSION,67,1,DDL,DROP TABLE,TABLE,public.wombat,DROP TABLE wombat;,<none>
 SET pgaudit.log = 'NONE';
 DROP EXTENSION pgaudit;
 DROP OPERATOR <> (text, text);
@@ -1183,14 +1172,14 @@ DROP FUNCTION upper(text);
 -- Cleanup
 -- Set client_min_messages up to warning to avoid noise
 SET client_min_messages = 'warning';
-ALTER ROLE :current_user RESET pgaudit.log;
-ALTER ROLE :current_user RESET pgaudit.log_catalog;
-ALTER ROLE :current_user RESET pgaudit.log_client;
-ALTER ROLE :current_user RESET pgaudit.log_level;
-ALTER ROLE :current_user RESET pgaudit.log_parameter;
-ALTER ROLE :current_user RESET pgaudit.log_relation;
-ALTER ROLE :current_user RESET pgaudit.log_statement_once;
-ALTER ROLE :current_user RESET pgaudit.role;
+ALTER ROLE :"current_user" RESET pgaudit.log;
+ALTER ROLE :"current_user" RESET pgaudit.log_catalog;
+ALTER ROLE :"current_user" RESET pgaudit.log_client;
+ALTER ROLE :"current_user" RESET pgaudit.log_level;
+ALTER ROLE :"current_user" RESET pgaudit.log_parameter;
+ALTER ROLE :"current_user" RESET pgaudit.log_relation;
+ALTER ROLE :"current_user" RESET pgaudit.log_statement_once;
+ALTER ROLE :"current_user" RESET pgaudit.role;
 RESET pgaudit.log;
 RESET pgaudit.log_catalog;
 RESET pgaudit.log_level;


### PR DESCRIPTION
Now pgaudit works on master only. So we don't receive messages from segments,
and the messages order is stable.
Fix use after free for auditEventStack->auditEvent.objectName.
Add DISTRIBUTED to the CREATE TABLE queries and RESOURCE QUEUE to CREATE ROLE to
get rid of Greenplum specific warnings.
Make changes in pg_hba.conf to login as users which are created in the tests.
Wrap the current user name in quotation marks, because it can contain symbols
which broke the tests, for example '-'.
Remove queries which Greenplum cannot execute: queries with more then one
writing slice and triggers updating each row.