### PR TITLE
Add the temp_tables_stat extension

### DIFF
--- a/.github/workflows/build-gpdb.yml
+++ b/.github/workflows/build-gpdb.yml
@@ -166,6 +166,9 @@ jobs:
               {"test":"ic-parallel-retrieve-cursor",
                "make_configs":["src/test/isolation2:installcheck-parallel-retrieve-cursor"]
               },
+              {"test":"ic-temp_tables_stat",
+               "make_configs":["src/test/isolation2:installcheck-tts"]
+              },
               {"test":"ic-mirrorless",
                "make_configs":["src/test/isolation2:installcheck-mirrorless"]
               },

--- a/gpcontrib/Makefile
+++ b/gpcontrib/Makefile
@@ -27,7 +27,8 @@ ifeq "$(enable_debug_extensions)" "yes"
                gp_subtransaction_overflow \
                gp_check_functions \
                gp_aux_catalog \
-			   gp_interconnect_stats
+               gp_interconnect_stats \
+               temp_tables_stat
 else
 	recurse_targets = gp_sparse_vector \
                gp_distribution_policy \
@@ -43,7 +44,8 @@ else
                gp_subtransaction_overflow \
                gp_check_functions \
                gp_aux_catalog \
-			   gp_interconnect_stats
+               gp_interconnect_stats \
+               temp_tables_stat
 endif
 
 ifeq "$(with_zstd)" "yes"

--- a/gpcontrib/temp_tables_stat/Makefile
+++ b/gpcontrib/temp_tables_stat/Makefile
@@ -1,0 +1,20 @@
+# gpcontrib/temp_tables_stat/Makefile
+
+MODULE_big = temp_tables_stat
+OBJS = $(MODULE_big).o $(WIN32RES)
+
+EXTENSION = $(MODULE_big)
+PGFILEDESC = "Collect and show statictics on temporary tables"
+
+DATA = $(MODULE_big)--0.1.sql
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = gpcontrib/temp_tables_stat
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/gpcontrib/temp_tables_stat/Makefile
+++ b/gpcontrib/temp_tables_stat/Makefile
@@ -4,7 +4,7 @@ MODULE_big = temp_tables_stat
 OBJS = $(MODULE_big).o $(WIN32RES)
 
 EXTENSION = $(MODULE_big)
-PGFILEDESC = "Collect and show statictics on temporary tables"
+PGFILEDESC = "Collect and show statistics on temporary tables"
 
 DATA = $(MODULE_big)--0.1.sql
 

--- a/gpcontrib/temp_tables_stat/temp_tables_stat--0.1.sql
+++ b/gpcontrib/temp_tables_stat/temp_tables_stat--0.1.sql
@@ -1,0 +1,8 @@
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION temp_tables_stat" to load this file. \quit
+
+CREATE FUNCTION tts_get_seg_files(OUT user_id oid, OUT sess_id int4, OUT path text, OUT content int2, OUT size int8)
+RETURNS SETOF RECORD
+AS 'MODULE_PATHNAME', 'tts_get_seg_files'
+LANGUAGE C
+EXECUTE ON ALL SEGMENTS;

--- a/gpcontrib/temp_tables_stat/temp_tables_stat.c
+++ b/gpcontrib/temp_tables_stat/temp_tables_stat.c
@@ -288,11 +288,11 @@ tts_get_seg_files(PG_FUNCTION_ARGS)
 		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
 
 		tupdesc = CreateTemplateTupleDesc(NATTR, false);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "user_id", OIDOID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "sess_id", INT4OID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 3, "path", TEXTOID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 4, "content", INT2OID, -1, 0);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 5, "size", INT8OID, -1, 0);
+		TupleDescInitEntry(tupdesc, 1, "user_id", OIDOID, -1, 0);
+		TupleDescInitEntry(tupdesc, 2, "sess_id", INT4OID, -1, 0);
+		TupleDescInitEntry(tupdesc, 3, "path", TEXTOID, -1, 0);
+		TupleDescInitEntry(tupdesc, 4, "content", INT2OID, -1, 0);
+		TupleDescInitEntry(tupdesc, 5, "size", INT8OID, -1, 0);
 
 		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
 

--- a/gpcontrib/temp_tables_stat/temp_tables_stat.c
+++ b/gpcontrib/temp_tables_stat/temp_tables_stat.c
@@ -218,11 +218,8 @@ tts_get_file_size(const char *dirname, const char *fn_start)
 		snprintf(fn, sizeof(fn), "%s/%s", dirname, direntry->d_name);
 
 		if (stat(fn, &fst) < 0)
-		{
-			ereport(ERROR,
-					(errcode_for_file_access(),
-					 errmsg("could not stat file \"%s\": %m", fn)));
-		}
+			continue;
+
 		dirsize += fst.st_size;
 	}
 

--- a/gpcontrib/temp_tables_stat/temp_tables_stat.c
+++ b/gpcontrib/temp_tables_stat/temp_tables_stat.c
@@ -230,6 +230,37 @@ tts_get_file_size(const char *dirname, const char *fn_start)
 	return dirsize;
 }
 
+/* Copy the files info from the list to local memory */
+static RelFileNodeBackend *
+get_files(uint32 *files_num)
+{
+	RelFileNodeBackend *files;
+
+	*files_num = 0;
+
+	LWLockAcquire(&head->lock, LW_SHARED);
+
+	/* Count files of temp tables */
+	for (const TTSNode *node = &head->node; node != NULL; node = next_node(node))
+		*files_num += node->num;
+
+	/* Allocate local memory for array of the files data */
+	files = palloc(sizeof(*files) * (*files_num));
+
+	/* Combine arrays from the list nodes into one array */
+	*files_num = 0;
+	for (const TTSNode *node = &head->node; node != NULL; node = next_node(node))
+	{
+		RelFileNodeBackend *dst = files + (*files_num);
+		memcpy(dst, node->files, sizeof(*files) * node->num);
+		*files_num += node->num;
+	}
+
+	LWLockRelease(&head->lock);
+
+	return files;
+}
+
 /* Get temp tables files list on segments */
 PG_FUNCTION_INFO_V1(tts_get_seg_files);
 Datum
@@ -251,8 +282,6 @@ tts_get_seg_files(PG_FUNCTION_ARGS)
 	{
 		MemoryContext oldcontext;
 		TupleDesc tupdesc;
-		RelFileNodeBackend *files;
-		int files_num = 0;
 
 		funcctx = SRF_FIRSTCALL_INIT();
 
@@ -273,27 +302,7 @@ tts_get_seg_files(PG_FUNCTION_ARGS)
 			SRF_RETURN_DONE(funcctx);
 		}
 
-		LWLockAcquire(&head->lock, LW_SHARED);
-
-		/* Count files of temp tables */
-		for (const TTSNode *node = &head->node; node != NULL; node = next_node(node))
-			files_num += node->num;
-
-		/* Allocate local memory for array of the files data */
-		files = palloc(sizeof(*files) * files_num);
-
-		/* Combine arrays from the list nodes into one array */
-		funcctx->max_calls = 0;
-		for (const TTSNode *node = &head->node; node != NULL; node = next_node(node))
-		{
-			RelFileNodeBackend *dst = files + funcctx->max_calls;
-			memcpy(dst, node->files, sizeof(*files) * node->num);
-			funcctx->max_calls += node->num;
-		}
-
-		LWLockRelease(&head->lock);
-
-		funcctx->user_fctx = files;
+		funcctx->user_fctx = get_files(&funcctx->max_calls);
 		MemoryContextSwitchTo(oldcontext);
 	}
 

--- a/gpcontrib/temp_tables_stat/temp_tables_stat.c
+++ b/gpcontrib/temp_tables_stat/temp_tables_stat.c
@@ -63,6 +63,38 @@ next_node(const TTSNode *node)
 }
 
 /*
+ * Returns the last node or a new node if the last one is full.
+ * Returns NULL when no need to add rnode to the list.
+ */
+static TTSNode *
+get_node_to_append(RelFileNodeBackend rnode)
+{
+	for (TTSNode *node = &head->node;; node = next_node(node))
+	{
+		/* Don't add rnode when it exists in the list of arrays */
+		for (int i = 0; i < node->num; i++)
+			if (RelFileNodeBackendEquals(rnode, node->files[i]))
+				return NULL;
+
+		if (node->next == DSM_HANDLE_INVALID)
+		{
+			/* Create a new node if the last node is full */
+			if (node->num == ARRAY_SIZE(node->files))
+			{
+				dsm_segment *next_seg = dsm_create(sizeof(TTSNode));
+				dsm_pin_mapping(next_seg);
+				node->next = dsm_segment_handle(next_seg);
+				node = dsm_segment_address(next_seg);
+				node->next = DSM_HANDLE_INVALID;
+				node->num = 0;
+			}
+
+			return node;
+		}
+	}
+}
+
+/*
  * This function is called with the same argument when each fork is created.
  * Add file info to the list if it is not there.
  */
@@ -81,31 +113,10 @@ tts_file_create_hook(RelFileNodeBackend rnode)
 
 	LWLockAcquire(&head->lock, LW_EXCLUSIVE);
 
-	/* Don't add rnode when it exists in the list of arrays */
-	for (node = &head->node;; node = next_node(node))
-	{
-		for (int i = 0; i < node->num; i++)
-			if (RelFileNodeBackendEquals(rnode, node->files[i]))
-				goto lExit;
+	node = get_node_to_append(rnode);
+	if (node != NULL)
+		node->files[node->num++] = rnode;
 
-		if (node->next == DSM_HANDLE_INVALID)
-			break;
-	}
-
-	/* Create a new node if the last node is full */
-	if (node->num == ARRAY_SIZE(node->files))
-	{
-		dsm_segment *next_seg = dsm_create(sizeof(TTSNode));
-		dsm_pin_mapping(next_seg);
-		node->next = dsm_segment_handle(next_seg);
-		node = dsm_segment_address(next_seg);
-		node->next = DSM_HANDLE_INVALID;
-		node->num = 0;
-	}
-
-	node->files[node->num++] = rnode;
-
-lExit:
 	LWLockRelease(&head->lock);
 }
 

