### PR TITLE
Add a copy of ic-good-opt-on, but with pgaudit (#274)

### DIFF
--- a/.github/workflows/build-gpdb.yml
+++ b/.github/workflows/build-gpdb.yml
@@ -106,6 +106,11 @@ jobs:
                "make_configs":["src/test/regress:installcheck-good"],
                "pg_settings":{"optimizer":"on"}
               },
+              {"test":"ic-good-opt-pgaudit",
+               "make_configs":["src/test/regress:installcheck-good"],
+               "pg_settings":{"optimizer":"on"},
+               "extension":"pgaudit"
+              },
               {"test":"ic-expandshrink",
                "make_configs":["src/test/isolation2:installcheck-expandshrink"]
               },
@@ -1066,6 +1071,33 @@ jobs:
           PG_OPTS=""
           if [[ "${{ matrix.pg_settings.optimizer != '' }}" == "true" ]]; then
             PG_OPTS="$PG_OPTS -c optimizer=${{ matrix.pg_settings.optimizer }}"
+          fi
+
+          # Create extension if required
+          if [[ "${{ matrix.extension != '' }}" == "true" ]]; then
+            case "${{ matrix.extension }}" in
+              pgaudit)
+                export BUILD_DESTINATION=/opt/greenplum-db-6
+
+                if ! su - gpadmin -c "source ${BUILD_DESTINATION}/greenplum_path.sh && \
+                  source ${SRC_DIR}/gpAux/gpdemo/gpdemo-env.sh && \
+                  gpconfig -c shared_preload_libraries -v 'pgaudit' --masteronly && \
+                  gpstop -ra && \
+                  echo 'CREATE EXTENSION IF NOT EXISTS gp_aux_catalog; \
+                        CREATE EXTENSION IF NOT EXISTS pgaudit; \
+                        SHOW shared_preload_libraries; \
+                        TABLE pg_extension;' | \
+                    psql postgres"
+                then
+                    echo "Error creating pgaudit extension"
+                    exit 1
+                fi
+                ;;
+              *)
+                echo "Unknown extension: ${{ matrix.extension }}"
+                exit 1
+                ;;
+            esac
           fi
 
           # Read configs into array

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -3581,6 +3581,16 @@ GetCommandLogLevel(Node *parsetree)
 			}
 			break;
 
+		case T_CreateQueueStmt:
+		case T_AlterQueueStmt:
+		case T_DropQueueStmt:
+		case T_CreateResourceGroupStmt:
+		case T_AlterResourceGroupStmt:
+		case T_DropResourceGroupStmt:
+		case T_AlterTypeStmt:
+			lev = LOGSTMT_DDL;
+			break;
+
 		default:
 			elog(WARNING, "unrecognized node type: %d",
 				 (int) nodeTag(parsetree));


### PR DESCRIPTION
When the ic-good-opt-on tests were run with pgaudit, some of them failed because
pgaudit output warnings "unrecognized node type". To make the tests comportable
with pgaudit add cases for Greenplum specific node types to GetCommandLogLevel.
GetCommandLogLevel is called only from check_log_statement which returns whether
to log a query. Queries of added types are logged as DDL.
