### PR TITLE
Renaming & remove newtablespace reset from kernel

### DIFF
--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -699,7 +699,7 @@ rebuild_relation(Relation OldHeap, Oid indexOid, bool verbose)
  * data, then call finish_heap_swap to complete the operation.
  */
 Oid
-make_new_heap(Oid OIDOldHeap, Oid NewTableSpace, Oid newTOASTTableSpace, bool forcetemp,
+make_new_heap(Oid OIDOldHeap, Oid NewTableSpace, Oid resolvedTOASTTableSpace, bool forcetemp,
 			  LOCKMODE lockmode,
 			  bool createAoBlockDirectory,
 			  bool makeCdbPolicy)
@@ -837,7 +837,7 @@ make_new_heap(Oid OIDOldHeap, Oid NewTableSpace, Oid newTOASTTableSpace, bool fo
 									 &isNull);
 		if (isNull)
 			reloptions = (Datum) 0;
-		NewHeapCreateToastTable(OIDNewHeap, newTOASTTableSpace, reloptions, lockmode,
+		NewHeapCreateToastTable(OIDNewHeap, resolvedTOASTTableSpace, reloptions, lockmode,
 								is_part_child, is_part_parent);
 
 		ReleaseSysCache(tuple);

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -4361,9 +4361,6 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 
 	tab->newTOASTTableSpace = newTOASTTableSpace;
 
-	/* Reset it */
-	newTOASTTableSpace = InvalidOid;
-
 	/*
 	 * Copy the original subcommand for each table.  This avoids conflicts
 	 * when different child tables need to make different parse
@@ -5995,7 +5992,7 @@ ATRewriteTables(AlterTableStmt *parsetree, List **wqueue, LOCKMODE lockmode)
 		Relation	OldHeap;
 		Oid			newTableSpace;
 		Oid 		oldTableSpace;
-		Oid			newTOASTTableSpace;
+		Oid			resolvedTOASTTableSpace;
 		bool		hasIndexes;
 
 		/* We will lock the table iff we decide to actually rewrite it */
@@ -6008,7 +6005,7 @@ ATRewriteTables(AlterTableStmt *parsetree, List **wqueue, LOCKMODE lockmode)
 
 		oldTableSpace = OldHeap->rd_rel->reltablespace;
 		newTableSpace = tab->newTableSpace ? tab->newTableSpace : oldTableSpace;
-		newTOASTTableSpace = tab->newTOASTTableSpace ? tab->newTOASTTableSpace : newTableSpace;
+		resolvedTOASTTableSpace = tab->newTOASTTableSpace ? tab->newTOASTTableSpace : newTableSpace;
 		relstorage    = OldHeap->rd_rel->relstorage;
 		{
 			List	   *indexIds;
@@ -6097,7 +6094,7 @@ ATRewriteTables(AlterTableStmt *parsetree, List **wqueue, LOCKMODE lockmode)
 			 * unlogged anyway.
 			 */
 			/* Create transient table that will receive the modified data */
-			OIDNewHeap = make_new_heap(tab->relid, newTableSpace, newTOASTTableSpace, false,
+			OIDNewHeap = make_new_heap(tab->relid, newTableSpace, resolvedTOASTTableSpace, false,
 									   lockmode, hasIndexes, false);
 
 			/*

--- a/src/include/commands/cluster.h
+++ b/src/include/commands/cluster.h
@@ -25,7 +25,7 @@ extern void check_index_is_clusterable(Relation OldHeap, Oid indexOid,
 						   bool recheck, LOCKMODE lockmode);
 extern void mark_index_clustered(Relation rel, Oid indexOid, bool is_internal);
 
-extern Oid make_new_heap(Oid OIDOldHeap, Oid NewTableSpace, Oid newTOASTTableSpace, bool forcetemp,
+extern Oid make_new_heap(Oid OIDOldHeap, Oid NewTableSpace, Oid resolvedTOASTTableSpace, bool forcetemp,
 			  LOCKMODE lockmode,
 			  bool createAoBlockDirectory,
 			  bool makeCdbPolicy);


### PR DESCRIPTION
# 
Reset should be called from extension

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