--- a/gpcontrib/temp_tables_stat/temp_tables_stat.c
+++ b/gpcontrib/temp_tables_stat/temp_tables_stat.c
@@ -134,7 +134,8 @@ tts_file_unlink_hook(RelFileNodeBackend rnode)
 			if (RelFileNodeBackendEquals(rnode, node->files[i]))
 			{
 				/* Find the last node */
-				TTSNode *last_node = node, *last_prev_node = prev_node;
+				TTSNode *last_node = node;
+				TTSNode *last_prev_node = prev_node;
 				while (last_node->next != DSM_HANDLE_INVALID)
 				{
 					last_prev_node = last_node;
@@ -233,8 +234,8 @@ tts_get_seg_files(PG_FUNCTION_ARGS)
 	enum { NATTR = 5 };
 
 	FuncCallContext *funcctx;
-	PgBackendStatus *beStatus;
-	RelFileNodeBackend *file;
+	const PgBackendStatus *beStatus;
+	const RelFileNodeBackend *file;
 	char	   *sep;
 	char	   *path;
 	HeapTuple	tuple;
@@ -271,7 +272,7 @@ tts_get_seg_files(PG_FUNCTION_ARGS)
 		LWLockAcquire(&head->lock, LW_SHARED);
 
 		/* Count files of temp tables */
-		for (TTSNode *node = &head->node; node != NULL; node = next_node(node))
+		for (const TTSNode *node = &head->node; node != NULL; node = next_node(node))
 			files_num += node->num;
 
 		/* Allocate local memory for array of the files data */
@@ -279,7 +280,7 @@ tts_get_seg_files(PG_FUNCTION_ARGS)
 
 		/* Combine arrays from the list nodes into one array */
 		funcctx->max_calls = 0;
-		for (TTSNode *node = &head->node; node != NULL; node = next_node(node))
+		for (const TTSNode *node = &head->node; node != NULL; node = next_node(node))
 		{
 			RelFileNodeBackend *dst = files + funcctx->max_calls;
 			memcpy(dst, node->files, sizeof(*files) * node->num);
@@ -318,6 +319,7 @@ tts_get_seg_files(PG_FUNCTION_ARGS)
 	Assert(sep != NULL);
 	*sep = '\0';
 	values[4] = Int64GetDatum(tts_get_file_size(path, sep + 1));
+	pfree(path);
 
 	tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
 

--- a/gpcontrib/temp_tables_stat/temp_tables_stat.c
+++ b/gpcontrib/temp_tables_stat/temp_tables_stat.c
@@ -76,21 +76,21 @@ get_node_to_append(RelFileNodeBackend rnode)
 			if (RelFileNodeBackendEquals(rnode, node->files[i]))
 				return NULL;
 
-		if (node->next == DSM_HANDLE_INVALID)
-		{
-			/* Create a new node if the last node is full */
-			if (node->num == ARRAY_SIZE(node->files))
-			{
-				dsm_segment *next_seg = dsm_create(sizeof(TTSNode));
-				dsm_pin_mapping(next_seg);
-				node->next = dsm_segment_handle(next_seg);
-				node = dsm_segment_address(next_seg);
-				node->next = DSM_HANDLE_INVALID;
-				node->num = 0;
-			}
+		if (node->next != DSM_HANDLE_INVALID)
+			continue;
 
-			return node;
+		/* Create a new node if the last node is full */
+		if (node->num == ARRAY_SIZE(node->files))
+		{
+			dsm_segment *next_seg = dsm_create(sizeof(TTSNode));
+			dsm_pin_mapping(next_seg);
+			node->next = dsm_segment_handle(next_seg);
+			node = dsm_segment_address(next_seg);
+			node->next = DSM_HANDLE_INVALID;
+			node->num = 0;
 		}
+
+		return node;
 	}
 }
 

--- a/gpcontrib/temp_tables_stat/temp_tables_stat.c
+++ b/gpcontrib/temp_tables_stat/temp_tables_stat.c
@@ -74,7 +74,7 @@ tts_file_create_hook(RelFileNodeBackend rnode)
 	if (prev_file_create_hook)
 		(*prev_file_create_hook)(rnode);
 
-	if (!RelFileNodeBackendIsTemp(rnode))
+	if (!RelFileNodeBackendIsTemp(rnode) || head == NULL)
 		return;
 
 	rnode.backend = MyBackendId;
@@ -116,7 +116,7 @@ tts_file_unlink_hook(RelFileNodeBackend rnode)
 	if (prev_file_unlink_hook)
 		(*prev_file_unlink_hook)(rnode);
 
-	if (!RelFileNodeBackendIsTemp(rnode))
+	if (!RelFileNodeBackendIsTemp(rnode) || head == NULL)
 		return;
 
 	rnode.backend = MyBackendId;

--- a/gpcontrib/temp_tables_stat/temp_tables_stat.c
+++ b/gpcontrib/temp_tables_stat/temp_tables_stat.c
@@ -276,7 +276,7 @@ tts_get_seg_files(PG_FUNCTION_ARGS)
 	HeapTuple	tuple;
 	Datum		values[NATTR] = {0};
 	bool		nulls [NATTR] = {0};
-	static PgBackendStatus *beStatuses = NULL;
+	static const PgBackendStatus *beStatuses = NULL;
 
 	if (SRF_IS_FIRSTCALL())
 	{

--- a/gpcontrib/temp_tables_stat/temp_tables_stat.c
+++ b/gpcontrib/temp_tables_stat/temp_tables_stat.c
@@ -109,6 +109,37 @@ lExit:
 	LWLockRelease(&head->lock);
 }
 
+static void
+delete_from_ttsnode(TTSNode *node, int index, TTSNode *prev_node)
+{
+	/* Find the last node */
+	TTSNode *last_node = node;
+	TTSNode *last_prev_node = prev_node;
+
+	while (last_node->next != DSM_HANDLE_INVALID)
+	{
+		last_prev_node = last_node;
+		last_node = next_node(last_node);
+	}
+
+	/* replace the deleted element with the last one */
+	node->files[index] = last_node->files[last_node->num - 1];
+
+	if (last_node->num > 1)
+		last_node->num--;
+	else if (last_node == &head->node)
+		head->node.num = 0;
+	else
+	{
+		/*
+		 * last_prev_node != NULL because last_node is not head.
+		 * next_node() has been called, so the mapping exists.
+		 */
+		dsm_detach(dsm_find_mapping(last_prev_node->next));
+		last_prev_node->next = DSM_HANDLE_INVALID;
+	}
+}
+
 /* This function is called once for all forks. Delete file info from the list */
 static void
 tts_file_unlink_hook(RelFileNodeBackend rnode)
@@ -122,10 +153,7 @@ tts_file_unlink_hook(RelFileNodeBackend rnode)
 	rnode.backend = MyBackendId;
 	LWLockAcquire(&head->lock, LW_EXCLUSIVE);
 
-	/*
-	 * Find rnode in the list of arrays, replace rnode with the last element,
-	 * decrement array length.
-	 */
+	/* Find rnode in the list of arrays and delete it from the list node */
 	for (TTSNode *node = &head->node, *prev_node = NULL;
 		 node != NULL;
 		 prev_node = node, node = next_node(node))
@@ -133,31 +161,7 @@ tts_file_unlink_hook(RelFileNodeBackend rnode)
 		for (int i = 0; i < node->num; i++)
 			if (RelFileNodeBackendEquals(rnode, node->files[i]))
 			{
-				/* Find the last node */
-				TTSNode *last_node = node;
-				TTSNode *last_prev_node = prev_node;
-				while (last_node->next != DSM_HANDLE_INVALID)
-				{
-					last_prev_node = last_node;
-					last_node = next_node(last_node);
-				}
-
-				node->files[i] = last_node->files[last_node->num - 1];
-
-				if (last_node->num > 1)
-					last_node->num--;
-				else if (last_node == &head->node)
-					head->node.num = 0;
-				else
-				{
-					/*
-					 * last_prev_node != NULL because last_node is not head.
-					 * next_node() has been called, so the mapping exists.
-					 */
-					dsm_detach(dsm_find_mapping(last_prev_node->next));
-					last_prev_node->next = DSM_HANDLE_INVALID;
-				}
-
+				delete_from_ttsnode(node, i, prev_node);
 				goto lExit;
 			}
 	}

--- a/gpcontrib/temp_tables_stat/temp_tables_stat.c
+++ b/gpcontrib/temp_tables_stat/temp_tables_stat.c
@@ -1,0 +1,361 @@
+#include "postgres.h"
+
+#include <sys/stat.h>
+
+#include "cdb/cdbvars.h"
+#include "funcapi.h"
+#include "pgstat.h"
+#include "storage/dsm.h"
+#include "storage/ipc.h"
+#include "utils/builtins.h"
+
+PG_MODULE_MAGIC;
+
+void _PG_init(void);
+void _PG_fini(void);
+
+static file_create_hook_type prev_file_create_hook = NULL;
+static file_unlink_hook_type prev_file_unlink_hook = NULL;
+static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
+
+/*
+ * RelFileNodeBackend-s for each temp table are stored in the list of arrays.
+ * The list is located in shared memory. The head node of the list (TTSHeadNode)
+ * is allocated using ShmemInitStruct. Next nodes (TTSNode) are allocated using
+ * DSM. The next node is created when array of RelFileNodeBackend-s in
+ * the previous one is full. It is assumed that array in the head node is large
+ * enough to contain all RelFileNodeBackend-s in normal case and DSM is used
+ * very rarely.
+ */
+
+typedef struct TTSNode
+{
+	dsm_handle	next;	/* Handle of DSM segment with the next node */
+	int			num;	/* Number of elements in files */
+	RelFileNodeBackend files[1000000];
+}	TTSNode;
+
+typedef struct TTSHeadNode
+{
+	LWLock		lock;
+	TTSNode		node;
+}	TTSHeadNode;
+
+static TTSHeadNode *head = NULL; /* Head of the list */
+
+/* Get next node by current one */
+static TTSNode *
+next_node(const TTSNode *node)
+{
+	dsm_segment *dsm_seg;
+
+	if (node->next == DSM_HANDLE_INVALID)
+		return NULL;
+
+	dsm_seg = dsm_find_mapping(node->next);
+	if (dsm_seg == NULL)
+	{
+		dsm_seg = dsm_attach(node->next);
+		dsm_pin_mapping(dsm_seg);
+	}
+
+	return dsm_segment_address(dsm_seg);
+}
+
+/*
+ * This function is called with the same argument when each fork is created.
+ * Add file info to the list if it is not there.
+ */
+static void
+tts_file_create_hook(RelFileNodeBackend rnode)
+{
+	TTSNode	   *node;
+
+	if (prev_file_create_hook)
+		(*prev_file_create_hook)(rnode);
+
+	if (!RelFileNodeBackendIsTemp(rnode))
+		return;
+
+	rnode.backend = MyBackendId;
+
+	LWLockAcquire(&head->lock, LW_EXCLUSIVE);
+
+	/* Don't add rnode when it exists in the list of arrays */
+	for (node = &head->node;; node = next_node(node))
+	{
+		for (int i = 0; i < node->num; i++)
+			if (RelFileNodeBackendEquals(rnode, node->files[i]))
+				goto lExit;
+
+		if (node->next == DSM_HANDLE_INVALID)
+			break;
+	}
+
+	/* Create a new node if the last node is full */
+	if (node->num == ARRAY_SIZE(node->files))
+	{
+		dsm_segment *next_seg = dsm_create(sizeof(TTSNode));
+		dsm_pin_mapping(next_seg);
+		node->next = dsm_segment_handle(next_seg);
+		node = dsm_segment_address(next_seg);
+		node->next = DSM_HANDLE_INVALID;
+		node->num = 0;
+	}
+
+	node->files[node->num++] = rnode;
+
+lExit:
+	LWLockRelease(&head->lock);
+}
+
+/* This function is called once for all forks. Delete file info from the list */
+static void
+tts_file_unlink_hook(RelFileNodeBackend rnode)
+{
+	if (prev_file_unlink_hook)
+		(*prev_file_unlink_hook)(rnode);
+
+	if (!RelFileNodeBackendIsTemp(rnode))
+		return;
+
+	rnode.backend = MyBackendId;
+	LWLockAcquire(&head->lock, LW_EXCLUSIVE);
+
+	/*
+	 * Find rnode in the list of arrays, replace rnode with the last element,
+	 * decrement array length.
+	 */
+	for (TTSNode *node = &head->node, *prev_node = NULL;
+		 node != NULL;
+		 prev_node = node, node = next_node(node))
+	{
+		for (int i = 0; i < node->num; i++)
+			if (RelFileNodeBackendEquals(rnode, node->files[i]))
+			{
+				/* Find the last node */
+				TTSNode *last_node = node, *last_prev_node = prev_node;
+				while (last_node->next != DSM_HANDLE_INVALID)
+				{
+					last_prev_node = last_node;
+					last_node = next_node(last_node);
+				}
+
+				node->files[i] = last_node->files[last_node->num - 1];
+
+				if (last_node->num > 1)
+					last_node->num--;
+				else if (last_node == &head->node)
+					head->node.num = 0;
+				else
+				{
+					/*
+					 * last_prev_node != NULL because last_node is not head.
+					 * next_node() has been called, so the mapping exists.
+					 */
+					dsm_detach(dsm_find_mapping(last_prev_node->next));
+					last_prev_node->next = DSM_HANDLE_INVALID;
+				}
+
+				goto lExit;
+			}
+	}
+
+lExit:
+	LWLockRelease(&head->lock);
+}
+
+/* Postmaster creates a new shared memory space for the head node of the list */
+static void
+tts_shmem_startup(void)
+{
+	bool		found;
+
+	if (prev_shmem_startup_hook)
+		(*prev_shmem_startup_hook)();
+
+	head = ShmemInitStruct("temp_tables_stat", sizeof(TTSHeadNode), &found);
+	if (found)
+		return;
+
+	LWLockInitialize(&head->lock, 0);
+	head->node.next = DSM_HANDLE_INVALID;
+	head->node.num = 0;
+}
+
+/*
+ * Get size of all files from the dirname directory, which names start
+ * with fn_start
+ */
+static int64
+tts_get_file_size(const char *dirname, const char *fn_start)
+{
+	struct dirent *direntry;
+	int64		dirsize = 0;
+	const size_t fn_start_len = strlen(fn_start);
+	DIR		   *dirdesc = AllocateDir(dirname);
+
+	if (!dirdesc)
+		return 0;
+
+	while ((direntry = ReadDir(dirdesc, dirname)) != NULL)
+	{
+		struct stat fst;
+		char		fn[MAXPGPATH * 2];
+
+		CHECK_FOR_INTERRUPTS();
+
+		if (strcmp(direntry->d_name, ".") == 0 ||
+			strcmp(direntry->d_name, "..") == 0 ||
+			strncmp(direntry->d_name, fn_start, fn_start_len) != 0)
+			continue;
+
+		snprintf(fn, sizeof(fn), "%s/%s", dirname, direntry->d_name);
+
+		if (stat(fn, &fst) < 0)
+		{
+			ereport(ERROR,
+					(errcode_for_file_access(),
+					 errmsg("could not stat file \"%s\": %m", fn)));
+		}
+		dirsize += fst.st_size;
+	}
+
+	FreeDir(dirdesc);
+	return dirsize;
+}
+
+/* Get temp tables files list on segments */
+PG_FUNCTION_INFO_V1(tts_get_seg_files);
+Datum
+tts_get_seg_files(PG_FUNCTION_ARGS)
+{
+	enum { NATTR = 5 };
+
+	FuncCallContext *funcctx;
+	PgBackendStatus *beStatus;
+	RelFileNodeBackend *file;
+	char	   *sep;
+	char	   *path;
+	HeapTuple	tuple;
+	Datum		values[NATTR] = {0};
+	bool		nulls [NATTR] = {0};
+	static PgBackendStatus *beStatuses = NULL;
+
+	if (SRF_IS_FIRSTCALL())
+	{
+		MemoryContext oldcontext;
+		TupleDesc tupdesc;
+		RelFileNodeBackend *files;
+		int files_num = 0;
+
+		funcctx = SRF_FIRSTCALL_INIT();
+
+		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
+
+		tupdesc = CreateTemplateTupleDesc(NATTR, false);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "user_id", OIDOID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "sess_id", INT4OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 3, "path", TEXTOID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 4, "content", INT2OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 5, "size", INT8OID, -1, 0);
+
+		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
+
+		if (head->node.num == 0)
+		{
+			MemoryContextSwitchTo(oldcontext);
+			SRF_RETURN_DONE(funcctx);
+		}
+
+		LWLockAcquire(&head->lock, LW_SHARED);
+
+		/* Count files of temp tables */
+		for (TTSNode *node = &head->node; node != NULL; node = next_node(node))
+			files_num += node->num;
+
+		/* Allocate local memory for array of the files data */
+		files = palloc(sizeof(*files) * files_num);
+
+		/* Combine arrays from the list nodes into one array */
+		funcctx->max_calls = 0;
+		for (TTSNode *node = &head->node; node != NULL; node = next_node(node))
+		{
+			RelFileNodeBackend *dst = files + funcctx->max_calls;
+			memcpy(dst, node->files, sizeof(*files) * node->num);
+			funcctx->max_calls += node->num;
+		}
+
+		LWLockRelease(&head->lock);
+
+		funcctx->user_fctx = files;
+		MemoryContextSwitchTo(oldcontext);
+	}
+
+	funcctx = SRF_PERCALL_SETUP();
+
+	if (funcctx->call_cntr >= funcctx->max_calls)
+		SRF_RETURN_DONE(funcctx);
+
+	if (beStatuses == NULL)
+	{
+		bool found;
+		Size size = mul_size(sizeof(PgBackendStatus), MaxBackends);
+		beStatuses = ShmemInitStruct("Backend Status Array", size, &found);
+		if (!found)
+			ereport(ERROR, (errmsg("Backend Status Array is not found")));
+	}
+
+	file = ((RelFileNodeBackend *) funcctx->user_fctx) + funcctx->call_cntr;
+
+	beStatus = &beStatuses[file->backend - 1];
+	values[0] = ObjectIdGetDatum(beStatus->st_userid);
+	values[1] = Int32GetDatum(beStatus->st_session_id);
+	path = relpathbackend(file->node, TempRelBackendId, MAIN_FORKNUM);
+	values[2] = CStringGetTextDatum(path);
+	values[3] = Int16GetDatum(GpIdentity.segindex);
+	sep = strrchr(path, '/');
+	Assert(sep != NULL);
+	*sep = '\0';
+	values[4] = Int64GetDatum(tts_get_file_size(path, sep + 1));
+
+	tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
+
+	SRF_RETURN_NEXT(funcctx, HeapTupleGetDatum(tuple));
+}
+
+void
+_PG_init(void)
+{
+	if (!process_shared_preload_libraries_in_progress)
+	{
+		ereport(ERROR,
+			(errmsg("temp_tables_stat is not in shared_preload_libraries")));
+	}
+
+	if (IS_QUERY_DISPATCHER())
+		return;
+
+	RequestAddinShmemSpace(sizeof(TTSHeadNode));
+	RequestAddinLWLocks(1);
+
+	prev_file_create_hook = file_create_hook;
+	file_create_hook = tts_file_create_hook;
+
+	prev_file_unlink_hook = file_unlink_hook;
+	file_unlink_hook = tts_file_unlink_hook;
+
+	prev_shmem_startup_hook = shmem_startup_hook;
+	shmem_startup_hook = tts_shmem_startup;
+}
+
+void
+_PG_fini(void)
+{
+	if (IS_QUERY_DISPATCHER())
+		return;
+
+	file_create_hook = prev_file_create_hook;
+	file_unlink_hook = prev_file_unlink_hook;
+	shmem_startup_hook = prev_shmem_startup_hook;
+}

