### PR TITLE
Suppress compiler warn for bitmap

### DIFF
--- a/src/backend/access/bitmap/bitmap.c
+++ b/src/backend/access/bitmap/bitmap.c
@@ -240,7 +240,7 @@ bmgetbitmap(PG_FUNCTION_ARGS)
 	 * node in the amgetbitmap AM.
 	 */
 	Assert(bmNodeP);
-	if (*bmNodeP == NULL || IsA(*bmNodeP, TIDBitmap) && tbm_is_empty((TIDBitmap*)*bmNodeP))
+	if (*bmNodeP == NULL || (IsA(*bmNodeP, TIDBitmap) && tbm_is_empty((TIDBitmap*)*bmNodeP)))
 	{
 		StreamBitmap *sb = makeNode(StreamBitmap);
 		sb->streamNode = is;


### PR DESCRIPTION
Add perenthesis for silence this:

```
bitmap.c: In function ‘bmgetbitmap’:
bitmap.c:243:58: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
  243 |         if (*bmNodeP == NULL || IsA(*bmNodeP, TIDBitmap) && tbm_is_empty((TIDBitmap*)*bmNodeP))

```
