### PR TITLE
Do not cast ATExecAddInherit input.

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -5845,7 +5845,7 @@ ATExecCmd(List **wqueue, AlteredTableInfo *tab, Relation *rel_p,
 			break;
 
 		case AT_AddInherit:
-			address = ATExecAddInherit(rel, (RangeVar *) cmd->def, lockmode);
+			address = ATExecAddInherit(rel, cmd->def, lockmode);
 			break;
 		case AT_DropInherit:
 			address = ATExecDropInherit(rel, (RangeVar *) cmd->def, lockmode);
@@ -14004,6 +14004,7 @@ ATExecAddInherit(Relation child_rel, Node *node, LOCKMODE lockmode)
 	}
 	else
 	{
+		Assert(IsA(node, RangeVar));
 		parent = (RangeVar *) node;
 		is_partition = false;
 	}


### PR DESCRIPTION
After upstream backports, this function can accept InheritPartitionCmd. remove callee-side cast and add assertion on InheritPartitionCmd's input