--- a/gpcontrib/temp_tables_stat/temp_tables_stat.control
+++ b/gpcontrib/temp_tables_stat/temp_tables_stat.control
@@ -1,5 +1,5 @@
 # temp_tables_stat extension
-comment = 'Collect and show statictics on temporary tables'
+comment = 'Collect and show statistics on temporary tables'
 default_version = '0.1'
 module_pathname = '$libdir/temp_tables_stat'
 relocatable = true

--- a/gpcontrib/temp_tables_stat/temp_tables_stat.control
+++ b/gpcontrib/temp_tables_stat/temp_tables_stat.control
@@ -1,0 +1,5 @@
+# temp_tables_stat extension
+comment = 'Collect and show statictics on temporary tables'
+default_version = '0.1'
+module_pathname = '$libdir/temp_tables_stat'
+relocatable = true

--- a/src/test/isolation2/Makefile
+++ b/src/test/isolation2/Makefile
@@ -76,6 +76,8 @@ installcheck: install installcheck-parallel-retrieve-cursor installcheck-ic-tcp 
 installcheck-mdb: install
 	./pg_isolation2_regress $(EXTRA_REGRESS_OPTS) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_isolation2 --psqldir='$(PSQLDIR)' --inputdir=$(srcdir) --schedule=$(srcdir)/isolation2_schedule_mdb
 
+installcheck-tts: install
+	./pg_isolation2_regress $(EXTRA_REGRESS_OPTS) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_isolation2 --psqldir='$(PSQLDIR)' --inputdir=$(srcdir) temp_tables_stat
 
 installcheck-resgroup: install
 	./pg_isolation2_regress $(EXTRA_REGRESS_OPTS) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_resgroup --psqldir='$(PSQLDIR)' --inputdir=$(srcdir) --dbname=isolation2resgrouptest --schedule=$(srcdir)/isolation2_resgroup_schedule

