### PR TITLE
Add parenthesis to suppress warning.

### DIFF
--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -734,9 +734,11 @@ DefineIndex(Oid relationId,
 			   accessMethodName)));
 
     if  (stmt->unique && RelationIsAppendOptimized(rel))
+    {
         ereport(ERROR,
                 (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
                  errmsg("append-only tables do not support unique indexes")));
+    }
 
 	amcanorder = accessMethodForm->amcanorder;
 	amoptions = accessMethodForm->amoptions;


### PR DESCRIPTION
Compiler warn about bogus indentation:
```
indexcmds.c: In function ‘DefineIndex’:
indexcmds.c:736:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
  736 |     if  (stmt->unique && RelationIsAppendOptimized(rel))
      |     ^~
indexcmds.c:741:9: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  741 |         amcanorder = accessMethodForm->amcanorder;
      |         ^~~~~~~~~~
```

To suppress this warning, use parenthesis around `elog`. Note that we keep space indentation here for sake of (possible) backports
