### PR TITLE
Don't try to use Orca for queries that it doesn't support

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -3195,6 +3195,7 @@ _copyQuery(const Query *from)
 	COPY_NODE_FIELD(constraintDeps);
 	COPY_NODE_FIELD(intoPolicy);
 	COPY_SCALAR_FIELD(parentStmtType);
+	COPY_SCALAR_FIELD(usePostgresPlanner);
 
 	return newnode;
 }

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -933,6 +933,7 @@ _equalQuery(const Query *a, const Query *b)
 		return false;
 
 	COMPARE_SCALAR_FIELD(parentStmtType);
+	COMPARE_SCALAR_FIELD(usePostgresPlanner);
 
 	return true;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3837,6 +3837,7 @@ _outQuery(StringInfo str, const Query *node)
 	WRITE_NODE_FIELD(setOperations);
 	WRITE_NODE_FIELD(constraintDeps);
 	WRITE_BOOL_FIELD(parentStmtType);
+	WRITE_BOOL_FIELD(usePostgresPlanner);
 
 	/* Don't serialize policy */
 }

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -404,6 +404,7 @@ _readQuery(void)
 	READ_NODE_FIELD(setOperations);
 	READ_NODE_FIELD(constraintDeps);
 	READ_BOOL_FIELD(parentStmtType);
+	READ_BOOL_FIELD(usePostgresPlanner);
 
 	local_node->intoPolicy = NULL;
 

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -231,6 +231,7 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	 * PARALLEL RETRIEVE CURSOR is not supported by ORCA yet.
 	 */
 	if (optimizer &&
+		!parse->usePostgresPlanner &&
 		GP_ROLE_DISPATCH == Gp_role &&
 		IS_QUERY_DISPATCHER() &&
 		(cursorOptions & CURSOR_OPT_PARALLEL_RETRIEVE) == 0)

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -355,6 +355,8 @@ transformStmt(ParseState *pstate, Node *parseTree)
 	if (pstate->p_hasDynamicFunction)
 		result->hasDynamicFunctions = true;
 
+	result->usePostgresPlanner = pstate->usePostgresPlanner;
+
 	return result;
 }
 

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -840,6 +840,8 @@ transformRangeFunction(ParseState *pstate, RangeFunction *r)
 
 					/* Now we set our special attribute in the rte. */
 					rte->forceDistRandom = true;
+					/* Orca doesn't support gp_dist_random */
+					pstate->usePostgresPlanner = true;
 
 					return rte;
 				}

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -316,6 +316,10 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 					 errmsg("OVER specified, but %s is not a window function nor an aggregate function",
 							NameListToString(funcname)),
 					 parser_errposition(pstate, location)));
+
+		/* Orca supports only the any exec location */
+		if (func_exec_location(funcid) != PROEXECLOCATION_ANY)
+			pstate->usePostgresPlanner = true;
 	}
 	else if (fdresult == FUNCDETAIL_AGGREGATE)
 	{

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -1029,8 +1029,13 @@ parserOpenTable(ParseState *pstate, const RangeVar *relation,
 		}
 	}
 
-	/* Orca doesn't support queries on master-only tables */
-	if (rel->rd_cdbpolicy == NULL)
+	/*
+	 * Orca doesn't support queries on master-only tables.  A view also has
+	 * no distribution policy, but it is expanded into its base relations
+	 * before planning, so exclude it -- otherwise every query over a view is
+	 * needlessly forced onto the Postgres planner.
+	 */
+	if (rel->rd_cdbpolicy == NULL && rel->rd_rel->relkind != RELKIND_VIEW)
 		pstate->usePostgresPlanner = true;
 
 	cancel_parser_errposition_callback(&pcbstate);

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -1029,6 +1029,10 @@ parserOpenTable(ParseState *pstate, const RangeVar *relation,
 		}
 	}
 