--- a/src/test/isolation2/expected/temp_tables_stat.out
+++ b/src/test/isolation2/expected/temp_tables_stat.out
@@ -1,0 +1,1380 @@
+-- start_ignore
+0: ! gpconfig -c shared_preload_libraries -v 'temp_tables_stat';
+20251120:10:17:27:025975 gpconfig:sokolov43a-yu-lin:sokolov43a-yu-[INFO]:-completed successfully with parameters '-c shared_preload_libraries -v temp_tables_stat'
+
+0: ! gpstop -raiq;
+
+
+1: CREATE EXTENSION IF NOT EXISTS temp_tables_stat;
+CREATE
+-- end_ignore
+
+-- No tables, the files list is empty
+1: SELECT * FROM tts_get_seg_files();
+ user_id | sess_id | path | content | size 
+---------+---------+------+---------+------
+(0 rows)
+
+--
+-- Ordinary heap tables
+
+-- We can see tables created in the current session
+1: CREATE TEMP TABLE t1(i INT) DISTRIBUTED BY (i);
+CREATE
+1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') sess_id_ok, content, size FROM tts_get_seg_files() f;
+ user_id_ok | sess_id_ok | content | size 
+------------+------------+---------+------
+ t          | t          | 0       | 0    
+ t          | t          | 2       | 0    
+ t          | t          | 1       | 0    
+(3 rows)
+1: CREATE TEMP TABLE t2(i INT) DISTRIBUTED BY (i);
+CREATE
+1: CREATE TEMP TABLE t3(i INT) DISTRIBUTED BY (i);
+CREATE
+1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') sess_id_ok, content, size FROM tts_get_seg_files() f;
+ user_id_ok | sess_id_ok | content | size 
+------------+------------+---------+------
+ t          | t          | 0       | 0    
+ t          | t          | 0       | 0    
+ t          | t          | 0       | 0    
+ t          | t          | 2       | 0    
+ t          | t          | 2       | 0    
+ t          | t          | 2       | 0    
+ t          | t          | 1       | 0    
+ t          | t          | 1       | 0    
+ t          | t          | 1       | 0    
+(9 rows)
+
+-- We can see tables created in other sessions
+2: CREATE TEMP TABLE t1(i INT) DISTRIBUTED BY (i);
+CREATE
+1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+ user_id_ok | cur_sess_id | content | size 
+------------+-------------+---------+------
+ t          | t           | 0       | 0    
+ t          | t           | 0       | 0    
+ t          | t           | 0       | 0    
+ t          | f           | 0       | 0    
+ t          | t           | 1       | 0    
+ t          | t           | 1       | 0    
+ t          | t           | 1       | 0    
+ t          | f           | 1       | 0    
+ t          | t           | 2       | 0    
+ t          | t           | 2       | 0    
+ t          | t           | 2       | 0    
+ t          | f           | 2       | 0    
+(12 rows)
+2: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+ user_id_ok | cur_sess_id | content | size 
+------------+-------------+---------+------
+ t          | f           | 1       | 0    
+ t          | f           | 1       | 0    
+ t          | f           | 1       | 0    
+ t          | t           | 1       | 0    
+ t          | f           | 0       | 0    
+ t          | f           | 0       | 0    
+ t          | f           | 0       | 0    
+ t          | t           | 0       | 0    
+ t          | f           | 2       | 0    
+ t          | f           | 2       | 0    
+ t          | f           | 2       | 0    
+ t          | t           | 2       | 0    
+(12 rows)
+3: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+ user_id_ok | cur_sess_id | content | size 
+------------+-------------+---------+------
+ t          | f           | 0       | 0    
+ t          | f           | 0       | 0    
+ t          | f           | 0       | 0    
+ t          | f           | 0       | 0    
+ t          | f           | 1       | 0    
+ t          | f           | 1       | 0    
+ t          | f           | 1       | 0    
+ t          | f           | 1       | 0    
+ t          | f           | 2       | 0    
+ t          | f           | 2       | 0    
+ t          | f           | 2       | 0    
+ t          | f           | 2       | 0    
+(12 rows)
+
+-- Dropped tables are removed from the list in all sessions
+1: DROP TABLE t2;
+DROP
+1: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 9     
+(1 row)
+2: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 9     
+(1 row)
+3: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 9     
+(1 row)
+2: DROP TABLE t1;
+DROP
+1: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 6     
+(1 row)
+2: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 6     
+(1 row)
+3: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 6     
+(1 row)
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>
+
+--
+-- Heap tables, on commit drop
+
+-- We can see tables created in the current session
+1: BEGIN;
+BEGIN
+1: CREATE TEMP TABLE t1(i INT) ON COMMIT DROP DISTRIBUTED BY (i);
+CREATE
+1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') sess_id_ok, content, size FROM tts_get_seg_files() f;
+ user_id_ok | sess_id_ok | content | size 
+------------+------------+---------+------
+ t          | t          | 0       | 0    
+ t          | t          | 2       | 0    
+ t          | t          | 1       | 0    
+(3 rows)
+1: CREATE TEMP TABLE t2(i INT) ON COMMIT DROP DISTRIBUTED BY (i);
+CREATE
+1: CREATE TEMP TABLE t3(i INT) ON COMMIT DROP DISTRIBUTED BY (i);
+CREATE
+1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') sess_id_ok, content, size FROM tts_get_seg_files() f;
+ user_id_ok | sess_id_ok | content | size 
+------------+------------+---------+------
+ t          | t          | 0       | 0    
+ t          | t          | 0       | 0    
+ t          | t          | 0       | 0    
+ t          | t          | 1       | 0    
+ t          | t          | 1       | 0    
+ t          | t          | 1       | 0    
+ t          | t          | 2       | 0    
+ t          | t          | 2       | 0    
+ t          | t          | 2       | 0    
+(9 rows)
+
+-- We can see tables created in other sessions
+2: BEGIN;
+BEGIN
+2: CREATE TEMP TABLE t1(i INT) ON COMMIT DROP DISTRIBUTED BY (i);
+CREATE
+1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+ user_id_ok | cur_sess_id | content | size 
+------------+-------------+---------+------
+ t          | t           | 1       | 0    
+ t          | t           | 1       | 0    
+ t          | t           | 1       | 0    
+ t          | f           | 1       | 0    
+ t          | t           | 0       | 0    
+ t          | t           | 0       | 0    
+ t          | t           | 0       | 0    
+ t          | f           | 0       | 0    
+ t          | t           | 2       | 0    
+ t          | t           | 2       | 0    
+ t          | t           | 2       | 0    
+ t          | f           | 2       | 0    
+(12 rows)
+2: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+ user_id_ok | cur_sess_id | content | size 
+------------+-------------+---------+------
+ t          | f           | 1       | 0    
+ t          | f           | 1       | 0    
+ t          | f           | 1       | 0    
+ t          | t           | 1       | 0    
+ t          | f           | 2       | 0    
+ t          | f           | 2       | 0    
+ t          | f           | 2       | 0    
+ t          | t           | 2       | 0    
+ t          | f           | 0       | 0    
+ t          | f           | 0       | 0    
+ t          | f           | 0       | 0    
+ t          | t           | 0       | 0    
+(12 rows)
+3: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+ user_id_ok | cur_sess_id | content | size 
+------------+-------------+---------+------
+ t          | f           | 0       | 0    
+ t          | f           | 0       | 0    
+ t          | f           | 0       | 0    
+ t          | f           | 0       | 0    
+ t          | f           | 2       | 0    
+ t          | f           | 2       | 0    
+ t          | f           | 2       | 0    
+ t          | f           | 2       | 0    
+ t          | f           | 1       | 0    
+ t          | f           | 1       | 0    
+ t          | f           | 1       | 0    
+ t          | f           | 1       | 0    
+(12 rows)
+
+-- Dropped tables are removed from the list in all sessions
+1: ROLLBACK;
+ROLLBACK
+1: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 3     
+(1 row)
+2: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 3     
+(1 row)
+3: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 3     
+(1 row)
+2: COMMIT;
+COMMIT
+1: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 0     
+(1 row)
+2: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 0     
+(1 row)
+3: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 0     
+(1 row)
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>
+
+--
+-- Ordinary AO tables
+-- 4 files per AO table: data file, pg_aoseg, pg_aovisimap, pg_aovisimap_index
+
+-- We can see tables created in the current session
+1: CREATE TEMP TABLE t1(i INT) WITH (APPENDOPTIMIZED = TRUE) DISTRIBUTED BY (i);
+CREATE
+1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') sess_id_ok, content, size FROM tts_get_seg_files() f;
+ user_id_ok | sess_id_ok | content | size  
+------------+------------+---------+-------
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 32768 
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 32768 
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 32768 
+(12 rows)
+1: CREATE TEMP TABLE t2(i INT) WITH (APPENDOPTIMIZED = TRUE) DISTRIBUTED BY (i);
+CREATE
+1: CREATE TEMP TABLE t3(i INT) WITH (APPENDOPTIMIZED = TRUE) DISTRIBUTED BY (i);
+CREATE
+1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') sess_id_ok, content, size FROM tts_get_seg_files() f;
+ user_id_ok | sess_id_ok | content | size  
+------------+------------+---------+-------
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 32768 
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 32768 
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 32768 
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 32768 
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 32768 
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 32768 
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 32768 
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 32768 
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 32768 
+(36 rows)
+
+-- We can see tables created in other sessions
+2: CREATE TEMP TABLE t1(i INT) WITH (APPENDOPTIMIZED = TRUE) DISTRIBUTED BY (i);
+CREATE
+1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+ user_id_ok | cur_sess_id | content | size  
+------------+-------------+---------+-------
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+(48 rows)
+2: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+ user_id_ok | cur_sess_id | content | size  
+------------+-------------+---------+-------
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+(48 rows)
+3: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+ user_id_ok | cur_sess_id | content | size  
+------------+-------------+---------+-------
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+(48 rows)
+
+-- Dropped tables are removed from the list in all sessions
+1: DROP TABLE t2;
+DROP
+1: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 36    
+(1 row)
+2: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 36    
+(1 row)
+3: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 36    
+(1 row)
+2: DROP TABLE t1;
+DROP
+1: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 24    
+(1 row)
+2: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 24    
+(1 row)
+3: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 24    
+(1 row)
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>
+
+--
+-- AO tables, on commit drop
+
+-- We can see tables created in the current session
+1: BEGIN;
+BEGIN
+1: CREATE TEMP TABLE t1(i INT) WITH (APPENDOPTIMIZED = TRUE) ON COMMIT DROP DISTRIBUTED BY (i);
+CREATE
+1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') sess_id_ok, content, size FROM tts_get_seg_files() f;
+ user_id_ok | sess_id_ok | content | size  
+------------+------------+---------+-------
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 32768 
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 32768 
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 32768 
+(12 rows)
+1: CREATE TEMP TABLE t2(i INT) WITH (APPENDOPTIMIZED = TRUE) ON COMMIT DROP DISTRIBUTED BY (i);
+CREATE
+1: CREATE TEMP TABLE t3(i INT) WITH (APPENDOPTIMIZED = TRUE) ON COMMIT DROP DISTRIBUTED BY (i);
+CREATE
+1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') sess_id_ok, content, size FROM tts_get_seg_files() f;
+ user_id_ok | sess_id_ok | content | size  
+------------+------------+---------+-------
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 32768 
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 32768 
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 32768 
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 32768 
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 32768 
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 32768 
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 32768 
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 32768 
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 32768 
+(36 rows)
+
+-- We can see tables created in other sessions
+2: BEGIN;
+BEGIN
+2: CREATE TEMP TABLE t1(i INT) WITH (APPENDOPTIMIZED = TRUE) ON COMMIT DROP DISTRIBUTED BY (i);
+CREATE
+1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+ user_id_ok | cur_sess_id | content | size  
+------------+-------------+---------+-------
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+(48 rows)
+2: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+ user_id_ok | cur_sess_id | content | size  
+------------+-------------+---------+-------
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+(48 rows)
+3: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+ user_id_ok | cur_sess_id | content | size  
+------------+-------------+---------+-------
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+(48 rows)
+
+-- Dropped tables are removed from the list in all sessions
+1: ROLLBACK;
+ROLLBACK
+1: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 12    
+(1 row)
+2: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 12    
+(1 row)
+3: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 12    
+(1 row)
+2: COMMIT;
+COMMIT
+1: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 0     
+(1 row)
+2: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 0     
+(1 row)
+3: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 0     
+(1 row)
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>
+
+--
+-- Ordinary AOCO tables
+-- 4 files per AOCO table: data file, pg_aocsseg, pg_aovisimap, pg_aovisimap_index
+
+-- We can see tables created in the current session
+1: CREATE TEMP TABLE t1(i INT, j INT) WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN) DISTRIBUTED BY (i);
+CREATE
+1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') sess_id_ok, content, size FROM tts_get_seg_files() f;
+ user_id_ok | sess_id_ok | content | size  
+------------+------------+---------+-------
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 32768 
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 32768 
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 32768 
+(12 rows)
+1: CREATE TEMP TABLE t2(i INT, j INT) WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN) DISTRIBUTED BY (i);
+CREATE
+1: CREATE TEMP TABLE t3(i INT, j INT) WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN) DISTRIBUTED BY (i);
+CREATE
+1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') sess_id_ok, content, size FROM tts_get_seg_files() f;
+ user_id_ok | sess_id_ok | content | size  
+------------+------------+---------+-------
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 32768 
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 32768 
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 32768 
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 32768 
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 32768 
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 32768 
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 32768 
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 32768 
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 32768 
+(36 rows)
+
+-- We can see tables created in other sessions
+2: CREATE TEMP TABLE t1(i INT, j INT) WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN) DISTRIBUTED BY (i);
+CREATE
+1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+ user_id_ok | cur_sess_id | content | size  
+------------+-------------+---------+-------
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+(48 rows)
+2: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+ user_id_ok | cur_sess_id | content | size  
+------------+-------------+---------+-------
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+(48 rows)
+3: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+ user_id_ok | cur_sess_id | content | size  
+------------+-------------+---------+-------
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+(48 rows)
+
+-- Dropped tables are removed from the list in all sessions
+1: DROP TABLE t2;
+DROP
+1: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 36    
+(1 row)
+2: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 36    
+(1 row)
+3: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 36    
+(1 row)
+2: DROP TABLE t1;
+DROP
+1: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 24    
+(1 row)
+2: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 24    
+(1 row)
+3: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 24    
+(1 row)
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>
+
+
+--
+-- AO tables, on commit drop
+
+-- We can see tables created in the current session
+1: BEGIN;
+BEGIN
+1: CREATE TEMP TABLE t1(i INT, j INT) WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN) ON COMMIT DROP DISTRIBUTED BY (i);
+CREATE
+1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') sess_id_ok, content, size FROM tts_get_seg_files() f;
+ user_id_ok | sess_id_ok | content | size  
+------------+------------+---------+-------
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 32768 
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 32768 
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 32768 
+(12 rows)
+1: CREATE TEMP TABLE t2(i INT, j INT) WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN) ON COMMIT DROP DISTRIBUTED BY (i);
+CREATE
+1: CREATE TEMP TABLE t3(i INT, j INT) WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN) ON COMMIT DROP DISTRIBUTED BY (i);
+CREATE
+1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') sess_id_ok, content, size FROM tts_get_seg_files() f;
+ user_id_ok | sess_id_ok | content | size  
+------------+------------+---------+-------
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 32768 
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 32768 
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 0     
+ t          | t          | 0       | 32768 
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 32768 
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 32768 
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 0     
+ t          | t          | 1       | 32768 
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 32768 
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 32768 
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 0     
+ t          | t          | 2       | 32768 
+(36 rows)
+
+-- We can see tables created in other sessions
+2: BEGIN;
+BEGIN
+2: CREATE TEMP TABLE t1(i INT, j INT) WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN) ON COMMIT DROP DISTRIBUTED BY (i);
+CREATE
+1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+ user_id_ok | cur_sess_id | content | size  
+------------+-------------+---------+-------
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+(48 rows)
+2: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+ user_id_ok | cur_sess_id | content | size  
+------------+-------------+---------+-------
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+(48 rows)
+3: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+ user_id_ok | cur_sess_id | content | size  
+------------+-------------+---------+-------
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+(48 rows)
+
+-- Dropped tables are removed from the list in all sessions
+1: ROLLBACK;
+ROLLBACK
+1: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 12    
+(1 row)
+2: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 12    
+(1 row)
+3: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 12    
+(1 row)
+2: COMMIT;
+COMMIT
+1: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 0     
+(1 row)
+2: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 0     
+(1 row)
+3: SELECT COUNT(*) FROM tts_get_seg_files();
+ count 
+-------
+ 0     
+(1 row)
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>
+
+--
+-- Check that files size calculation takes into account all the forks
+CREATE TEMP TABLE t1 WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN) AS SELECT i, i j FROM generate_series(1, 100) i DISTRIBUTED BY (i);
+CREATE 100
+-- t1 consists of two colums. Both column files are taken into account
+SELECT content, size FROM tts_get_seg_files();
+ content | size  
+---------+-------
+ 0       | 384   
+ 0       | 32768 
+ 0       | 0     
+ 0       | 32768 
+ 1       | 384   
+ 1       | 32768 
+ 1       | 0     
+ 1       | 32768 
+ 2       | 288   
+ 2       | 32768 
+ 2       | 0     
+ 2       | 32768 
+(12 rows)
+-- Vaccum adds FSM and VM
+VACUUM t1;
+VACUUM
+SELECT content, size FROM tts_get_seg_files();
+ content | size   
+---------+--------
+ 0       | 384    
+ 0       | 163840 
+ 0       | 0      
+ 0       | 32768  
+ 1       | 384    
+ 1       | 163840 
+ 1       | 0      
+ 1       | 32768  
+ 2       | 288    
+ 2       | 163840 
+ 2       | 0      
+ 2       | 32768  
+(12 rows)

--- a/src/test/isolation2/expected/temp_tables_stat.out
+++ b/src/test/isolation2/expected/temp_tables_stat.out
@@ -9,7 +9,7 @@
 CREATE
 -- end_ignore
 
-1: CREATE OR REPLACE FUNCTION get_files (OUT user_id_ok bool, OUT cur_sess_id bool, OUT content int2, OUT size int8) RETURNS SETOF record AS $$ SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f; /**/ $$ LANGUAGE SQL;
+1: CREATE OR REPLACE FUNCTION get_files (OUT user_id_ok bool, OUT cur_sess_id bool, OUT content int2, OUT size int8) RETURNS SETOF record AS $$ SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f; -- $$ LANGUAGE SQL;
 CREATE
 
 -- No tables, the files list is empty

