### PR TITLE
Use separate struct to hold pointers in AOCO pageinspect

### DIFF
--- a/contrib/pageinspect/aofuncs.c
+++ b/contrib/pageinspect/aofuncs.c
@@ -18,6 +18,11 @@
 PG_FUNCTION_INFO_V1(get_ao_headers_info);
 PG_FUNCTION_INFO_V1(get_aocs_headers_info);
 
+typedef struct AOCOHeadersInfoCxt {
+    AOCSScanDesc scan;
+    TupleTableSlot *slot;
+} AOCOHeadersInfoCxt;
+
 typedef struct AOHeadersInfoCxt {
     AppendOnlyScanDesc scan;
     TupleTableSlot *slot;
@@ -299,10 +304,10 @@ get_aocs_headers_info(PG_FUNCTION_ARGS)
 
         funcctx->tuple_desc = BlessTupleDesc(funcctx->tuple_desc);
 
-        funcctx->user_fctx = palloc(sizeof(AOHeadersInfoCxt));
+        funcctx->user_fctx = palloc(sizeof(AOCOHeadersInfoCxt));
 
-        ((AOHeadersInfoCxt*)funcctx->user_fctx)->scan = scan;
-        ((AOHeadersInfoCxt*)funcctx->user_fctx)->slot = slot;
+        ((AOCOHeadersInfoCxt*)funcctx->user_fctx)->scan = scan;
+        ((AOCOHeadersInfoCxt*)funcctx->user_fctx)->slot = slot;
 
         MemoryContextSwitchTo(oldcontext);
     }
@@ -310,8 +315,8 @@ get_aocs_headers_info(PG_FUNCTION_ARGS)
     /* stuff done on every call of the function */
     funcctx = SRF_PERCALL_SETUP();
 
-    scan = ((AOHeadersInfoCxt*)funcctx->user_fctx)->scan;
-    slot = ((AOHeadersInfoCxt*)funcctx->user_fctx)->slot;
+    scan = ((AOCOHeadersInfoCxt*)funcctx->user_fctx)->scan;
+    slot = ((AOCOHeadersInfoCxt*)funcctx->user_fctx)->slot;
 
 	while (1)
 	{


### PR DESCRIPTION
This resolves long-standing commpiler warn

```
aofuncs.c: In function ‘get_aocs_headers_info’:
aofuncs.c:304:55: warning: assignment to ‘AppendOnlyScanDesc’ {aka ‘AppendOnlyScanDescData *’} from incompatible pointer type ‘AOCSScanDesc’ {aka ‘AOCSScanDescData *’} [-Wincompatible-pointer-types]
  304 |         ((AOHeadersInfoCxt*)funcctx->user_fctx)->scan = scan;
      |                                                       ^
aofuncs.c:313:10: warning: assignment to ‘AOCSScanDesc’ {aka ‘AOCSScanDescData *’} from incompatible pointer type ‘AppendOnlyScanDesc’ {aka ‘AppendOnlyScanDescData *’} [-Wincompatible-pointer-types]
  313 |     scan = ((AOHeadersInfoCxt*)funcctx->user_fctx)->scan;
      |          ^
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
