### PR TITLE
Fix compile-time error for DateTimeParseError.

### DIFF
--- a/src/backend/utils/adt/datetime.c
+++ b/src/backend/utils/adt/datetime.c
@@ -4083,11 +4083,14 @@ DecodeUnits(int field, char *lowtoken, int *val)
  * DTERR_TZDISP_OVERFLOW from DTERR_FIELD_OVERFLOW, but SQL99 mandates three
  * separate SQLSTATE codes, so ...
  */
+/* XXX: we keep this in #if 0 for sake of (possible) rebase */
+#if 0
 void
 DateTimeParseError(int dterr, const char *str, const char *datatype)
 {
 	(void) DateTimeParseErrorSafe(dterr, str, datatype, NULL);
 }
+#endif
 
 bool
 DateTimeParseErrorSafe(int dterr, const char *str, const char *datatype, Node *escontext)

--- a/src/include/utils/datetime.h
+++ b/src/include/utils/datetime.h
@@ -313,8 +313,12 @@ extern int DecodeInterval(char **field, int *ftype, int nf, int range,
 extern int DecodeISO8601Interval(char *str,
 					  int *dtype, struct pg_tm * tm, fsec_t *fsec);
 
+/* XXX: we keep this in #if 0 for sake of (possible) rebase */
+#if 0
 extern void DateTimeParseError(int dterr, const char *str,
 				   const char *datatype) __attribute__((noreturn));
+#endif
+
 extern bool DateTimeParseErrorSafe(int dterr, const char *str,
 				   const char *datatype, Node *escontext);
 


### PR DESCRIPTION
This is oversight of TRY CONVERT feature

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
