### PR TITLE
libpq: Bail out during SSLnegotiation errors

### DIFF
--- a/src/interfaces/libpq/fe-connect.c
+++ b/src/interfaces/libpq/fe-connect.c
@@ -2424,15 +2424,11 @@ keep_going:						/* We will come back to here until there is
 					{
 						/*
 						 * Server failure of some sort, such as failure to
-						 * fork a backend process.  We need to process and
-						 * report the error message, which might be formatted
-						 * according to either protocol 2 or protocol 3.
-						 * Rather than duplicate the code for that, we flip
-						 * into AWAITING_RESPONSE state and let the code there
-						 * deal with it.  Note we have *not* consumed the "E"
-						 * byte here.
+						 * fork a backend process.  Don't bother retrieving
+						 * the error message; we should not trust it as the
+						 * server has not been authenticated yet.
 						 */
-						libpq_append_conn_error(conn, "server sent an error response during SSL exchange");
+						appendPQExpBuffer(&conn->errorMessage, "server sent an error response during SSL exchange");
 						goto error_return;
 					}
 					else

--- a/src/interfaces/libpq/fe-connect.c
+++ b/src/interfaces/libpq/fe-connect.c
@@ -2432,8 +2432,8 @@ keep_going:						/* We will come back to here until there is
 						 * deal with it.  Note we have *not* consumed the "E"
 						 * byte here.
 						 */
-						conn->status = CONNECTION_AWAITING_RESPONSE;
-						goto keep_going;
+						libpq_append_conn_error(conn, "server sent an error response during SSL exchange");
+						goto error_return;
 					}
 					else
 					{

--- a/src/interfaces/libpq/fe-connect.c
+++ b/src/interfaces/libpq/fe-connect.c
@@ -2428,7 +2428,7 @@ keep_going:						/* We will come back to here until there is
 						 * the error message; we should not trust it as the
 						 * server has not been authenticated yet.
 						 */
-						appendPQExpBuffer(&conn->errorMessage, "server sent an error response during SSL exchange");
+						appendPQExpBuffer(&conn->errorMessage, libpq_gettext("server sent an error response during SSL exchange"));
 						goto error_return;
 					}
 					else


### PR DESCRIPTION
This commit changes libpq so that errors reported by the backend during the protocol negotiation for SSL are discarded by the client, as these may include bytes that could be consumed by the client and write arbitrary bytes to a client's terminal.

A failure with the SSL negotiation now leads to an error immediately reported, without a retry on any other methods allowed, like a fallback to a plaintext connection.

Author: Jacob Champion
Reviewed-by: Peter Eisentraut, Heikki Linnakangas, Michael Paquier
Security: CVE-2024-10977


cherry-picked from bf8835ea9717df50230c12133cff1b486dcc57be

tests omitted as src/interfaces/libpq/t/005_negotiate_encryption.pl does not present in GPDB. GSS changes also not ported (they are v12 +).