### PR TITLE
Change storage declaration of RWRestoreArchivedFile.

### DIFF
--- a/src/bin/pg_rewind/parsexlog.c
+++ b/src/bin/pg_rewind/parsexlog.c
@@ -81,7 +81,7 @@ static int SimpleXLogPageRead(XLogReaderState *xlogreader,
  * additional crosscheck on successful recovery.  If the file size is not
  * known, set expectedSize = 0.
  */
-int
+static int
 RWRestoreArchivedFile(const char *path, const char *xlogfname,
 					off_t expectedSize, const char *restoreCommand, int segindx)
 {


### PR DESCRIPTION
```

parsexlog.c:85:1: warning: no previous prototype for ‘RWRestoreArchivedFile’ [-Wmissing-prototypes]
   85 | RWRestoreArchivedFile(const char *path, const char *xlogfname,
      | ^~~~~~~~~~~~~~~~~~~~~
```