+	/* Orca doesn't support queries on master-only tables */
+	if (rel->rd_cdbpolicy == NULL)
+		pstate->usePostgresPlanner = true;
+
 	cancel_parser_errposition_callback(&pcbstate);
 	return rel;
 }

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -1264,6 +1264,10 @@ addRangeTableEntryForSubquery(ParseState *pstate,
 	rte->inh = false;			/* never true for subqueries */
 	rte->inFromCl = inFromCl;
 
+	/* Orca doesn't support LATERAL */
+	if (pstate != NULL && lateral)
+		pstate->usePostgresPlanner = true;
+
 	rte->requiredPerms = 0;
 	rte->checkAsUser = InvalidOid;
 	rte->selectedCols = NULL;
@@ -1638,6 +1642,10 @@ addRangeTableEntryForFunction(ParseState *pstate,
 	rte->inh = false;			/* never true for functions */
 	rte->inFromCl = inFromCl;
 
+	/* Orca doesn't support LATERAL */
+	if (pstate != NULL && lateral)
+		pstate->usePostgresPlanner = true;
+
 	rte->requiredPerms = 0;
 	rte->checkAsUser = InvalidOid;
 	rte->selectedCols = NULL;
@@ -1709,6 +1717,10 @@ addRangeTableEntryForValues(ParseState *pstate,
 	rte->lateral = lateral;
 	rte->inh = false;			/* never true for values RTEs */
 	rte->inFromCl = inFromCl;
+
+	/* Orca doesn't support LATERAL */
+	if (pstate != NULL && lateral)
+		pstate->usePostgresPlanner = true;
 
 	rte->requiredPerms = 0;
 	rte->checkAsUser = InvalidOid;

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -1133,6 +1133,10 @@ addRangeTableEntry(ParseState *pstate,
 	rte->inh = inh;
 	rte->inFromCl = inFromCl;
 
+	/* Orca doesn't support ONLY in the FROM clause */
+	if (pstate != NULL && !inh)
+		pstate->usePostgresPlanner = true;
+
 	rte->requiredPerms = ACL_SELECT;
 	rte->checkAsUser = InvalidOid;		/* not set-uid by default, either */
 	rte->selectedCols = NULL;
@@ -1185,6 +1189,10 @@ addRangeTableEntryForRelation(ParseState *pstate,
 	rte->lateral = false;
 	rte->inh = inh;
 	rte->inFromCl = inFromCl;
+
+	/* Orca doesn't support ONLY in the FROM clause */
+	if (pstate != NULL && !inh)
+		pstate->usePostgresPlanner = true;
 
 	rte->requiredPerms = ACL_SELECT;
 	rte->checkAsUser = InvalidOid;		/* not set-uid by default, either */
@@ -1264,6 +1272,10 @@ addRangeTableEntryForSubquery(ParseState *pstate,
 	rte->inh = false;			/* never true for subqueries */
 	rte->inFromCl = inFromCl;
 
+	/* Orca doesn't support LATERAL */
+	if (pstate != NULL && lateral)
+		pstate->usePostgresPlanner = true;
+
 	rte->requiredPerms = 0;
 	rte->checkAsUser = InvalidOid;
 	rte->selectedCols = NULL;
@@ -1317,6 +1329,14 @@ addRangeTableEntryForFunction(ParseState *pstate,
 	rte->functions = NIL;		/* we'll fill this list below */
 	rte->funcordinality = rangefunc->ordinality;
 	rte->alias = alias;
+
+	/* Orca doesn't support WITH ORDINALITY */
+	if (pstate != NULL && rangefunc->ordinality)
+		pstate->usePostgresPlanner = true;
+
+	/* Orca doesn't support multi-argument UNNEST() or ROWS FROM() */
+	if (pstate != NULL && nfuncs != 1)
+		pstate->usePostgresPlanner = true;
 
 	/*
 	 * Choose the RTE alias name.  We default to using the first function's
@@ -1394,6 +1414,10 @@ addRangeTableEntryForFunction(ParseState *pstate,
 						 */
 						rte->rtekind = RTE_TABLEFUNCTION;
 						rte->subquery = (Query *) input->subquery;
+
+						/* Orca doesn't support RTE_TABLEFUNCTION */
+						if (pstate != NULL)
+							pstate->usePostgresPlanner = true;
 
 						/* 
 						 * Mark function as a table function so that the second pass
@@ -1638,6 +1662,10 @@ addRangeTableEntryForFunction(ParseState *pstate,
 	rte->inh = false;			/* never true for functions */
 	rte->inFromCl = inFromCl;
 
+	/* Orca doesn't support LATERAL */
+	if (pstate != NULL && lateral)
+		pstate->usePostgresPlanner = true;
+
 	rte->requiredPerms = 0;
 	rte->checkAsUser = InvalidOid;
 	rte->selectedCols = NULL;
@@ -1709,6 +1737,10 @@ addRangeTableEntryForValues(ParseState *pstate,
 	rte->lateral = lateral;
 	rte->inh = false;			/* never true for values RTEs */
 	rte->inFromCl = inFromCl;
+
+	/* Orca doesn't support LATERAL */
+	if (pstate != NULL && lateral)
+		pstate->usePostgresPlanner = true;
 
 	rte->requiredPerms = 0;
 	rte->checkAsUser = InvalidOid;

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -215,6 +215,7 @@ typedef struct Query
 	 */
 	ParentStmtType	parentStmtType;
 	bool		expandMatViews; /* force expansion of materialized views during rewrite to treat as views */
+	bool		usePostgresPlanner; /* don't try to plan the query using Orca */
 } Query;
 
 /****************************************************************************

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -177,6 +177,8 @@ struct ParseState
 	ParseParamRefHook p_paramref_hook;
 	CoerceParamHook p_coerce_param_hook;
 	void	   *p_ref_hook_state;		/* common passthrough link for above */
+	bool		usePostgresPlanner; /* parse analysis found out that Orca
+									   doesn't support the query */
 };
 
 /*

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -386,8 +386,6 @@ from generate_series(1, 3) s1,
      lateral (select s2, sum(s1 + s2) sm
               from generate_series(1, 3) s2 group by s2) ss
 order by 1, 2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Sort
@@ -414,8 +412,6 @@ from generate_series(1, 3) s1,
      lateral (select s2, sum(s1 + s2) sm
               from generate_series(1, 3) s2 group by s2) ss
 order by 1, 2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: LATERAL
  s1 | s2 | sm 
 ----+----+----
   1 |  1 |  2

--- a/src/test/regress/expected/bfv_cte_optimizer.out
+++ b/src/test/regress/expected/bfv_cte_optimizer.out
@@ -519,8 +519,6 @@ create view cte_view as
 -- to pick a plan that would crash before this fix
 set allow_system_table_mods=true;
 update pg_class set relpages = 1::int, reltuples = 12.0::real where relname = 'a_table';
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on master-only tables
 reset allow_system_table_mods;
 explain select * from a_table join cte_view on a_table.a = (select a from cte_view) where cte_view.a = 2024;
 NOTICE:  One or more columns in the following table(s) do not have statistics: a_table

--- a/src/test/regress/expected/bfv_statistic_optimizer.out
+++ b/src/test/regress/expected/bfv_statistic_optimizer.out
@@ -463,8 +463,6 @@ SET
         reltuples = 10000000000.0::real,
         relallvisible = 0::int
 WHERE relname = 'tiny_freq' AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'bfv_statistic');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on master-only tables
 INSERT INTO pg_statistic VALUES (
         'bfv_statistic.tiny_freq'::regclass,
         1::smallint,

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -9845,11 +9845,7 @@ with x as (select * from foo_missing_stats) select count(*) from x x1, x x2 wher
 
 set allow_system_table_mods=true;
 delete from pg_statistic where starelid='foo_missing_stats'::regclass;
-NOTICE:  One or more columns in the following table(s) do not have statistics: pg_statistic
-HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
 delete from pg_statistic where starelid='bar_missing_stats'::regclass;
-NOTICE:  One or more columns in the following table(s) do not have statistics: pg_statistic
-HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
 set allow_system_table_mods=false;
 select count(*) from foo_missing_stats where a = 10;
 NOTICE:  One or more columns in the following table(s) do not have statistics: foo_missing_stats

--- a/src/test/regress/expected/olap_window_seq_optimizer.out
+++ b/src/test/regress/expected/olap_window_seq_optimizer.out
@@ -7394,22 +7394,6 @@ create view v1 as
 select dt, sum(cn) over(order by grouping(cn) range grouping(cn) preceding) 
 from sale group by rollup(cn,dt);
 \d+ v1
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on master-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on master-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on master-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on master-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on master-only tables
-CONTEXT:  SQL function "col_description" during startup
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on master-only tables
-CONTEXT:  SQL statement "SELECT * FROM pg_catalog.pg_rewrite WHERE ev_class = $1 AND rulename = $2"
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on master-only tables
               View "olap_window_seq.v1"
  Column |  Type  | Modifiers | Storage | Description 
 --------+--------+-----------+---------+-------------
@@ -8992,22 +8976,6 @@ ERROR:  DISTINCT is supported only for single-argument window aggregates
 -- Test deparsing (for \d+ and pg_dump)
 create view distinct_windowagg_view as select sum(distinct g/2) OVER (partition by g/4) from generate_series (1, 5) g;
 \d+ distinct_windowagg_view
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on master-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on master-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on master-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on master-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on master-only tables
-CONTEXT:  SQL function "col_description" during startup
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on master-only tables
-CONTEXT:  SQL statement "SELECT * FROM pg_catalog.pg_rewrite WHERE ev_class = $1 AND rulename = $2"
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on master-only tables
    View "olap_window_seq.distinct_windowagg_view"
  Column |  Type  | Modifiers | Storage | Description 
 --------+--------+-----------+---------+-------------

--- a/src/test/regress/expected/qp_with_clause_optimizer.out
+++ b/src/test/regress/expected/qp_with_clause_optimizer.out
@@ -9532,22 +9532,6 @@ where longlivingregions.region = denseregions.region and allcountrystats.code = 
 and country.indepyear > 1900
 );
 \d+ view_with_shared_scans;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on master-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on master-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on master-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on master-only tables
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on master-only tables
-CONTEXT:  SQL function "col_description" during startup
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on master-only tables
-CONTEXT:  SQL statement "SELECT * FROM pg_catalog.pg_rewrite WHERE ev_class = $1 AND rulename = $2"
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Queries on master-only tables
                 View "qp_with_clause.view_with_shared_scans"
        Column        |       Type       | Modifiers | Storage  | Description 
 ---------------------+------------------+-----------+----------+-------------


### PR DESCRIPTION
Don't try to use Orca for queries that it doesn't support

On translating to DXL we can find out that the query is unsupported. The better
time to make this decision is analyse stage, because in this case we can run
Postgres planner without trying to run Orca and, as a consequence, significantly
reduce planning time.
Orca doesn't support gp_dist_random, queries on master-only tables, and function
exec locations except for any. It's easy to detect on analyse stage, that
a query contains these unsupported query properties.
The number of unsupported query properties to check before translating to DXL
will be increased later.

------------------------------
Before the patch
```
postgres=# select oid from pg_class where relname='pg_class';
 oid  
------
 1259
(1 row)

Time: 9,869 ms
postgres=# 
```

After the patch
```
postgres=# select oid from pg_class where relname='pg_class';
 oid  
------
 1259
(1 row)

Time: 1,995 ms
postgres=#
```

Don't plan simple inserts using Orca