--- a/src/test/isolation2/expected/temp_tables_stat.out
+++ b/src/test/isolation2/expected/temp_tables_stat.out
@@ -1,3 +1,16 @@
+-- start_ignore
+0: ! gpconfig -c shared_preload_libraries -v 'temp_tables_stat';
+20251123:12:36:14:039354 gpconfig:sokolov43a-yu-lin:sokolov43a-yu-[INFO]:-completed successfully with parameters '-c shared_preload_libraries -v temp_tables_stat'
+
+0: ! gpstop -raiq;
+
+
+1: CREATE EXTENSION IF NOT EXISTS temp_tables_stat;
+CREATE
+-- end_ignore
+
+1: CREATE OR REPLACE FUNCTION get_files (OUT user_id_ok bool, OUT cur_sess_id bool, OUT content int2, OUT size int8) RETURNS SETOF record AS $$ SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f; /**/ $$ LANGUAGE SQL;
+CREATE
 
 -- No tables, the files list is empty
 1: SELECT * FROM tts_get_seg_files();
@@ -11,41 +24,37 @@
 -- We can see tables created in the current session
 1: CREATE TEMP TABLE t1(i INT) DISTRIBUTED BY (i);
 CREATE
-1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') sess_id_ok, content, size FROM tts_get_seg_files() f;
- user_id_ok | sess_id_ok | content | size 
-------------+------------+---------+------
- t          | t          | 0       | 0    
- t          | t          | 2       | 0    
- t          | t          | 1       | 0    
+1: SELECT * FROM get_files();
+ user_id_ok | cur_sess_id | content | size 
+------------+-------------+---------+------
+ t          | t           | 0       | 0    
+ t          | t           | 1       | 0    
+ t          | t           | 2       | 0    
 (3 rows)
 1: CREATE TEMP TABLE t2(i INT) DISTRIBUTED BY (i);
 CREATE
 1: CREATE TEMP TABLE t3(i INT) DISTRIBUTED BY (i);
 CREATE
-1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') sess_id_ok, content, size FROM tts_get_seg_files() f;
- user_id_ok | sess_id_ok | content | size 
-------------+------------+---------+------
- t          | t          | 0       | 0    
- t          | t          | 0       | 0    
- t          | t          | 0       | 0    
- t          | t          | 2       | 0    
- t          | t          | 2       | 0    
- t          | t          | 2       | 0    
- t          | t          | 1       | 0    
- t          | t          | 1       | 0    
- t          | t          | 1       | 0    
+1: SELECT * FROM get_files();
+ user_id_ok | cur_sess_id | content | size 
+------------+-------------+---------+------
+ t          | t           | 1       | 0    
+ t          | t           | 1       | 0    
+ t          | t           | 1       | 0    
+ t          | t           | 2       | 0    
+ t          | t           | 2       | 0    
+ t          | t           | 2       | 0    
+ t          | t           | 0       | 0    
+ t          | t           | 0       | 0    
+ t          | t           | 0       | 0    
 (9 rows)
 
 -- We can see tables created in other sessions
 2: CREATE TEMP TABLE t1(i INT) DISTRIBUTED BY (i);
 CREATE
-1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+1: SELECT * FROM get_files();
  user_id_ok | cur_sess_id | content | size 
 ------------+-------------+---------+------
- t          | t           | 0       | 0    
- t          | t           | 0       | 0    
- t          | t           | 0       | 0    
- t          | f           | 0       | 0    
  t          | t           | 1       | 0    
  t          | t           | 1       | 0    
  t          | t           | 1       | 0    
@@ -54,24 +63,28 @@ CREATE
  t          | t           | 2       | 0    
  t          | t           | 2       | 0    
  t          | f           | 2       | 0    
+ t          | t           | 0       | 0    
+ t          | t           | 0       | 0    
+ t          | t           | 0       | 0    
+ t          | f           | 0       | 0    
 (12 rows)
-2: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+2: SELECT * FROM get_files();
  user_id_ok | cur_sess_id | content | size 
 ------------+-------------+---------+------
- t          | f           | 1       | 0    
- t          | f           | 1       | 0    
- t          | f           | 1       | 0    
- t          | t           | 1       | 0    
  t          | f           | 0       | 0    
  t          | f           | 0       | 0    
  t          | f           | 0       | 0    
  t          | t           | 0       | 0    
+ t          | f           | 1       | 0    
+ t          | f           | 1       | 0    
+ t          | f           | 1       | 0    
+ t          | t           | 1       | 0    
  t          | f           | 2       | 0    
  t          | f           | 2       | 0    
  t          | f           | 2       | 0    
  t          | t           | 2       | 0    
 (12 rows)
-3: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+3: SELECT * FROM get_files();
  user_id_ok | cur_sess_id | content | size 
 ------------+-------------+---------+------
  t          | f           | 0       | 0    
@@ -135,29 +148,29 @@ DROP
 BEGIN
 1: CREATE TEMP TABLE t1(i INT) ON COMMIT DROP DISTRIBUTED BY (i);
 CREATE
-1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') sess_id_ok, content, size FROM tts_get_seg_files() f;
- user_id_ok | sess_id_ok | content | size 
-------------+------------+---------+------
- t          | t          | 0       | 0    
- t          | t          | 2       | 0    
- t          | t          | 1       | 0    
+1: SELECT * FROM get_files();
+ user_id_ok | cur_sess_id | content | size 
+------------+-------------+---------+------
+ t          | t           | 1       | 0    
+ t          | t           | 2       | 0    
+ t          | t           | 0       | 0    
 (3 rows)
 1: CREATE TEMP TABLE t2(i INT) ON COMMIT DROP DISTRIBUTED BY (i);
 CREATE
 1: CREATE TEMP TABLE t3(i INT) ON COMMIT DROP DISTRIBUTED BY (i);
 CREATE
-1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') sess_id_ok, content, size FROM tts_get_seg_files() f;
- user_id_ok | sess_id_ok | content | size 
-------------+------------+---------+------
- t          | t          | 0       | 0    
- t          | t          | 0       | 0    
- t          | t          | 0       | 0    
- t          | t          | 1       | 0    
- t          | t          | 1       | 0    
- t          | t          | 1       | 0    
- t          | t          | 2       | 0    
- t          | t          | 2       | 0    
- t          | t          | 2       | 0    
+1: SELECT * FROM get_files();
+ user_id_ok | cur_sess_id | content | size 
+------------+-------------+---------+------
+ t          | t           | 1       | 0    
+ t          | t           | 1       | 0    
+ t          | t           | 1       | 0    
+ t          | t           | 2       | 0    
+ t          | t           | 2       | 0    
+ t          | t           | 2       | 0    
+ t          | t           | 0       | 0    
+ t          | t           | 0       | 0    
+ t          | t           | 0       | 0    
 (9 rows)
 
 -- We can see tables created in other sessions
@@ -165,9 +178,13 @@ CREATE
 BEGIN
 2: CREATE TEMP TABLE t1(i INT) ON COMMIT DROP DISTRIBUTED BY (i);
 CREATE
-1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+1: SELECT * FROM get_files();
  user_id_ok | cur_sess_id | content | size 
 ------------+-------------+---------+------
+ t          | t           | 2       | 0    
+ t          | t           | 2       | 0    
+ t          | t           | 2       | 0    
+ t          | f           | 2       | 0    
  t          | t           | 1       | 0    
  t          | t           | 1       | 0    
  t          | t           | 1       | 0    
@@ -176,18 +193,10 @@ CREATE
  t          | t           | 0       | 0    
  t          | t           | 0       | 0    
  t          | f           | 0       | 0    
- t          | t           | 2       | 0    
- t          | t           | 2       | 0    
- t          | t           | 2       | 0    
- t          | f           | 2       | 0    
 (12 rows)
-2: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+2: SELECT * FROM get_files();
  user_id_ok | cur_sess_id | content | size 
 ------------+-------------+---------+------
- t          | f           | 1       | 0    
- t          | f           | 1       | 0    
- t          | f           | 1       | 0    
- t          | t           | 1       | 0    
  t          | f           | 2       | 0    
  t          | f           | 2       | 0    
  t          | f           | 2       | 0    
@@ -196,22 +205,26 @@ CREATE
  t          | f           | 0       | 0    
  t          | f           | 0       | 0    
  t          | t           | 0       | 0    
+ t          | f           | 1       | 0    
+ t          | f           | 1       | 0    
+ t          | f           | 1       | 0    
+ t          | t           | 1       | 0    
 (12 rows)
-3: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+3: SELECT * FROM get_files();
  user_id_ok | cur_sess_id | content | size 
 ------------+-------------+---------+------
- t          | f           | 0       | 0    
- t          | f           | 0       | 0    
- t          | f           | 0       | 0    
- t          | f           | 0       | 0    
- t          | f           | 2       | 0    
- t          | f           | 2       | 0    
- t          | f           | 2       | 0    
- t          | f           | 2       | 0    
  t          | f           | 1       | 0    
  t          | f           | 1       | 0    
  t          | f           | 1       | 0    
  t          | f           | 1       | 0    
+ t          | f           | 2       | 0    
+ t          | f           | 2       | 0    
+ t          | f           | 2       | 0    
+ t          | f           | 2       | 0    
+ t          | f           | 0       | 0    
+ t          | f           | 0       | 0    
+ t          | f           | 0       | 0    
+ t          | f           | 0       | 0    
 (12 rows)
 
 -- Dropped tables are removed from the list in all sessions
@@ -260,73 +273,89 @@ COMMIT
 -- We can see tables created in the current session
 1: CREATE TEMP TABLE t1(i INT) WITH (APPENDOPTIMIZED = TRUE) DISTRIBUTED BY (i);
 CREATE
-1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') sess_id_ok, content, size FROM tts_get_seg_files() f;
- user_id_ok | sess_id_ok | content | size  
-------------+------------+---------+-------
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 32768 
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 32768 
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 32768 
+1: SELECT * FROM get_files();
+ user_id_ok | cur_sess_id | content | size  
+------------+-------------+---------+-------
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
 (12 rows)
 1: CREATE TEMP TABLE t2(i INT) WITH (APPENDOPTIMIZED = TRUE) DISTRIBUTED BY (i);
 CREATE
 1: CREATE TEMP TABLE t3(i INT) WITH (APPENDOPTIMIZED = TRUE) DISTRIBUTED BY (i);
 CREATE
-1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') sess_id_ok, content, size FROM tts_get_seg_files() f;
- user_id_ok | sess_id_ok | content | size  
-------------+------------+---------+-------
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 32768 
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 32768 
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 32768 
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 32768 
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 32768 
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 32768 
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 32768 
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 32768 
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 32768 
+1: SELECT * FROM get_files();
+ user_id_ok | cur_sess_id | content | size  
+------------+-------------+---------+-------
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
 (36 rows)
 
 -- We can see tables created in other sessions
 2: CREATE TEMP TABLE t1(i INT) WITH (APPENDOPTIMIZED = TRUE) DISTRIBUTED BY (i);
 CREATE
-1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+1: SELECT * FROM get_files();
  user_id_ok | cur_sess_id | content | size  
 ------------+-------------+---------+-------
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
  t          | t           | 0       | 0     
  t          | t           | 0       | 0     
  t          | t           | 0       | 0     
@@ -359,26 +388,26 @@ CREATE
  t          | f           | 1       | 0     
  t          | f           | 1       | 0     
  t          | f           | 1       | 32768 
- t          | t           | 2       | 0     
- t          | t           | 2       | 0     
- t          | t           | 2       | 0     
- t          | t           | 2       | 32768 
- t          | t           | 2       | 0     
- t          | t           | 2       | 0     
- t          | t           | 2       | 0     
- t          | t           | 2       | 32768 
- t          | t           | 2       | 0     
- t          | t           | 2       | 0     
- t          | t           | 2       | 0     
- t          | t           | 2       | 32768 
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 32768 
 (48 rows)
-2: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+2: SELECT * FROM get_files();
  user_id_ok | cur_sess_id | content | size  
 ------------+-------------+---------+-------
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
  t          | f           | 0       | 0     
  t          | f           | 0       | 0     
  t          | f           | 0       | 0     
@@ -411,42 +440,10 @@ CREATE
  t          | t           | 1       | 0     
  t          | t           | 1       | 0     
  t          | t           | 1       | 32768 
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 32768 
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 32768 
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 32768 
- t          | t           | 2       | 0     
- t          | t           | 2       | 0     
- t          | t           | 2       | 0     
- t          | t           | 2       | 32768 
 (48 rows)
