### PR TITLE
Fix couple of  -Wmisleading-indentation warns.

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1377,13 +1377,16 @@ standard_ExecutorEnd(QueryDesc *queryDesc)
 	oldcontext = MemoryContextSwitchTo(estate->es_query_cxt);
 
     /*
+	 * XXX: GPDB specific
      * If EXPLAIN ANALYZE, qExec returns stats to qDisp now.
      */
     if (estate->es_sliceTable &&
         estate->es_sliceTable->instrument_options &&
         (estate->es_sliceTable->instrument_options & INSTRUMENT_CDB) &&
         Gp_role == GP_ROLE_EXECUTE)
+	{
         cdbexplain_sendExecStats(queryDesc);
+	}
 
 	/*
 	 * if needed, collect mpp dispatch results and tear down

--- a/src/backend/postmaster/syslogger.c
+++ b/src/backend/postmaster/syslogger.c
@@ -592,7 +592,7 @@ SysLoggerMain(int argc, char *argv[])
 		if (alert_log_level_opened && alert_rotation_requested)
 		{
 		    if (!time_based_rotation && size_rotation_for_alert == 0)
-		        size_rotation_for_alert = true;
+				size_rotation_for_alert = true;
 
 			alert_rotation_requested = false;
 			all_rotations_occurred &=


### PR DESCRIPTION
```
execMain.c: In function ‘standard_ExecutorEnd’:
execMain.c:1382:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
 1382 |     if (estate->es_sliceTable &&
      |     ^~
In file included from ../../../src/include/postgres.h:53,
                 from execMain.c:40:
../../../src/include/utils/elog.h:523:9: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  523 |         do { \
      |         ^~
execMain.c:1392:9: note: in expansion of macro ‘PG_TRY’
 1392 |         PG_TRY();
      |         ^~~~~~
^[[A^[[A^[[A^[[A^[[A^[[Osyslogger.c: In function ‘SysLoggerMain’:
syslogger.c:594:21: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
  594 |                     if (!time_based_rotation && size_rotation_for_alert == 0)
      |                     ^~
syslogger.c:597:25: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  597 |                         alert_rotation_requested = false;


```
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
