### PR TITLE
Add tests from the modules directory

### DIFF
--- a/.github/workflows/build-gpdb.yml
+++ b/.github/workflows/build-gpdb.yml
@@ -172,6 +172,9 @@ jobs:
               {"test":"ic-recovery",
                "install_target":true,
                "make_configs":["src/test/recovery:installcheck"]
+              },
+              {"test":"ic-modules",
+               "make_configs":["src/test/modules:installcheck"]
               }
             ]
           }'

--- a/src/test/modules/test_bloomfilter/expected/test_bloomfilter.out
+++ b/src/test/modules/test_bloomfilter/expected/test_bloomfilter.out
@@ -1,9 +1,9 @@
 CREATE EXTENSION test_bloomfilter;
 -- See README for explanation of arguments:
-SELECT test_bloomfilter(power => 23,
-    nelements => 838861,
-    seed => -1,
-    tests => 1);
+SELECT test_bloomfilter(power := 23,
+    nelements := 838861,
+    seed := -1,
+    tests := 1);
  test_bloomfilter 
 ------------------
  

--- a/src/test/modules/test_bloomfilter/sql/test_bloomfilter.sql
+++ b/src/test/modules/test_bloomfilter/sql/test_bloomfilter.sql
@@ -1,10 +1,10 @@
 CREATE EXTENSION test_bloomfilter;
 
 -- See README for explanation of arguments:
-SELECT test_bloomfilter(power => 23,
-    nelements => 838861,
-    seed => -1,
-    tests => 1);
+SELECT test_bloomfilter(power := 23,
+    nelements := 838861,
+    seed := -1,
+    tests := 1);
 
 -- Equivalent "10 bits per element" tests for all possible bitset sizes:
 --


### PR DESCRIPTION
Rewrite the test_bloomfilter function call to make the test_bloomfilter test
passed. Argument passing using "=>" is unsupported in GPDB 6.