-3: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+3: SELECT * FROM get_files();
  user_id_ok | cur_sess_id | content | size  
 ------------+-------------+---------+-------
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 32768 
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 32768 
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 32768 
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 32768 
  t          | f           | 1       | 0     
  t          | f           | 1       | 0     
  t          | f           | 1       | 0     
@@ -463,6 +460,22 @@ CREATE
  t          | f           | 1       | 0     
  t          | f           | 1       | 0     
  t          | f           | 1       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
  t          | f           | 0       | 0     
  t          | f           | 0       | 0     
  t          | f           | 0       | 0     
@@ -528,65 +541,65 @@ DROP
 BEGIN
 1: CREATE TEMP TABLE t1(i INT) WITH (APPENDOPTIMIZED = TRUE) ON COMMIT DROP DISTRIBUTED BY (i);
 CREATE
-1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') sess_id_ok, content, size FROM tts_get_seg_files() f;
- user_id_ok | sess_id_ok | content | size  
-------------+------------+---------+-------
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 32768 
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 32768 
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 32768 
+1: SELECT * FROM get_files();
+ user_id_ok | cur_sess_id | content | size  
+------------+-------------+---------+-------
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
 (12 rows)
 1: CREATE TEMP TABLE t2(i INT) WITH (APPENDOPTIMIZED = TRUE) ON COMMIT DROP DISTRIBUTED BY (i);
 CREATE
 1: CREATE TEMP TABLE t3(i INT) WITH (APPENDOPTIMIZED = TRUE) ON COMMIT DROP DISTRIBUTED BY (i);
 CREATE
-1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') sess_id_ok, content, size FROM tts_get_seg_files() f;
- user_id_ok | sess_id_ok | content | size  
-------------+------------+---------+-------
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 32768 
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 32768 
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 32768 
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 32768 
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 32768 
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 32768 
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 32768 
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 32768 
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 32768 
+1: SELECT * FROM get_files();
+ user_id_ok | cur_sess_id | content | size  
+------------+-------------+---------+-------
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
 (36 rows)
 
 -- We can see tables created in other sessions
@@ -594,25 +607,9 @@ CREATE
 BEGIN
 2: CREATE TEMP TABLE t1(i INT) WITH (APPENDOPTIMIZED = TRUE) ON COMMIT DROP DISTRIBUTED BY (i);
 CREATE
-1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+1: SELECT * FROM get_files();
  user_id_ok | cur_sess_id | content | size  
 ------------+-------------+---------+-------
- t          | t           | 1       | 0     
- t          | t           | 1       | 0     
- t          | t           | 1       | 0     
- t          | t           | 1       | 32768 
- t          | t           | 1       | 0     
- t          | t           | 1       | 0     
- t          | t           | 1       | 0     
- t          | t           | 1       | 32768 
- t          | t           | 1       | 0     
- t          | t           | 1       | 0     
- t          | t           | 1       | 0     
- t          | t           | 1       | 32768 
- t          | f           | 1       | 0     
- t          | f           | 1       | 0     
- t          | f           | 1       | 0     
- t          | f           | 1       | 32768 
  t          | t           | 0       | 0     
  t          | t           | 0       | 0     
  t          | t           | 0       | 0     
@@ -629,6 +626,22 @@ CREATE
  t          | f           | 0       | 0     
  t          | f           | 0       | 0     
  t          | f           | 0       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
  t          | t           | 2       | 0     
  t          | t           | 2       | 0     
  t          | t           | 2       | 0     
@@ -646,41 +659,9 @@ CREATE
  t          | f           | 2       | 0     
  t          | f           | 2       | 32768 
 (48 rows)
-2: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+2: SELECT * FROM get_files();
  user_id_ok | cur_sess_id | content | size  
 ------------+-------------+---------+-------
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 32768 
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 32768 
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 32768 
- t          | t           | 2       | 0     
- t          | t           | 2       | 0     
- t          | t           | 2       | 0     
- t          | t           | 2       | 32768 
- t          | f           | 1       | 0     
- t          | f           | 1       | 0     
- t          | f           | 1       | 0     
- t          | f           | 1       | 32768 
- t          | f           | 1       | 0     
- t          | f           | 1       | 0     
- t          | f           | 1       | 0     
- t          | f           | 1       | 32768 
- t          | f           | 1       | 0     
- t          | f           | 1       | 0     
- t          | f           | 1       | 0     
- t          | f           | 1       | 32768 
- t          | t           | 1       | 0     
- t          | t           | 1       | 0     
- t          | t           | 1       | 0     
- t          | t           | 1       | 32768 
  t          | f           | 0       | 0     
  t          | f           | 0       | 0     
  t          | f           | 0       | 0     
@@ -697,8 +678,40 @@ CREATE
  t          | t           | 0       | 0     
  t          | t           | 0       | 0     
  t          | t           | 0       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
 (48 rows)
-3: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+3: SELECT * FROM get_files();
  user_id_ok | cur_sess_id | content | size  
 ------------+-------------+---------+-------
  t          | f           | 0       | 0     
@@ -797,71 +810,71 @@ COMMIT
 -- We can see tables created in the current session
 1: CREATE TEMP TABLE t1(i INT, j INT) WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN) DISTRIBUTED BY (i);
 CREATE
-1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') sess_id_ok, content, size FROM tts_get_seg_files() f;
- user_id_ok | sess_id_ok | content | size  
-------------+------------+---------+-------
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 32768 
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 32768 
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 32768 
+1: SELECT * FROM get_files();
+ user_id_ok | cur_sess_id | content | size  
+------------+-------------+---------+-------
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
 (12 rows)
 1: CREATE TEMP TABLE t2(i INT, j INT) WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN) DISTRIBUTED BY (i);
 CREATE
 1: CREATE TEMP TABLE t3(i INT, j INT) WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN) DISTRIBUTED BY (i);
 CREATE
-1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') sess_id_ok, content, size FROM tts_get_seg_files() f;
- user_id_ok | sess_id_ok | content | size  
-------------+------------+---------+-------
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 32768 
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 32768 
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 32768 
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 32768 
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 32768 
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 32768 
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 32768 
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 32768 
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 32768 
+1: SELECT * FROM get_files();
+ user_id_ok | cur_sess_id | content | size  
+------------+-------------+---------+-------
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
 (36 rows)
 
 -- We can see tables created in other sessions
 2: CREATE TEMP TABLE t1(i INT, j INT) WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN) DISTRIBUTED BY (i);
 CREATE
-1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+1: SELECT * FROM get_files();
  user_id_ok | cur_sess_id | content | size  
 ------------+-------------+---------+-------
  t          | t           | 2       | 0     
@@ -913,25 +926,9 @@ CREATE
  t          | f           | 1       | 0     
  t          | f           | 1       | 32768 
 (48 rows)
-2: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+2: SELECT * FROM get_files();
  user_id_ok | cur_sess_id | content | size  
 ------------+-------------+---------+-------
- t          | f           | 1       | 0     
- t          | f           | 1       | 0     
- t          | f           | 1       | 0     
- t          | f           | 1       | 32768 
- t          | f           | 1       | 0     
- t          | f           | 1       | 0     
- t          | f           | 1       | 0     
- t          | f           | 1       | 32768 
- t          | f           | 1       | 0     
- t          | f           | 1       | 0     
- t          | f           | 1       | 0     
- t          | f           | 1       | 32768 
- t          | t           | 1       | 0     
- t          | t           | 1       | 0     
- t          | t           | 1       | 0     
- t          | t           | 1       | 32768 
  t          | f           | 2       | 0     
  t          | f           | 2       | 0     
  t          | f           | 2       | 0     
@@ -964,10 +961,42 @@ CREATE
  t          | t           | 0       | 0     
  t          | t           | 0       | 0     
  t          | t           | 0       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
 (48 rows)
-3: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+3: SELECT * FROM get_files();
  user_id_ok | cur_sess_id | content | size  
 ------------+-------------+---------+-------
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 0     
+ t          | f           | 0       | 32768 
  t          | f           | 1       | 0     
  t          | f           | 1       | 0     
  t          | f           | 1       | 0     
@@ -1000,22 +1029,6 @@ CREATE
  t          | f           | 2       | 0     
  t          | f           | 2       | 0     
  t          | f           | 2       | 32768 
- t          | f           | 0       | 0     
- t          | f           | 0       | 0     
- t          | f           | 0       | 0     
- t          | f           | 0       | 32768 
- t          | f           | 0       | 0     
- t          | f           | 0       | 0     
- t          | f           | 0       | 0     
- t          | f           | 0       | 32768 
- t          | f           | 0       | 0     
- t          | f           | 0       | 0     
- t          | f           | 0       | 0     
- t          | f           | 0       | 32768 
- t          | f           | 0       | 0     
- t          | f           | 0       | 0     
- t          | f           | 0       | 0     
- t          | f           | 0       | 32768 
 (48 rows)
 
 -- Dropped tables are removed from the list in all sessions
@@ -1066,65 +1079,65 @@ DROP
 BEGIN
 1: CREATE TEMP TABLE t1(i INT, j INT) WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN) ON COMMIT DROP DISTRIBUTED BY (i);
 CREATE
-1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') sess_id_ok, content, size FROM tts_get_seg_files() f;
- user_id_ok | sess_id_ok | content | size  
-------------+------------+---------+-------
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 32768 
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 32768 
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 32768 
+1: SELECT * FROM get_files();
+ user_id_ok | cur_sess_id | content | size  
+------------+-------------+---------+-------
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
 (12 rows)
 1: CREATE TEMP TABLE t2(i INT, j INT) WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN) ON COMMIT DROP DISTRIBUTED BY (i);
 CREATE
 1: CREATE TEMP TABLE t3(i INT, j INT) WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN) ON COMMIT DROP DISTRIBUTED BY (i);
 CREATE
-1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') sess_id_ok, content, size FROM tts_get_seg_files() f;
- user_id_ok | sess_id_ok | content | size  
-------------+------------+---------+-------
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 32768 
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 32768 
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 0     
- t          | t          | 0       | 32768 
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 32768 
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 32768 
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 0     
- t          | t          | 1       | 32768 
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 32768 
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 32768 
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 0     
- t          | t          | 2       | 32768 
+1: SELECT * FROM get_files();
+ user_id_ok | cur_sess_id | content | size  
+------------+-------------+---------+-------
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 0     
+ t          | t           | 0       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 0     
+ t          | t           | 1       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
 (36 rows)
 
 -- We can see tables created in other sessions
@@ -1132,7 +1145,7 @@ CREATE
 BEGIN
 2: CREATE TEMP TABLE t1(i INT, j INT) WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN) ON COMMIT DROP DISTRIBUTED BY (i);
 CREATE
-1: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+1: SELECT * FROM get_files();
  user_id_ok | cur_sess_id | content | size  
 ------------+-------------+---------+-------
  t          | t           | 2       | 0     
@@ -1184,7 +1197,7 @@ CREATE
  t          | f           | 1       | 0     
  t          | f           | 1       | 32768 
 (48 rows)
-2: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+2: SELECT * FROM get_files();
  user_id_ok | cur_sess_id | content | size  
 ------------+-------------+---------+-------
  t          | f           | 1       | 0     
@@ -1203,22 +1216,6 @@ CREATE
  t          | t           | 1       | 0     
  t          | t           | 1       | 0     
  t          | t           | 1       | 32768 
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 32768 
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 32768 
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 0     
- t          | f           | 2       | 32768 
- t          | t           | 2       | 0     
- t          | t           | 2       | 0     
- t          | t           | 2       | 0     
- t          | t           | 2       | 32768 
  t          | f           | 0       | 0     
  t          | f           | 0       | 0     
  t          | f           | 0       | 0     
@@ -1235,8 +1232,24 @@ CREATE
  t          | t           | 0       | 0     
  t          | t           | 0       | 0     
  t          | t           | 0       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 0     
+ t          | f           | 2       | 32768 
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 0     
+ t          | t           | 2       | 32768 
 (48 rows)
-3: SELECT (SELECT a.oid = f.user_id FROM pg_authid a WHERE a.rolname = current_user) user_id_ok, (SELECT s.setting::int = f.sess_id FROM pg_settings s WHERE name = 'gp_session_id') cur_sess_id, content, size FROM tts_get_seg_files() f;
+3: SELECT * FROM get_files();
  user_id_ok | cur_sess_id | content | size  
 ------------+-------------+---------+-------
  t          | f           | 2       | 0     
@@ -1255,22 +1268,6 @@ CREATE
  t          | f           | 2       | 0     
  t          | f           | 2       | 0     
  t          | f           | 2       | 32768 
