### PR TITLE
Fix AOCO tables expansion

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1470,7 +1470,20 @@ class gpexpand:
         """
         delete_statements = ["delete from pg_catalog.%s" % tab for tab in MASTER_ONLY_TABLES_MAPPED]
         truncate_statements = ["truncate pg_catalog.%s" % tab for tab in MASTER_ONLY_TABLES_NON_MAPPED]
-        statements = delete_statements + truncate_statements
+        truncate_aoco = """do $$ 
+            declare
+                cmd text;
+            begin 
+                for cmd in
+                    select 'truncate only ' || oid::regclass::text
+                      from pg_class
+                     where relstorage = 'c'
+                loop
+                    execute cmd;
+                end loop; 
+            end
+            $$"""
+        statements = delete_statements + truncate_statements + [ truncate_aoco ]
         """
           Connect to each database in the new segments, and clean up the catalog tables.
         """

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1478,6 +1478,7 @@ class gpexpand:
                     select 'truncate only ' || oid::regclass::text
                       from pg_class
                      where relstorage = 'c'
+                       and relkind = 'r'
                 loop
                     execute cmd;
                 end loop; 

--- a/src/test/regress/expected/bfv_gpexpand.out
+++ b/src/test/regress/expected/bfv_gpexpand.out
@@ -1,0 +1,104 @@
+-- Check that it is possible to add columns to AOCO tables in the period
+-- between adding new segments to a cluster and expanding the tables.
+-- Create table without partitions
+create table t (i int, j int)
+with (appendonly = true, orientation = column)
+distributed by (i);
+-- Create table with partitions
+create table tp (i int, j int)
+with (appendonly = true, orientation = column)
+distributed by (i)
+partition by range (j) (partition p start (0) end (2) every(1));
+NOTICE:  CREATE TABLE will create partition "tp_1_prt_p_1" for table "tp"
+NOTICE:  CREATE TABLE will create partition "tp_1_prt_p_2" for table "tp"
+-- Create table with subpartitions
+create table tsp (i int, j int, k int)
+with (appendonly = true, orientation = column)
+distributed by (i)
+partition by range (j)
+  subpartition by range (k)
+  subpartition template (subpartition sp start (0) end (2) every(1))
+(partition p start (0) end (2) every(1));
+NOTICE:  CREATE TABLE will create partition "tsp_1_prt_p_1" for table "tsp"
+NOTICE:  CREATE TABLE will create partition "tsp_1_prt_p_1_2_prt_sp_1" for table "tsp_1_prt_p_1"
+NOTICE:  CREATE TABLE will create partition "tsp_1_prt_p_1_2_prt_sp_2" for table "tsp_1_prt_p_1"
+NOTICE:  CREATE TABLE will create partition "tsp_1_prt_p_2" for table "tsp"
+NOTICE:  CREATE TABLE will create partition "tsp_1_prt_p_2_2_prt_sp_1" for table "tsp_1_prt_p_2"
+NOTICE:  CREATE TABLE will create partition "tsp_1_prt_p_2_2_prt_sp_2" for table "tsp_1_prt_p_2"
+-- Add tuples to the tables to fill their pg_aocsseg-s on master
+insert into t (i, j) values (1, 1);
+insert into tp (i, j) values (1, 1);
+insert into tsp (i, j, k) values (1, 1, 1);
+-- Check that pg_aocsseg-s contain tuples
+select string_agg('table ' || segrelid::regclass::text, ' union all ')
+         || ';' show_pg_aocssegs
+  from pg_appendonly
+ where relid in ('t'::regclass,
+                 'tp_1_prt_p_2'::regclass,
+                 'tsp_1_prt_p_2_2_prt_sp_2'::regclass) \gset
+:show_pg_aocssegs
+ segno | tupcount | varblockcount |                                                           vpinfo                                                           | modcount | formatversion | state 
+-------+----------+---------------+----------------------------------------------------------------------------------------------------------------------------+----------+---------------+-------
+     1 |        1 |             0 | \x0000000002000000000000000000000000000000000000000000000000000000000000000000000000000000                                 |        1 |             3 |     1
+     1 |        1 |             0 | \x0000000002000000000000000000000000000000000000000000000000000000000000000000000000000000                                 |        1 |             3 |     1
+     1 |        1 |             0 | \x000000000300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 |        1 |             3 |     1
+(3 rows)
+
+-- Add new segments
+\! echo "localhost|localhost|7008|/tmp/datadirs/dbfast4/demoDataDir3|9|3|p" > /tmp/testexpand
+\! echo "localhost|localhost|7009|/tmp/datadirs/dbfast_mirror4/demoDataDir3|10|3|m" >> /tmp/testexpand
+-- Add columns to the tables
+alter table t add b boolean;
+alter table tp add b boolean;
+alter table tsp add b boolean;
+-- Expand tables, no error must happen
+\! gpexpand | grep ERROR | wc -l
+0
+-- Check that the tables are expanded
+select numsegments
+  from gp_distribution_policy
+ where localoid in ('t'::regclass,
+                    'tp_1_prt_p_2'::regclass,
+                    'tsp_1_prt_p_2_2_prt_sp_2'::regclass);
+ numsegments 
+-------------
+           4
+           4
+           4
+(3 rows)
+
+\c postgres
+select status
+  from gpexpand.status_detail
+ where dbname = 'regression'
+   and fq_name in ('public.t',
+                   'public.tp_1_prt_p_2',
+                   'public.tsp_1_prt_p_2_2_prt_sp_2');
+  status   
+-----------
+ COMPLETED
+ COMPLETED
+ COMPLETED
+(3 rows)
+
+\c regression
+-- Cleanup
+-- Check that cluster is shrunk
+select count(*) from gp_segment_configuration;
+ count 
+-------
+     8
+(1 row)
+
+drop table t, tp, tsp;
+\c postgres
+drop schema gpexpand, gpshrink cascade;
+NOTICE:  drop cascades to 6 other objects
+DETAIL:  drop cascades to table gpshrink.status
+drop cascades to table gpshrink.status_detail
+drop cascades to view gpshrink.shrink_progress
+drop cascades to table gpexpand.status
+drop cascades to table gpexpand.status_detail
+drop cascades to view gpexpand.expansion_progress
+\c regression
+\! rm -rf /tmp/datadirs/dbfast_mirror4/ /tmp/datadirs/dbfast4/ /tmp/testexpand

--- a/src/test/regress/expected/gpctas.out
+++ b/src/test/regress/expected/gpctas.out
@@ -261,6 +261,8 @@ from
 refresh materialized view sro_mv_issue_11999;
 ERROR:  division by zero
 CONTEXT:  SQL function "mv_action_select_issue_11999" during startup
+drop materialized view sro_mv_issue_11999;
+drop table t_sro_mv_issue_11999;
 -- CTAS into AOCS table with not crash
 -- See github issue: https://github.com/greenplum-db/gpdb/issues/12936
 set gp_default_storage_options to 'appendonly=true,blocksize=32768,compresstype=zstd,compresslevel=1,checksum=true,orientation=column';

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -305,6 +305,8 @@ test: create_extension_fail
 # check syslogger (since GP syslogger code is divergent from upstream)
 test: syslogger_gp
 
+test: bfv_gpexpand
+
 # run this at the end of the schedule for more chance to catch abnormalies
 test: gp_check_files
 

--- a/src/test/regress/sql/bfv_gpexpand.sql
+++ b/src/test/regress/sql/bfv_gpexpand.sql
@@ -58,8 +58,7 @@ alter table tp add b boolean;
 alter table tsp add b boolean;
 
 -- Expand tables, no error must happen
--- \! gpexpand | grep ERROR | wc -l
-\! gpexpand
+\! gpexpand | grep ERROR | wc -l
 
 -- Check that the tables are expanded
 select numsegments

--- a/src/test/regress/sql/bfv_gpexpand.sql
+++ b/src/test/regress/sql/bfv_gpexpand.sql
@@ -58,7 +58,8 @@ alter table tp add b boolean;
 alter table tsp add b boolean;
 
 -- Expand tables, no error must happen
-\! gpexpand | grep ERROR | wc -l
+-- \! gpexpand | grep ERROR | wc -l
+\! gpexpand
 
 -- Check that the tables are expanded
 select numsegments

--- a/src/test/regress/sql/bfv_gpexpand.sql
+++ b/src/test/regress/sql/bfv_gpexpand.sql
@@ -1,0 +1,94 @@
+-- Check that it is possible to add columns to AOCO tables in the period
+-- between adding new segments to a cluster and expanding the tables.
+
+-- start_ignore
+drop table if exists t, tp, tsp;
+\c postgres
+drop schema if exists gpexpand, gpshrink cascade;
+\c regression
+\! rm -rf /tmp/datadirs/dbfast_mirror4/ /tmp/datadirs/dbfast4/
+-- end_ignore
+
+-- Create table without partitions
+create table t (i int, j int)
+with (appendonly = true, orientation = column)
+distributed by (i);
+
+-- Create table with partitions
+create table tp (i int, j int)
+with (appendonly = true, orientation = column)
+distributed by (i)
+partition by range (j) (partition p start (0) end (2) every(1));
+
+-- Create table with subpartitions
+create table tsp (i int, j int, k int)
+with (appendonly = true, orientation = column)
+distributed by (i)
+partition by range (j)
+  subpartition by range (k)
+  subpartition template (subpartition sp start (0) end (2) every(1))
+(partition p start (0) end (2) every(1));
+
+-- Add tuples to the tables to fill their pg_aocsseg-s on master
+insert into t (i, j) values (1, 1);
+insert into tp (i, j) values (1, 1);
+insert into tsp (i, j, k) values (1, 1, 1);
+
+-- Check that pg_aocsseg-s contain tuples
+select string_agg('table ' || segrelid::regclass::text, ' union all ')
+         || ';' show_pg_aocssegs
+  from pg_appendonly
+ where relid in ('t'::regclass,
+                 'tp_1_prt_p_2'::regclass,
+                 'tsp_1_prt_p_2_2_prt_sp_2'::regclass) \gset
+
+:show_pg_aocssegs
+
+-- Add new segments
+\! echo "localhost|localhost|7008|/tmp/datadirs/dbfast4/demoDataDir3|9|3|p" > /tmp/testexpand
+\! echo "localhost|localhost|7009|/tmp/datadirs/dbfast_mirror4/demoDataDir3|10|3|m" >> /tmp/testexpand
+
+-- start_ignore
+\! gpexpand -i /tmp/testexpand
+-- end_ignore
+
+-- Add columns to the tables
+alter table t add b boolean;
+alter table tp add b boolean;
+alter table tsp add b boolean;
+
+-- Expand tables, no error must happen
+\! gpexpand | grep ERROR | wc -l
+
+-- Check that the tables are expanded
+select numsegments
+  from gp_distribution_policy
+ where localoid in ('t'::regclass,
+                    'tp_1_prt_p_2'::regclass,
+                    'tsp_1_prt_p_2_2_prt_sp_2'::regclass);
+
+\c postgres
+select status
+  from gpexpand.status_detail
+ where dbname = 'regression'
+   and fq_name in ('public.t',
+                   'public.tp_1_prt_p_2',
+                   'public.tsp_1_prt_p_2_2_prt_sp_2');
+\c regression
+
+
+-- Cleanup
+-- start_ignore
+\! gpshrink -i /tmp/testexpand
+\! gpshrink -i /tmp/testexpand
+-- end_ignore
+
+-- Check that cluster is shrunk
+select count(*) from gp_segment_configuration;
+
+drop table t, tp, tsp;
+\c postgres
+drop schema gpexpand, gpshrink cascade;
+\c regression
+
+\! rm -rf /tmp/datadirs/dbfast_mirror4/ /tmp/datadirs/dbfast4/ /tmp/testexpand

--- a/src/test/regress/sql/gpctas.sql
+++ b/src/test/regress/sql/gpctas.sql
@@ -161,6 +161,8 @@ from
 -- then refresh should error out
 refresh materialized view sro_mv_issue_11999;
 
+drop materialized view sro_mv_issue_11999;
+drop table t_sro_mv_issue_11999;
 
 -- CTAS into AOCS table with not crash
 -- See github issue: https://github.com/greenplum-db/gpdb/issues/12936


### PR DESCRIPTION
When a column was added to AOCO after adding new segments to cluster and before
the table expansion, then an error happened on gpexpand calling pg_relation_size
because pg_aocsseg.vpinfo contains invalid value. The table was not expanded in
this case.

A new segment is created based on master using pg_basebackup. AOCO tables on
master are empty, but their pg_aocsseg table contains rows where tupcount > 0,
but all EOFs in vpinfo are 0. These rows are copied to new segments. When
a column is added then the vpinfo column is not updated on the new segment,
because the aocs_addcol_emptyvpe function changes vpinfo when tupcount is 0
and AOCSFileSegInfoAddVpe is called from other functions when EOFs in vpinfo are
greater than zero.

GPDB 7 is not affected, because pg_aocsseg on master does not contain rows.

We cannot change data in pg_aocsseg on master, but we can truncate AOCO tables
on new segments.

Add cleanup to the gpctas test because the sro_mv_issue_11999 materialized view
is not refreshable. So we got an expected error running gpexpand in bfv_gpexpand.