### PR TITLE
Reject FAST in temporary table creation

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -4257,8 +4257,8 @@ OptTemp:	TEMPORARY					{ $$ = RELPERSISTENCE_TEMP; }
 			| TEMP						{ $$ = RELPERSISTENCE_TEMP; }
 			| LOCAL TEMPORARY			{ $$ = RELPERSISTENCE_TEMP; }
 			| LOCAL TEMP				{ $$ = RELPERSISTENCE_TEMP; }
-			| FAST TEMPORARY			{ $$ = RELPERSISTENCE_FAST_TEMP; }
-			| FAST TEMP				{ $$ = RELPERSISTENCE_FAST_TEMP; }
+			| FAST TEMPORARY			{ $$ = RELPERSISTENCE_TEMP; }
+			| FAST TEMP				{ $$ = RELPERSISTENCE_TEMP; }
 			| GLOBAL TEMPORARY
 				{
 					ereport(WARNING,
@@ -12310,12 +12310,12 @@ OptTempTableName:
 			| FAST TEMPORARY opt_table qualified_name
 				{
 					$$ = $4;
-					$$->relpersistence = RELPERSISTENCE_FAST_TEMP;
+					$$->relpersistence = RELPERSISTENCE_TEMP;
 				}
 			| FAST TEMP opt_table qualified_name
 				{
 					$$ = $4;
-					$$->relpersistence = RELPERSISTENCE_FAST_TEMP;
+					$$->relpersistence = RELPERSISTENCE_TEMP;
 				}
 			| GLOBAL TEMPORARY opt_table qualified_name
 				{

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -4257,8 +4257,6 @@ OptTemp:	TEMPORARY					{ $$ = RELPERSISTENCE_TEMP; }
 			| TEMP						{ $$ = RELPERSISTENCE_TEMP; }
 			| LOCAL TEMPORARY			{ $$ = RELPERSISTENCE_TEMP; }
 			| LOCAL TEMP				{ $$ = RELPERSISTENCE_TEMP; }
-			| FAST TEMPORARY			{ $$ = RELPERSISTENCE_TEMP; }
-			| FAST TEMP				{ $$ = RELPERSISTENCE_TEMP; }
 			| GLOBAL TEMPORARY
 				{
 					ereport(WARNING,
@@ -12303,16 +12301,6 @@ OptTempTableName:
 					$$->relpersistence = RELPERSISTENCE_TEMP;
 				}
 			| LOCAL TEMP opt_table qualified_name
-				{
-					$$ = $4;
-					$$->relpersistence = RELPERSISTENCE_TEMP;
-				}
-			| FAST TEMPORARY opt_table qualified_name
-				{
-					$$ = $4;
-					$$->relpersistence = RELPERSISTENCE_TEMP;
-				}
-			| FAST TEMP opt_table qualified_name
 				{
 					$$ = $4;
 					$$->relpersistence = RELPERSISTENCE_TEMP;


### PR DESCRIPTION
This practically reverts support for CREATE FAST TEMP

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