- t          | f           | 1       | 0     
- t          | f           | 1       | 0     
- t          | f           | 1       | 0     
- t          | f           | 1       | 32768 
- t          | f           | 1       | 0     
- t          | f           | 1       | 0     
- t          | f           | 1       | 0     
- t          | f           | 1       | 32768 
- t          | f           | 1       | 0     
- t          | f           | 1       | 0     
- t          | f           | 1       | 0     
- t          | f           | 1       | 32768 
- t          | f           | 1       | 0     
- t          | f           | 1       | 0     
- t          | f           | 1       | 0     
- t          | f           | 1       | 32768 
  t          | f           | 0       | 0     
  t          | f           | 0       | 0     
  t          | f           | 0       | 0     
@@ -1287,6 +1284,22 @@ CREATE
  t          | f           | 0       | 0     
  t          | f           | 0       | 0     
  t          | f           | 0       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 0     
+ t          | f           | 1       | 32768 
 (48 rows)
 
 -- Dropped tables are removed from the list in all sessions
@@ -1336,6 +1349,10 @@ CREATE 100
 SELECT content, size FROM tts_get_seg_files();
  content | size  
 ---------+-------
+ 2       | 288   
+ 2       | 32768 
+ 2       | 0     
+ 2       | 32768 
  0       | 384   
  0       | 32768 
  0       | 0     
@@ -1344,10 +1361,6 @@ SELECT content, size FROM tts_get_seg_files();
  1       | 32768 
  1       | 0     
  1       | 32768 
- 2       | 288   
- 2       | 32768 
- 2       | 0     
- 2       | 32768 
 (12 rows)
 -- Vaccum adds FSM and VM
 VACUUM t1;
@@ -1355,10 +1368,6 @@ VACUUM
 SELECT content, size FROM tts_get_seg_files();
  content | size   
 ---------+--------
- 0       | 384    
- 0       | 163840 
- 0       | 0      
- 0       | 32768  
  1       | 384    
  1       | 163840 
  1       | 0      
@@ -1367,10 +1376,24 @@ SELECT content, size FROM tts_get_seg_files();
  2       | 163840 
  2       | 0      
  2       | 32768  
+ 0       | 384    
+ 0       | 163840 
+ 0       | 0      
+ 0       | 32768  
 (12 rows)
 
 --
 -- Cleanup
+DROP FUNCTION get_files (OUT user_id_ok bool, OUT cur_sess_id bool, OUT content int2, OUT size int8);
+DROP
+
 DROP EXTENSION temp_tables_stat;
 DROP
 
+-- start_ignore
+! gpconfig -r shared_preload_libraries;
+20251123:12:36:27:042380 gpconfig:sokolov43a-yu-lin:sokolov43a-yu-[INFO]:-completed successfully with parameters '-r shared_preload_libraries'
+
+! gpstop -raiq;
+
+-- end_ignore

--- a/src/test/isolation2/expected/temp_tables_stat.out
+++ b/src/test/isolation2/expected/temp_tables_stat.out
@@ -1,13 +1,3 @@
--- start_ignore
-0: ! gpconfig -c shared_preload_libraries -v 'temp_tables_stat';
-20251120:10:17:27:025975 gpconfig:sokolov43a-yu-lin:sokolov43a-yu-[INFO]:-completed successfully with parameters '-c shared_preload_libraries -v temp_tables_stat'
-
-0: ! gpstop -raiq;
-
-
-1: CREATE EXTENSION IF NOT EXISTS temp_tables_stat;
-CREATE
--- end_ignore
 
 -- No tables, the files list is empty
 1: SELECT * FROM tts_get_seg_files();

--- a/src/test/isolation2/expected/temp_tables_stat.out
+++ b/src/test/isolation2/expected/temp_tables_stat.out
@@ -1368,3 +1368,9 @@ SELECT content, size FROM tts_get_seg_files();
  2       | 0      
  2       | 32768  
 (12 rows)
+
+--
+-- Cleanup
+DROP EXTENSION temp_tables_stat;
+DROP
+

--- a/src/test/isolation2/sql/temp_tables_stat.sql
+++ b/src/test/isolation2/sql/temp_tables_stat.sql
@@ -462,3 +462,12 @@ SELECT content, size FROM tts_get_seg_files();
 -- Vaccum adds FSM and VM
 VACUUM t1;
 SELECT content, size FROM tts_get_seg_files();
+
+--
+-- Cleanup
+DROP EXTENSION temp_tables_stat;
+
+-- start_ignore
+! gpconfig -r shared_preload_libraries;
+! gpstop -raiq;
+-- end_ignore

--- a/src/test/isolation2/sql/temp_tables_stat.sql
+++ b/src/test/isolation2/sql/temp_tables_stat.sql
@@ -17,7 +17,7 @@ AS $$
             WHERE name = 'gp_session_id') cur_sess_id,
           content,
           size
-     FROM tts_get_seg_files() f; /**/
+     FROM tts_get_seg_files() f; --
 $$ LANGUAGE SQL;
 
 -- No tables, the files list is empty

--- a/src/test/isolation2/sql/temp_tables_stat.sql
+++ b/src/test/isolation2/sql/temp_tables_stat.sql
@@ -5,6 +5,21 @@
 1: CREATE EXTENSION IF NOT EXISTS temp_tables_stat;
 -- end_ignore
 
+1: CREATE OR REPLACE FUNCTION get_files
+(OUT user_id_ok bool, OUT cur_sess_id bool, OUT content int2, OUT size int8)
+RETURNS SETOF record
+AS $$
+    SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') cur_sess_id,
+          content,
+          size
+     FROM tts_get_seg_files() f; /**/
+$$ LANGUAGE SQL;
+
 -- No tables, the files list is empty
 1: SELECT * FROM tts_get_seg_files();
 
@@ -13,56 +28,16 @@
 
 -- We can see tables created in the current session
 1: CREATE TEMP TABLE t1(i INT) DISTRIBUTED BY (i);
-1: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') sess_id_ok,
-          content,
-          size
-     FROM tts_get_seg_files() f;
+1: SELECT * FROM get_files();
 1: CREATE TEMP TABLE t2(i INT) DISTRIBUTED BY (i);
 1: CREATE TEMP TABLE t3(i INT) DISTRIBUTED BY (i);
-1: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') sess_id_ok,
-          content,
-          size
-     FROM tts_get_seg_files() f;
+1: SELECT * FROM get_files();
 
 -- We can see tables created in other sessions
 2: CREATE TEMP TABLE t1(i INT) DISTRIBUTED BY (i);
-1: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') cur_sess_id,
-          content,
-          size
-     FROM tts_get_seg_files() f;
-2: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') cur_sess_id,
-          content,
-          size
-     FROM tts_get_seg_files() f;
-3: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') cur_sess_id,
-          content,
-          size
-     FROM tts_get_seg_files() f;
+1: SELECT * FROM get_files();
+2: SELECT * FROM get_files();
+3: SELECT * FROM get_files();
 
 -- Dropped tables are removed from the list in all sessions
 1: DROP TABLE t2;
@@ -83,57 +58,17 @@
 -- We can see tables created in the current session
 1: BEGIN;
 1: CREATE TEMP TABLE t1(i INT) ON COMMIT DROP DISTRIBUTED BY (i);
-1: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') sess_id_ok,
-          content,
-          size
-     FROM tts_get_seg_files() f;
+1: SELECT * FROM get_files();
 1: CREATE TEMP TABLE t2(i INT) ON COMMIT DROP DISTRIBUTED BY (i);
 1: CREATE TEMP TABLE t3(i INT) ON COMMIT DROP DISTRIBUTED BY (i);
-1: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') sess_id_ok,
-          content,
-          size
-     FROM tts_get_seg_files() f;
+1: SELECT * FROM get_files();
 
 -- We can see tables created in other sessions
 2: BEGIN;
 2: CREATE TEMP TABLE t1(i INT) ON COMMIT DROP DISTRIBUTED BY (i);
-1: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') cur_sess_id,
-          content,
-          size
-     FROM tts_get_seg_files() f;
-2: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') cur_sess_id,
-          content,
-          size
-     FROM tts_get_seg_files() f;
-3: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') cur_sess_id,
-          content,
-          size
-     FROM tts_get_seg_files() f;
+1: SELECT * FROM get_files();
+2: SELECT * FROM get_files();
+3: SELECT * FROM get_files();
 
 -- Dropped tables are removed from the list in all sessions
 1: ROLLBACK;
@@ -154,56 +89,16 @@
 
 -- We can see tables created in the current session
 1: CREATE TEMP TABLE t1(i INT) WITH (APPENDOPTIMIZED = TRUE) DISTRIBUTED BY (i);
-1: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') sess_id_ok,
-          content,
-          size
-     FROM tts_get_seg_files() f;
+1: SELECT * FROM get_files();
 1: CREATE TEMP TABLE t2(i INT) WITH (APPENDOPTIMIZED = TRUE) DISTRIBUTED BY (i);
 1: CREATE TEMP TABLE t3(i INT) WITH (APPENDOPTIMIZED = TRUE) DISTRIBUTED BY (i);
-1: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') sess_id_ok,
-          content,
-          size
-     FROM tts_get_seg_files() f;
+1: SELECT * FROM get_files();
 
 -- We can see tables created in other sessions
 2: CREATE TEMP TABLE t1(i INT) WITH (APPENDOPTIMIZED = TRUE) DISTRIBUTED BY (i);
-1: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') cur_sess_id,
-          content,
-          size
-     FROM tts_get_seg_files() f;
-2: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') cur_sess_id,
-          content,
-          size
-     FROM tts_get_seg_files() f;
-3: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') cur_sess_id,
-          content,
-          size
-     FROM tts_get_seg_files() f;
+1: SELECT * FROM get_files();
+2: SELECT * FROM get_files();
+3: SELECT * FROM get_files();
 
 -- Dropped tables are removed from the list in all sessions
 1: DROP TABLE t2;
@@ -224,57 +119,17 @@
 -- We can see tables created in the current session
 1: BEGIN;
 1: CREATE TEMP TABLE t1(i INT) WITH (APPENDOPTIMIZED = TRUE) ON COMMIT DROP DISTRIBUTED BY (i);
-1: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') sess_id_ok,
-          content,
-          size
-     FROM tts_get_seg_files() f;
+1: SELECT * FROM get_files();
 1: CREATE TEMP TABLE t2(i INT) WITH (APPENDOPTIMIZED = TRUE) ON COMMIT DROP DISTRIBUTED BY (i);
 1: CREATE TEMP TABLE t3(i INT) WITH (APPENDOPTIMIZED = TRUE) ON COMMIT DROP DISTRIBUTED BY (i);
-1: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') sess_id_ok,
-          content,
-          size
-     FROM tts_get_seg_files() f;
+1: SELECT * FROM get_files();
 
 -- We can see tables created in other sessions
 2: BEGIN;
 2: CREATE TEMP TABLE t1(i INT) WITH (APPENDOPTIMIZED = TRUE) ON COMMIT DROP DISTRIBUTED BY (i);
-1: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') cur_sess_id,
-          content,
-          size
-     FROM tts_get_seg_files() f;
-2: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') cur_sess_id,
-          content,
-          size
-     FROM tts_get_seg_files() f;
-3: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') cur_sess_id,
-          content,
-          size
-     FROM tts_get_seg_files() f;
+1: SELECT * FROM get_files();
+2: SELECT * FROM get_files();
+3: SELECT * FROM get_files();
 
 -- Dropped tables are removed from the list in all sessions
 1: ROLLBACK;
@@ -297,62 +152,22 @@
 1: CREATE TEMP TABLE t1(i INT, j INT)
    WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN)
    DISTRIBUTED BY (i);
-1: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') sess_id_ok,
-          content,
-          size
-     FROM tts_get_seg_files() f;
+1: SELECT * FROM get_files();
 1: CREATE TEMP TABLE t2(i INT, j INT)
    WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN)
    DISTRIBUTED BY (i);
 1: CREATE TEMP TABLE t3(i INT, j INT)
    WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN)
    DISTRIBUTED BY (i);
-1: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') sess_id_ok,
-          content,
-          size
-     FROM tts_get_seg_files() f;
+1: SELECT * FROM get_files();
 
 -- We can see tables created in other sessions
 2: CREATE TEMP TABLE t1(i INT, j INT)
    WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN)
    DISTRIBUTED BY (i);
-1: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') cur_sess_id,
-          content,
-          size
-     FROM tts_get_seg_files() f;
-2: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') cur_sess_id,
-          content,
-          size
-     FROM tts_get_seg_files() f;
-3: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') cur_sess_id,
-          content,
-          size
-     FROM tts_get_seg_files() f;
+1: SELECT * FROM get_files();
+2: SELECT * FROM get_files();
+3: SELECT * FROM get_files();
 
 -- Dropped tables are removed from the list in all sessions
 1: DROP TABLE t2;
