### PR TITLE
Remove unused varibables in appendonly_acquire_sample_rows

### DIFF
--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -3553,14 +3553,12 @@ appendonly_acquire_sample_rows(Relation onerel, int elevel, HeapTuple *rows,
 {
 	FileSegTotals	*fileSegTotals;
 	BlockNumber		totalBlocks;
-	BlockNumber     blksdone = 0;
 	int		numrows = 0;	/* # number of rows sampled */
 	double	liverows = 0;	/* # live rows seen */
 	double	deadrows = 0;	/* # dead rows seen */
 
 	Snapshot	appendOnlyMetaDataSnapshot;
 	Assert(targrows > 0);
-	int			i;
 
 	appendOnlyMetaDataSnapshot = GetTransactionSnapshot();
 


### PR DESCRIPTION
```

appendonlyam.c: In function ‘appendonly_acquire_sample_rows’:
appendonlyam.c:3563:33: warning: unused variable ‘i’ [-Wunused-variable]
 3563 |         int                     i;
      |                                 ^
appendonlyam.c:3556:25: warning: unused variable ‘blksdone’ [-Wunused-variable]
 3556 |         BlockNumber     blksdone = 0;
      |                         ^~~~~~~~

```