@@ -377,15 +192,7 @@
    WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN)
    ON COMMIT DROP
    DISTRIBUTED BY (i);
-1: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') sess_id_ok,
-          content,
-          size
-     FROM tts_get_seg_files() f;
+1: SELECT * FROM get_files();
 1: CREATE TEMP TABLE t2(i INT, j INT)
    WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN)
    ON COMMIT DROP
@@ -394,15 +201,7 @@
    WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN)
    ON COMMIT DROP
    DISTRIBUTED BY (i);
-1: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') sess_id_ok,
-          content,
-          size
-     FROM tts_get_seg_files() f;
+1: SELECT * FROM get_files();
 
 -- We can see tables created in other sessions
 2: BEGIN;
@@ -410,33 +209,9 @@
    WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN)
    ON COMMIT DROP
    DISTRIBUTED BY (i);
-1: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') cur_sess_id,
-          content,
-          size
-     FROM tts_get_seg_files() f;
-2: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') cur_sess_id,
-          content,
-          size
-     FROM tts_get_seg_files() f;
-3: SELECT (SELECT a.oid = f.user_id
-             FROM pg_authid a
-            WHERE a.rolname = current_user) user_id_ok,
-          (SELECT s.setting::int = f.sess_id
-             FROM pg_settings s
-            WHERE name = 'gp_session_id') cur_sess_id,
-          content,
-          size
-     FROM tts_get_seg_files() f;
+1: SELECT * FROM get_files();
+2: SELECT * FROM get_files();
+3: SELECT * FROM get_files();
 
 -- Dropped tables are removed from the list in all sessions
 1: ROLLBACK;
@@ -465,6 +240,9 @@ SELECT content, size FROM tts_get_seg_files();
 
 --
 -- Cleanup
+DROP FUNCTION get_files
+(OUT user_id_ok bool, OUT cur_sess_id bool, OUT content int2, OUT size int8);
+
 DROP EXTENSION temp_tables_stat;
 
 -- start_ignore

--- a/src/test/isolation2/sql/temp_tables_stat.sql
+++ b/src/test/isolation2/sql/temp_tables_stat.sql
@@ -1,0 +1,464 @@
+-- start_ignore
+0: ! gpconfig -c shared_preload_libraries -v 'temp_tables_stat';
+0: ! gpstop -raiq;
+
+1: CREATE EXTENSION IF NOT EXISTS temp_tables_stat;
+-- end_ignore
+
+-- No tables, the files list is empty
+1: SELECT * FROM tts_get_seg_files();
+
+--
+-- Ordinary heap tables
+
+-- We can see tables created in the current session
+1: CREATE TEMP TABLE t1(i INT) DISTRIBUTED BY (i);
+1: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') sess_id_ok,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+1: CREATE TEMP TABLE t2(i INT) DISTRIBUTED BY (i);
+1: CREATE TEMP TABLE t3(i INT) DISTRIBUTED BY (i);
+1: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') sess_id_ok,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+
+-- We can see tables created in other sessions
+2: CREATE TEMP TABLE t1(i INT) DISTRIBUTED BY (i);
+1: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') cur_sess_id,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+2: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') cur_sess_id,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+3: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') cur_sess_id,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+
+-- Dropped tables are removed from the list in all sessions
+1: DROP TABLE t2;
+1: SELECT COUNT(*) FROM tts_get_seg_files();
+2: SELECT COUNT(*) FROM tts_get_seg_files();
+3: SELECT COUNT(*) FROM tts_get_seg_files();
+2: DROP TABLE t1;
+1: SELECT COUNT(*) FROM tts_get_seg_files();
+2: SELECT COUNT(*) FROM tts_get_seg_files();
+3: SELECT COUNT(*) FROM tts_get_seg_files();
+1q:
+2q:
+3q:
+
+--
+-- Heap tables, on commit drop 
+
+-- We can see tables created in the current session
+1: BEGIN;
+1: CREATE TEMP TABLE t1(i INT) ON COMMIT DROP DISTRIBUTED BY (i);
+1: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') sess_id_ok,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+1: CREATE TEMP TABLE t2(i INT) ON COMMIT DROP DISTRIBUTED BY (i);
+1: CREATE TEMP TABLE t3(i INT) ON COMMIT DROP DISTRIBUTED BY (i);
+1: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') sess_id_ok,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+
+-- We can see tables created in other sessions
+2: BEGIN;
+2: CREATE TEMP TABLE t1(i INT) ON COMMIT DROP DISTRIBUTED BY (i);
+1: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') cur_sess_id,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+2: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') cur_sess_id,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+3: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') cur_sess_id,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+
+-- Dropped tables are removed from the list in all sessions
+1: ROLLBACK;
+1: SELECT COUNT(*) FROM tts_get_seg_files();
+2: SELECT COUNT(*) FROM tts_get_seg_files();
+3: SELECT COUNT(*) FROM tts_get_seg_files();
+2: COMMIT;
+1: SELECT COUNT(*) FROM tts_get_seg_files();
+2: SELECT COUNT(*) FROM tts_get_seg_files();
+3: SELECT COUNT(*) FROM tts_get_seg_files();
+1q:
+2q:
+3q:
+
+--
+-- Ordinary AO tables
+-- 4 files per AO table: data file, pg_aoseg, pg_aovisimap, pg_aovisimap_index
+
+-- We can see tables created in the current session
+1: CREATE TEMP TABLE t1(i INT) WITH (APPENDOPTIMIZED = TRUE) DISTRIBUTED BY (i);
+1: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') sess_id_ok,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+1: CREATE TEMP TABLE t2(i INT) WITH (APPENDOPTIMIZED = TRUE) DISTRIBUTED BY (i);
+1: CREATE TEMP TABLE t3(i INT) WITH (APPENDOPTIMIZED = TRUE) DISTRIBUTED BY (i);
+1: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') sess_id_ok,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+
+-- We can see tables created in other sessions
+2: CREATE TEMP TABLE t1(i INT) WITH (APPENDOPTIMIZED = TRUE) DISTRIBUTED BY (i);
+1: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') cur_sess_id,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+2: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') cur_sess_id,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+3: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') cur_sess_id,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+
+-- Dropped tables are removed from the list in all sessions
+1: DROP TABLE t2;
+1: SELECT COUNT(*) FROM tts_get_seg_files();
+2: SELECT COUNT(*) FROM tts_get_seg_files();
+3: SELECT COUNT(*) FROM tts_get_seg_files();
+2: DROP TABLE t1;
+1: SELECT COUNT(*) FROM tts_get_seg_files();
+2: SELECT COUNT(*) FROM tts_get_seg_files();
+3: SELECT COUNT(*) FROM tts_get_seg_files();
+1q:
+2q:
+3q:
+
+--
+-- AO tables, on commit drop 
+
+-- We can see tables created in the current session
+1: BEGIN;
+1: CREATE TEMP TABLE t1(i INT) WITH (APPENDOPTIMIZED = TRUE) ON COMMIT DROP DISTRIBUTED BY (i);
+1: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') sess_id_ok,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+1: CREATE TEMP TABLE t2(i INT) WITH (APPENDOPTIMIZED = TRUE) ON COMMIT DROP DISTRIBUTED BY (i);
+1: CREATE TEMP TABLE t3(i INT) WITH (APPENDOPTIMIZED = TRUE) ON COMMIT DROP DISTRIBUTED BY (i);
+1: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') sess_id_ok,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+
+-- We can see tables created in other sessions
+2: BEGIN;
+2: CREATE TEMP TABLE t1(i INT) WITH (APPENDOPTIMIZED = TRUE) ON COMMIT DROP DISTRIBUTED BY (i);
+1: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') cur_sess_id,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+2: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') cur_sess_id,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+3: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') cur_sess_id,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+
+-- Dropped tables are removed from the list in all sessions
+1: ROLLBACK;
+1: SELECT COUNT(*) FROM tts_get_seg_files();
+2: SELECT COUNT(*) FROM tts_get_seg_files();
+3: SELECT COUNT(*) FROM tts_get_seg_files();
+2: COMMIT;
+1: SELECT COUNT(*) FROM tts_get_seg_files();
+2: SELECT COUNT(*) FROM tts_get_seg_files();
+3: SELECT COUNT(*) FROM tts_get_seg_files();
+1q:
+2q:
+3q:
+
+--
+-- Ordinary AOCO tables
+-- 4 files per AOCO table: data file, pg_aocsseg, pg_aovisimap, pg_aovisimap_index
+
+-- We can see tables created in the current session
+1: CREATE TEMP TABLE t1(i INT, j INT)
+   WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN)
+   DISTRIBUTED BY (i);
+1: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') sess_id_ok,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+1: CREATE TEMP TABLE t2(i INT, j INT)
+   WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN)
+   DISTRIBUTED BY (i);
+1: CREATE TEMP TABLE t3(i INT, j INT)
+   WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN)
+   DISTRIBUTED BY (i);
+1: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') sess_id_ok,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+
+-- We can see tables created in other sessions
+2: CREATE TEMP TABLE t1(i INT, j INT)
+   WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN)
+   DISTRIBUTED BY (i);
+1: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') cur_sess_id,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+2: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') cur_sess_id,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+3: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') cur_sess_id,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+
+-- Dropped tables are removed from the list in all sessions
+1: DROP TABLE t2;
+1: SELECT COUNT(*) FROM tts_get_seg_files();
+2: SELECT COUNT(*) FROM tts_get_seg_files();
+3: SELECT COUNT(*) FROM tts_get_seg_files();
+2: DROP TABLE t1;
+1: SELECT COUNT(*) FROM tts_get_seg_files();
+2: SELECT COUNT(*) FROM tts_get_seg_files();
+3: SELECT COUNT(*) FROM tts_get_seg_files();
+1q:
+2q:
+3q:
+
+
+--
+-- AO tables, on commit drop 
+
+-- We can see tables created in the current session
+1: BEGIN;
+1: CREATE TEMP TABLE t1(i INT, j INT)
+   WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN)
+   ON COMMIT DROP
+   DISTRIBUTED BY (i);
+1: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') sess_id_ok,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+1: CREATE TEMP TABLE t2(i INT, j INT)
+   WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN)
+   ON COMMIT DROP
+   DISTRIBUTED BY (i);
+1: CREATE TEMP TABLE t3(i INT, j INT)
+   WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN)
+   ON COMMIT DROP
+   DISTRIBUTED BY (i);
+1: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') sess_id_ok,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+
+-- We can see tables created in other sessions
+2: BEGIN;
+2: CREATE TEMP TABLE t1(i INT, j INT)
+   WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN)
+   ON COMMIT DROP
+   DISTRIBUTED BY (i);
+1: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') cur_sess_id,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+2: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') cur_sess_id,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+3: SELECT (SELECT a.oid = f.user_id
+             FROM pg_authid a
+            WHERE a.rolname = current_user) user_id_ok,
+          (SELECT s.setting::int = f.sess_id
+             FROM pg_settings s
+            WHERE name = 'gp_session_id') cur_sess_id,
+          content,
+          size
+     FROM tts_get_seg_files() f;
+
+-- Dropped tables are removed from the list in all sessions
+1: ROLLBACK;
+1: SELECT COUNT(*) FROM tts_get_seg_files();
+2: SELECT COUNT(*) FROM tts_get_seg_files();
+3: SELECT COUNT(*) FROM tts_get_seg_files();
+2: COMMIT;
+1: SELECT COUNT(*) FROM tts_get_seg_files();
+2: SELECT COUNT(*) FROM tts_get_seg_files();
+3: SELECT COUNT(*) FROM tts_get_seg_files();
+1q:
+2q:
+3q:
+
+--
+-- Check that files size calculation takes into account all the forks
+CREATE TEMP TABLE t1
+   WITH (APPENDOPTIMIZED = TRUE, ORIENTATION = COLUMN)
+   AS SELECT i, i j FROM generate_series(1, 100) i
+   DISTRIBUTED BY (i);
+-- t1 consists of two colums. Both column files are taken into account
+SELECT content, size FROM tts_get_seg_files();
+-- Vaccum adds FSM and VM
+VACUUM t1;
+SELECT content, size FROM tts_get_seg_files();


### PR DESCRIPTION
This extension is useful to find out how much disk space is occupied by
temporary tables and which user created them in which session.
The extension tracks the creation and deletion of temporary table files on
segments. The list of files is stored in the shared memory of each segment.
If memory allocated using ShmemInitStruct is not enough, the extension uses DSM.
The extension adds the tts_get_seg_files function to get the tracked files,
their sizes, user and session where they was created from segments.
Add the ic-temp_tables_stat test for the extension.