### PR TITLE
Cache GUC values at query SUBMIT to ensure consistent filtering

### DIFF
--- a/gpcontrib/yagp_hooks_collector/Makefile
+++ b/gpcontrib/yagp_hooks_collector/Makefile
@@ -1,7 +1,7 @@
 MODULE_big = yagp_hooks_collector
 EXTENSION  = yagp_hooks_collector
 DATA       = $(wildcard *--*.sql)
-REGRESS    = yagp_cursors yagp_dist yagp_select yagp_utf8_trim yagp_utility
+REGRESS    = yagp_cursors yagp_dist yagp_select yagp_utf8_trim yagp_utility yagp_guc_cache
 
 PROTO_BASES = yagpcc_plan yagpcc_metrics yagpcc_set_service
 PROTO_OBJS  = $(patsubst %,src/protos/%.pb.o,$(PROTO_BASES))

--- a/gpcontrib/yagp_hooks_collector/expected/yagp_cursors.out
+++ b/gpcontrib/yagp_hooks_collector/expected/yagp_cursors.out
@@ -26,7 +26,6 @@ RESET yagpcc.logging_mode;
 SELECT segid, query_text, query_status FROM yagpcc.log WHERE segid = -1 AND utility = true ORDER BY segid, ccnt, yagp_status_order(query_status) ASC;
  segid |                 query_text                  |    query_status     
 -------+---------------------------------------------+---------------------
-    -1 | SET yagpcc.logging_mode to 'TBL';           | QUERY_STATUS_DONE
     -1 | BEGIN;                                      | QUERY_STATUS_SUBMIT
     -1 | BEGIN;                                      | QUERY_STATUS_DONE
     -1 | DECLARE cursor_stats_0 CURSOR FOR SELECT 0; | QUERY_STATUS_SUBMIT
@@ -36,6 +35,7 @@ SELECT segid, query_text, query_status FROM yagpcc.log WHERE segid = -1 AND util
     -1 | COMMIT;                                     | QUERY_STATUS_SUBMIT
     -1 | COMMIT;                                     | QUERY_STATUS_DONE
     -1 | RESET yagpcc.logging_mode;                  | QUERY_STATUS_SUBMIT
+    -1 | RESET yagpcc.logging_mode;                  | QUERY_STATUS_DONE
 (10 rows)
 
 SELECT yagpcc.truncate_log() IS NOT NULL AS t;
@@ -56,7 +56,6 @@ RESET yagpcc.logging_mode;
 SELECT segid, query_text, query_status FROM yagpcc.log WHERE segid = -1 AND utility = true ORDER BY segid, ccnt, yagp_status_order(query_status) ASC;
  segid |                      query_text                       |    query_status     
 -------+-------------------------------------------------------+---------------------
-    -1 | SET yagpcc.logging_mode to 'TBL';                     | QUERY_STATUS_DONE
     -1 | BEGIN;                                                | QUERY_STATUS_SUBMIT
     -1 | BEGIN;                                                | QUERY_STATUS_DONE
     -1 | DECLARE cursor_stats_1 CURSOR WITH HOLD FOR SELECT 1; | QUERY_STATUS_SUBMIT
@@ -70,6 +69,7 @@ SELECT segid, query_text, query_status FROM yagpcc.log WHERE segid = -1 AND util
     -1 | COMMIT;                                               | QUERY_STATUS_SUBMIT
     -1 | COMMIT;                                               | QUERY_STATUS_DONE
     -1 | RESET yagpcc.logging_mode;                            | QUERY_STATUS_SUBMIT
+    -1 | RESET yagpcc.logging_mode;                            | QUERY_STATUS_DONE
 (14 rows)
 
 SELECT yagpcc.truncate_log() IS NOT NULL AS t;
@@ -89,7 +89,6 @@ RESET yagpcc.logging_mode;
 SELECT segid, query_text, query_status FROM yagpcc.log WHERE segid = -1 AND utility = true ORDER BY segid, ccnt, yagp_status_order(query_status) ASC;
  segid |                 query_text                  |    query_status     
 -------+---------------------------------------------+---------------------
-    -1 | SET yagpcc.logging_mode to 'TBL';           | QUERY_STATUS_DONE
     -1 | BEGIN;                                      | QUERY_STATUS_SUBMIT
     -1 | BEGIN;                                      | QUERY_STATUS_DONE
     -1 | DECLARE cursor_stats_3 CURSOR FOR SELECT 1; | QUERY_STATUS_SUBMIT
@@ -101,6 +100,7 @@ SELECT segid, query_text, query_status FROM yagpcc.log WHERE segid = -1 AND util
     -1 | ROLLBACK;                                   | QUERY_STATUS_SUBMIT
     -1 | ROLLBACK;                                   | QUERY_STATUS_DONE
     -1 | RESET yagpcc.logging_mode;                  | QUERY_STATUS_SUBMIT
+    -1 | RESET yagpcc.logging_mode;                  | QUERY_STATUS_DONE
 (12 rows)
 
 SELECT yagpcc.truncate_log() IS NOT NULL AS t;
@@ -133,7 +133,6 @@ RESET yagpcc.logging_mode;
 SELECT segid, query_text, query_status FROM yagpcc.log WHERE segid = -1 AND utility = true ORDER BY segid, ccnt, yagp_status_order(query_status) ASC;
  segid |                      query_text                       |    query_status     
 -------+-------------------------------------------------------+---------------------
-    -1 | SET yagpcc.logging_mode to 'TBL';                     | QUERY_STATUS_DONE
     -1 | BEGIN;                                                | QUERY_STATUS_SUBMIT
     -1 | BEGIN;                                                | QUERY_STATUS_DONE
     -1 | DECLARE cursor_stats_5 CURSOR WITH HOLD FOR SELECT 2; | QUERY_STATUS_SUBMIT
@@ -151,6 +150,7 @@ SELECT segid, query_text, query_status FROM yagpcc.log WHERE segid = -1 AND util
     -1 | COMMIT;                                               | QUERY_STATUS_SUBMIT
     -1 | COMMIT;                                               | QUERY_STATUS_DONE
     -1 | RESET yagpcc.logging_mode;                            | QUERY_STATUS_SUBMIT
+    -1 | RESET yagpcc.logging_mode;                            | QUERY_STATUS_DONE
 (18 rows)
 
 SELECT yagpcc.truncate_log() IS NOT NULL AS t;

--- a/gpcontrib/yagp_hooks_collector/expected/yagp_guc_cache.out
+++ b/gpcontrib/yagp_hooks_collector/expected/yagp_guc_cache.out
@@ -9,6 +9,7 @@
 -- This is due to query being actually executed between SUBMIT and DONE.
 -- start_ignore
 CREATE EXTENSION IF NOT EXISTS yagp_hooks_collector;
+SELECT yagpcc.truncate_log();
 -- end_ignore
 CREATE OR REPLACE FUNCTION print_last_query(query text)
 RETURNS TABLE(query_status text) AS $$

--- a/gpcontrib/yagp_hooks_collector/expected/yagp_guc_cache.out
+++ b/gpcontrib/yagp_hooks_collector/expected/yagp_guc_cache.out
@@ -1,0 +1,54 @@
+--
+-- Test GUC caching for query lifecycle consistency.
+--
+-- The extension logs SUBMIT and DONE events for each query.
+-- GUC values that control logging (enable_utility, ignored_users_list, ...)
+-- must be cached at SUBMIT time to ensure DONE uses the same filtering
+-- criteria. Otherwise, a SET command that modifies these GUCs would
+-- have its DONE event rejected, creating orphaned SUBMIT entries.
+-- This is due to query being actually executed between SUBMIT and DONE.
+CREATE EXTENSION yagp_hooks_collector;
+CREATE OR REPLACE FUNCTION print_last_query_like(query_pattern text)
+RETURNS TABLE(query_text text, query_status text) AS $$
+    SELECT l.query_text, l.query_status
+    FROM yagpcc.log l
+    WHERE l.segid = -1 AND l.query_text LIKE query_pattern
+    ORDER BY l.ccnt DESC
+$$ LANGUAGE sql;
+SET yagpcc.ignored_users_list TO '';
+SET yagpcc.enable TO TRUE;
+SET yagpcc.enable_utility TO TRUE;
+SET yagpcc.logging_mode TO 'TBL';
+-- SET below disables utility logging and DONE must still be logged.
+SET yagpcc.enable_utility TO FALSE;
+SELECT * FROM print_last_query_like('SET yagpcc.enable_utility%');
+             query_text              |    query_status     
+-------------------------------------+---------------------
+ SET yagpcc.enable_utility TO FALSE; | QUERY_STATUS_SUBMIT
+ SET yagpcc.enable_utility TO FALSE; | QUERY_STATUS_DONE
+(2 rows)
+
+-- SELECT below adds current user to ignore list and DONE must still be logged.
+-- start_ignore
+SELECT set_config('yagpcc.ignored_users_list', current_user, false);
+ set_config 
+------------
+ gpadmin
+(1 row)
+
+-- end_ignore
+SELECT * FROM print_last_query_like('SELECT set_config%');
+                              query_text                              |    query_status     
+----------------------------------------------------------------------+---------------------
+ SELECT set_config('yagpcc.ignored_users_list', current_user, false); | QUERY_STATUS_SUBMIT
+ SELECT set_config('yagpcc.ignored_users_list', current_user, false); | QUERY_STATUS_START
+ SELECT set_config('yagpcc.ignored_users_list', current_user, false); | QUERY_STATUS_END
+ SELECT set_config('yagpcc.ignored_users_list', current_user, false); | QUERY_STATUS_DONE
+(4 rows)
+
+DROP FUNCTION print_last_query_like(text);
+DROP EXTENSION yagp_hooks_collector;
+RESET yagpcc.enable;
+RESET yagpcc.enable_utility;
+RESET yagpcc.ignored_users_list;
+RESET yagpcc.logging_mode;

--- a/gpcontrib/yagp_hooks_collector/expected/yagp_guc_cache.out
+++ b/gpcontrib/yagp_hooks_collector/expected/yagp_guc_cache.out
@@ -7,13 +7,15 @@
 -- criteria. Otherwise, a SET command that modifies these GUCs would
 -- have its DONE event rejected, creating orphaned SUBMIT entries.
 -- This is due to query being actually executed between SUBMIT and DONE.
-CREATE EXTENSION yagp_hooks_collector;
-CREATE OR REPLACE FUNCTION print_last_query_like(query_pattern text)
-RETURNS TABLE(query_text text, query_status text) AS $$
-    SELECT l.query_text, l.query_status
-    FROM yagpcc.log l
-    WHERE l.segid = -1 AND l.query_text LIKE query_pattern
-    ORDER BY l.ccnt DESC
+-- start_ignore
+CREATE EXTENSION IF NOT EXISTS yagp_hooks_collector;
+-- end_ignore
+CREATE OR REPLACE FUNCTION print_last_query(query text)
+RETURNS TABLE(query_status text) AS $$
+    SELECT query_status
+    FROM yagpcc.log
+    WHERE segid = -1 AND query_text = query
+    ORDER BY ccnt DESC
 $$ LANGUAGE sql;
 SET yagpcc.ignored_users_list TO '';
 SET yagpcc.enable TO TRUE;
@@ -21,11 +23,11 @@ SET yagpcc.enable_utility TO TRUE;
 SET yagpcc.logging_mode TO 'TBL';
 -- SET below disables utility logging and DONE must still be logged.
 SET yagpcc.enable_utility TO FALSE;
-SELECT * FROM print_last_query_like('SET yagpcc.enable_utility%');
-             query_text              |    query_status     
--------------------------------------+---------------------
- SET yagpcc.enable_utility TO FALSE; | QUERY_STATUS_SUBMIT
- SET yagpcc.enable_utility TO FALSE; | QUERY_STATUS_DONE
+SELECT * FROM print_last_query('SET yagpcc.enable_utility TO FALSE;');
+    query_status     
+---------------------
+ QUERY_STATUS_SUBMIT
+ QUERY_STATUS_DONE
 (2 rows)
 
 -- SELECT below adds current user to ignore list and DONE must still be logged.
@@ -37,16 +39,16 @@ SELECT set_config('yagpcc.ignored_users_list', current_user, false);
 (1 row)
 
 -- end_ignore
-SELECT * FROM print_last_query_like('SELECT set_config%');
-                              query_text                              |    query_status     
-----------------------------------------------------------------------+---------------------
- SELECT set_config('yagpcc.ignored_users_list', current_user, false); | QUERY_STATUS_SUBMIT
- SELECT set_config('yagpcc.ignored_users_list', current_user, false); | QUERY_STATUS_START
- SELECT set_config('yagpcc.ignored_users_list', current_user, false); | QUERY_STATUS_END
- SELECT set_config('yagpcc.ignored_users_list', current_user, false); | QUERY_STATUS_DONE
+SELECT * FROM print_last_query('SELECT set_config(''yagpcc.ignored_users_list'', current_user, false);');
+    query_status     
+---------------------
+ QUERY_STATUS_SUBMIT
+ QUERY_STATUS_START
+ QUERY_STATUS_END
+ QUERY_STATUS_DONE
 (4 rows)
 
-DROP FUNCTION print_last_query_like(text);
+DROP FUNCTION print_last_query(text);
 DROP EXTENSION yagp_hooks_collector;
 RESET yagpcc.enable;
 RESET yagpcc.enable_utility;

--- a/gpcontrib/yagp_hooks_collector/expected/yagp_utility.out
+++ b/gpcontrib/yagp_hooks_collector/expected/yagp_utility.out
@@ -27,7 +27,6 @@ RESET yagpcc.logging_mode;
 SELECT segid, query_text, query_status FROM yagpcc.log WHERE segid = -1 AND utility = true ORDER BY segid, ccnt, yagp_status_order(query_status) ASC;
  segid |                     query_text                     |    query_status     
 -------+----------------------------------------------------+---------------------
-    -1 | SET yagpcc.logging_mode to 'TBL';                  | QUERY_STATUS_DONE
     -1 | CREATE TABLE test_table (a int, b text);           | QUERY_STATUS_SUBMIT
     -1 | CREATE TABLE test_table (a int, b text);           | QUERY_STATUS_DONE
     -1 | CREATE INDEX test_idx ON test_table(a);            | QUERY_STATUS_SUBMIT
@@ -37,6 +36,7 @@ SELECT segid, query_text, query_status FROM yagpcc.log WHERE segid = -1 AND util
     -1 | DROP TABLE test_table;                             | QUERY_STATUS_SUBMIT
     -1 | DROP TABLE test_table;                             | QUERY_STATUS_DONE
     -1 | RESET yagpcc.logging_mode;                         | QUERY_STATUS_SUBMIT
+    -1 | RESET yagpcc.logging_mode;                         | QUERY_STATUS_DONE
 (10 rows)
 
 SELECT yagpcc.truncate_log() IS NOT NULL AS t;
@@ -58,7 +58,6 @@ RESET yagpcc.logging_mode;
 SELECT segid, query_text, query_status FROM yagpcc.log WHERE segid = -1 AND utility = true ORDER BY segid, ccnt, yagp_status_order(query_status) ASC;
  segid |             query_text              |    query_status     
 -------+-------------------------------------+---------------------
-    -1 | SET yagpcc.logging_mode to 'TBL';   | QUERY_STATUS_DONE
     -1 | CREATE TABLE pt_test (a int, b int)+| QUERY_STATUS_SUBMIT
        | DISTRIBUTED BY (a)                 +| 
        | PARTITION BY RANGE (a)             +| 
@@ -86,6 +85,7 @@ SELECT segid, query_text, query_status FROM yagpcc.log WHERE segid = -1 AND util
     -1 | DROP TABLE pt_test;                 | QUERY_STATUS_SUBMIT
     -1 | DROP TABLE pt_test;                 | QUERY_STATUS_DONE
     -1 | RESET yagpcc.logging_mode;          | QUERY_STATUS_SUBMIT
+    -1 | RESET yagpcc.logging_mode;          | QUERY_STATUS_DONE
 (10 rows)
 
 SELECT yagpcc.truncate_log() IS NOT NULL AS t;
@@ -104,7 +104,6 @@ RESET yagpcc.logging_mode;
 SELECT segid, query_text, query_status FROM yagpcc.log WHERE segid = -1 AND utility = true ORDER BY segid, ccnt, yagp_status_order(query_status) ASC;
  segid |                                     query_text                                     |    query_status     
 -------+------------------------------------------------------------------------------------+---------------------
-    -1 | SET yagpcc.logging_mode to 'TBL';                                                  | QUERY_STATUS_DONE
     -1 | CREATE VIEW test_view AS SELECT 1 AS a;                                            | QUERY_STATUS_SUBMIT
     -1 | CREATE VIEW test_view AS SELECT 1 AS a;                                            | QUERY_STATUS_DONE
     -1 | CREATE FUNCTION test_func(i int) RETURNS int AS $$ SELECT $1 + 1; $$ LANGUAGE SQL; | QUERY_STATUS_SUBMIT
@@ -114,6 +113,7 @@ SELECT segid, query_text, query_status FROM yagpcc.log WHERE segid = -1 AND util
     -1 | DROP FUNCTION test_func(int);                                                      | QUERY_STATUS_SUBMIT
     -1 | DROP FUNCTION test_func(int);                                                      | QUERY_STATUS_DONE
     -1 | RESET yagpcc.logging_mode;                                                         | QUERY_STATUS_SUBMIT
+    -1 | RESET yagpcc.logging_mode;                                                         | QUERY_STATUS_DONE
 (10 rows)
 
 SELECT yagpcc.truncate_log() IS NOT NULL AS t;
@@ -135,26 +135,26 @@ BEGIN;
 ROLLBACK;
 RESET yagpcc.logging_mode;
 SELECT segid, query_text, query_status FROM yagpcc.log WHERE segid = -1 AND utility = true ORDER BY segid, ccnt, yagp_status_order(query_status) ASC;
- segid |            query_text             |    query_status     
--------+-----------------------------------+---------------------
-    -1 | SET yagpcc.logging_mode to 'TBL'; | QUERY_STATUS_DONE
-    -1 | BEGIN;                            | QUERY_STATUS_SUBMIT
-    -1 | BEGIN;                            | QUERY_STATUS_DONE
-    -1 | SAVEPOINT sp1;                    | QUERY_STATUS_SUBMIT
-    -1 | ROLLBACK TO sp1;                  | QUERY_STATUS_SUBMIT
-    -1 | ROLLBACK TO sp1;                  | QUERY_STATUS_DONE
-    -1 | COMMIT;                           | QUERY_STATUS_SUBMIT
-    -1 | COMMIT;                           | QUERY_STATUS_DONE
-    -1 | BEGIN;                            | QUERY_STATUS_SUBMIT
-    -1 | BEGIN;                            | QUERY_STATUS_DONE
-    -1 | SAVEPOINT sp2;                    | QUERY_STATUS_SUBMIT
-    -1 | ABORT;                            | QUERY_STATUS_SUBMIT
-    -1 | ABORT;                            | QUERY_STATUS_DONE
-    -1 | BEGIN;                            | QUERY_STATUS_SUBMIT
-    -1 | BEGIN;                            | QUERY_STATUS_DONE
-    -1 | ROLLBACK;                         | QUERY_STATUS_SUBMIT
-    -1 | ROLLBACK;                         | QUERY_STATUS_DONE
-    -1 | RESET yagpcc.logging_mode;        | QUERY_STATUS_SUBMIT
+ segid |         query_text         |    query_status     
+-------+----------------------------+---------------------
+    -1 | BEGIN;                     | QUERY_STATUS_SUBMIT
+    -1 | BEGIN;                     | QUERY_STATUS_DONE
+    -1 | SAVEPOINT sp1;             | QUERY_STATUS_SUBMIT
+    -1 | ROLLBACK TO sp1;           | QUERY_STATUS_SUBMIT
+    -1 | ROLLBACK TO sp1;           | QUERY_STATUS_DONE
+    -1 | COMMIT;                    | QUERY_STATUS_SUBMIT
+    -1 | COMMIT;                    | QUERY_STATUS_DONE
+    -1 | BEGIN;                     | QUERY_STATUS_SUBMIT
+    -1 | BEGIN;                     | QUERY_STATUS_DONE
+    -1 | SAVEPOINT sp2;             | QUERY_STATUS_SUBMIT
+    -1 | ABORT;                     | QUERY_STATUS_SUBMIT
+    -1 | ABORT;                     | QUERY_STATUS_DONE
+    -1 | BEGIN;                     | QUERY_STATUS_SUBMIT
+    -1 | BEGIN;                     | QUERY_STATUS_DONE
+    -1 | ROLLBACK;                  | QUERY_STATUS_SUBMIT
+    -1 | ROLLBACK;                  | QUERY_STATUS_DONE
+    -1 | RESET yagpcc.logging_mode; | QUERY_STATUS_SUBMIT
+    -1 | RESET yagpcc.logging_mode; | QUERY_STATUS_DONE
 (18 rows)
 
 SELECT yagpcc.truncate_log() IS NOT NULL AS t;
@@ -176,12 +176,12 @@ RESET yagpcc.logging_mode;
 SELECT segid, query_text, query_status FROM yagpcc.log WHERE segid = -1 AND utility = true ORDER BY segid, ccnt, yagp_status_order(query_status) ASC;
  segid |               query_text               |    query_status     
 -------+----------------------------------------+---------------------
-    -1 | SET yagpcc.logging_mode to 'TBL';      | QUERY_STATUS_DONE
     -1 | CREATE TABLE dml_test (a int, b text); | QUERY_STATUS_SUBMIT
     -1 | CREATE TABLE dml_test (a int, b text); | QUERY_STATUS_DONE
     -1 | DROP TABLE dml_test;                   | QUERY_STATUS_SUBMIT
     -1 | DROP TABLE dml_test;                   | QUERY_STATUS_DONE
     -1 | RESET yagpcc.logging_mode;             | QUERY_STATUS_SUBMIT
+    -1 | RESET yagpcc.logging_mode;             | QUERY_STATUS_DONE
 (6 rows)
 
 SELECT yagpcc.truncate_log() IS NOT NULL AS t;
@@ -200,16 +200,16 @@ COPY (SELECT 1) TO STDOUT;
 DROP TABLE copy_test;
 RESET yagpcc.logging_mode;
 SELECT segid, query_text, query_status FROM yagpcc.log WHERE segid = -1 AND utility = true ORDER BY segid, ccnt, yagp_status_order(query_status) ASC;
- segid |            query_text             |    query_status     
--------+-----------------------------------+---------------------
-    -1 | SET yagpcc.logging_mode to 'TBL'; | QUERY_STATUS_DONE
-    -1 | CREATE TABLE copy_test (a int);   | QUERY_STATUS_SUBMIT
-    -1 | CREATE TABLE copy_test (a int);   | QUERY_STATUS_DONE
-    -1 | COPY (SELECT 1) TO STDOUT;        | QUERY_STATUS_SUBMIT
-    -1 | COPY (SELECT 1) TO STDOUT;        | QUERY_STATUS_DONE
-    -1 | DROP TABLE copy_test;             | QUERY_STATUS_SUBMIT
-    -1 | DROP TABLE copy_test;             | QUERY_STATUS_DONE
-    -1 | RESET yagpcc.logging_mode;        | QUERY_STATUS_SUBMIT
+ segid |           query_text            |    query_status     
+-------+---------------------------------+---------------------
+    -1 | CREATE TABLE copy_test (a int); | QUERY_STATUS_SUBMIT
+    -1 | CREATE TABLE copy_test (a int); | QUERY_STATUS_DONE
+    -1 | COPY (SELECT 1) TO STDOUT;      | QUERY_STATUS_SUBMIT
+    -1 | COPY (SELECT 1) TO STDOUT;      | QUERY_STATUS_DONE
+    -1 | DROP TABLE copy_test;           | QUERY_STATUS_SUBMIT
+    -1 | DROP TABLE copy_test;           | QUERY_STATUS_DONE
+    -1 | RESET yagpcc.logging_mode;      | QUERY_STATUS_SUBMIT
+    -1 | RESET yagpcc.logging_mode;      | QUERY_STATUS_DONE
 (8 rows)
 
 SELECT yagpcc.truncate_log() IS NOT NULL AS t;
@@ -228,7 +228,6 @@ RESET yagpcc.logging_mode;
 SELECT segid, query_text, query_status FROM yagpcc.log WHERE segid = -1 AND utility = true ORDER BY segid, ccnt, yagp_status_order(query_status) ASC;
  segid |                   query_text                    |    query_status     
 -------+-------------------------------------------------+---------------------
-    -1 | SET yagpcc.logging_mode to 'TBL';               | QUERY_STATUS_DONE
     -1 | PREPARE test_prep(int) AS SELECT $1/0 AS value; | QUERY_STATUS_SUBMIT
     -1 | PREPARE test_prep(int) AS SELECT $1/0 AS value; | QUERY_STATUS_DONE
     -1 | EXECUTE test_prep(0::int);                      | QUERY_STATUS_SUBMIT
@@ -236,6 +235,7 @@ SELECT segid, query_text, query_status FROM yagpcc.log WHERE segid = -1 AND util
     -1 | DEALLOCATE test_prep;                           | QUERY_STATUS_SUBMIT
     -1 | DEALLOCATE test_prep;                           | QUERY_STATUS_DONE
     -1 | RESET yagpcc.logging_mode;                      | QUERY_STATUS_SUBMIT
+    -1 | RESET yagpcc.logging_mode;                      | QUERY_STATUS_DONE
 (8 rows)
 
 SELECT yagpcc.truncate_log() IS NOT NULL AS t;
@@ -252,12 +252,12 @@ RESET yagpcc.logging_mode;
 SELECT segid, query_text, query_status FROM yagpcc.log WHERE segid = -1 AND utility = true ORDER BY segid, ccnt, yagp_status_order(query_status) ASC;
  segid |                 query_text                 |    query_status     
 -------+--------------------------------------------+---------------------
-    -1 | SET yagpcc.logging_mode to 'TBL';          | QUERY_STATUS_DONE
     -1 | SET yagpcc.report_nested_queries TO FALSE; | QUERY_STATUS_SUBMIT
     -1 | SET yagpcc.report_nested_queries TO FALSE; | QUERY_STATUS_DONE
     -1 | RESET yagpcc.report_nested_queries;        | QUERY_STATUS_SUBMIT
     -1 | RESET yagpcc.report_nested_queries;        | QUERY_STATUS_DONE
     -1 | RESET yagpcc.logging_mode;                 | QUERY_STATUS_SUBMIT
+    -1 | RESET yagpcc.logging_mode;                 | QUERY_STATUS_DONE
 (6 rows)
 
 SELECT yagpcc.truncate_log() IS NOT NULL AS t;

--- a/gpcontrib/yagp_hooks_collector/sql/yagp_guc_cache.sql
+++ b/gpcontrib/yagp_hooks_collector/sql/yagp_guc_cache.sql
@@ -9,6 +9,7 @@
 -- This is due to query being actually executed between SUBMIT and DONE.
 -- start_ignore
 CREATE EXTENSION IF NOT EXISTS yagp_hooks_collector;
+SELECT yagpcc.truncate_log();
 -- end_ignore
 
 CREATE OR REPLACE FUNCTION print_last_query(query text)

--- a/gpcontrib/yagp_hooks_collector/sql/yagp_guc_cache.sql
+++ b/gpcontrib/yagp_hooks_collector/sql/yagp_guc_cache.sql
@@ -1,0 +1,40 @@
+--
+-- Test GUC caching for query lifecycle consistency.
+--
+-- The extension logs SUBMIT and DONE events for each query.
+-- GUC values that control logging (enable_utility, ignored_users_list, ...)
+-- must be cached at SUBMIT time to ensure DONE uses the same filtering
+-- criteria. Otherwise, a SET command that modifies these GUCs would
+-- have its DONE event rejected, creating orphaned SUBMIT entries.
+-- This is due to query being actually executed between SUBMIT and DONE.
+CREATE EXTENSION yagp_hooks_collector;
+
+CREATE OR REPLACE FUNCTION print_last_query_like(query_pattern text)
+RETURNS TABLE(query_text text, query_status text) AS $$
+    SELECT l.query_text, l.query_status
+    FROM yagpcc.log l
+    WHERE l.segid = -1 AND l.query_text LIKE query_pattern
+    ORDER BY l.ccnt DESC
+$$ LANGUAGE sql;
+
+SET yagpcc.ignored_users_list TO '';
+SET yagpcc.enable TO TRUE;
+SET yagpcc.enable_utility TO TRUE;
+SET yagpcc.logging_mode TO 'TBL';
+
+-- SET below disables utility logging and DONE must still be logged.
+SET yagpcc.enable_utility TO FALSE;
+SELECT * FROM print_last_query_like('SET yagpcc.enable_utility%');
+
+-- SELECT below adds current user to ignore list and DONE must still be logged.
+-- start_ignore
+SELECT set_config('yagpcc.ignored_users_list', current_user, false);
+-- end_ignore
+SELECT * FROM print_last_query_like('SELECT set_config%');
+
+DROP FUNCTION print_last_query_like(text);
+DROP EXTENSION yagp_hooks_collector;
+RESET yagpcc.enable;
+RESET yagpcc.enable_utility;
+RESET yagpcc.ignored_users_list;
+RESET yagpcc.logging_mode;

--- a/gpcontrib/yagp_hooks_collector/sql/yagp_guc_cache.sql
+++ b/gpcontrib/yagp_hooks_collector/sql/yagp_guc_cache.sql
@@ -7,14 +7,16 @@
 -- criteria. Otherwise, a SET command that modifies these GUCs would
 -- have its DONE event rejected, creating orphaned SUBMIT entries.
 -- This is due to query being actually executed between SUBMIT and DONE.
-CREATE EXTENSION yagp_hooks_collector;
+-- start_ignore
+CREATE EXTENSION IF NOT EXISTS yagp_hooks_collector;
+-- end_ignore
 
-CREATE OR REPLACE FUNCTION print_last_query_like(query_pattern text)
-RETURNS TABLE(query_text text, query_status text) AS $$
-    SELECT l.query_text, l.query_status
-    FROM yagpcc.log l
-    WHERE l.segid = -1 AND l.query_text LIKE query_pattern
-    ORDER BY l.ccnt DESC
+CREATE OR REPLACE FUNCTION print_last_query(query text)
+RETURNS TABLE(query_status text) AS $$
+    SELECT query_status
+    FROM yagpcc.log
+    WHERE segid = -1 AND query_text = query
+    ORDER BY ccnt DESC
 $$ LANGUAGE sql;
 
 SET yagpcc.ignored_users_list TO '';
@@ -24,15 +26,15 @@ SET yagpcc.logging_mode TO 'TBL';
 
 -- SET below disables utility logging and DONE must still be logged.
 SET yagpcc.enable_utility TO FALSE;
-SELECT * FROM print_last_query_like('SET yagpcc.enable_utility%');
+SELECT * FROM print_last_query('SET yagpcc.enable_utility TO FALSE;');
 
 -- SELECT below adds current user to ignore list and DONE must still be logged.
 -- start_ignore
 SELECT set_config('yagpcc.ignored_users_list', current_user, false);
 -- end_ignore
-SELECT * FROM print_last_query_like('SELECT set_config%');
+SELECT * FROM print_last_query('SELECT set_config(''yagpcc.ignored_users_list'', current_user, false);');
 
-DROP FUNCTION print_last_query_like(text);
+DROP FUNCTION print_last_query(text);
 DROP EXTENSION yagp_hooks_collector;
 RESET yagpcc.enable;
 RESET yagpcc.enable_utility;

--- a/gpcontrib/yagp_hooks_collector/src/Config.cpp
+++ b/gpcontrib/yagp_hooks_collector/src/Config.cpp
@@ -16,9 +16,9 @@ static bool guc_enable_cdbstats = true;
 static bool guc_enable_collector = true;
 static bool guc_report_nested_queries = true;
 static char *guc_ignored_users = nullptr;
-static int guc_max_text_size = 1 << 20;  // in bytes (1MB)
-static int guc_max_plan_size = 1024;     // in KB
-static int guc_min_analyze_time = 10000; // in ms
+static int guc_max_text_size = 1 << 20;     // in bytes (1MB)
+static int guc_max_plan_size = 1024;        // in KB
+static int guc_min_analyze_time = 10000;    // in ms
 static int guc_logging_mode = LOG_MODE_UDS;
 static bool guc_enable_utility = false;
 
@@ -27,7 +27,7 @@ static const struct config_enum_entry logging_mode_options[] = {
     {"tbl", LOG_MODE_TBL, false},
     {NULL, 0, false}};
 
-static constexpr std::string_view default_uds_path = "/tmp/yagpcc_agent.sock";
+static constexpr char default_uds_path[] = "/tmp/yagpcc_agent.sock";
 static bool ignored_users_guc_dirty = false;
 
 static void assign_ignored_users_hook(const char *, void *) {
@@ -37,7 +37,7 @@ static void assign_ignored_users_hook(const char *, void *) {
 void Config::init_gucs() {
   DefineCustomStringVariable(
       "yagpcc.uds_path", "Sets filesystem path of the agent socket", 0LL,
-      &guc_uds_path, default_uds_path.data(), PGC_SUSET,
+      &guc_uds_path, default_uds_path, PGC_SUSET,
       GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC, 0LL, 0LL, 0LL);
 
   DefineCustomBoolVariable(

--- a/gpcontrib/yagp_hooks_collector/src/Config.cpp
+++ b/gpcontrib/yagp_hooks_collector/src/Config.cpp
@@ -138,7 +138,7 @@ void Config::sync() {
     update_ignored_users(guc_ignored_users);
     ignored_users_guc_dirty = false;
   }
-  uds_path_ = guc_uds_path ? guc_uds_path : default_uds_path;
+  uds_path_ = guc_uds_path;
   enable_analyze_ = guc_enable_analyze;
   enable_cdbstats_ = guc_enable_cdbstats;
   enable_collector_ = guc_enable_collector;

--- a/gpcontrib/yagp_hooks_collector/src/Config.cpp
+++ b/gpcontrib/yagp_hooks_collector/src/Config.cpp
@@ -16,9 +16,9 @@ static bool guc_enable_cdbstats = true;
 static bool guc_enable_collector = true;
 static bool guc_report_nested_queries = true;
 static char *guc_ignored_users = nullptr;
-static int guc_max_text_size = 1 << 20;     // in bytes (1MB)
-static int guc_max_plan_size = 1024;        // in KB
-static int guc_min_analyze_time = 10000;    // in ms
+static int guc_max_text_size = 1 << 20;  // in bytes (1MB)
+static int guc_max_plan_size = 1024;     // in KB
+static int guc_min_analyze_time = 10000; // in ms
 static int guc_logging_mode = LOG_MODE_UDS;
 static bool guc_enable_utility = false;
 
@@ -27,48 +27,17 @@ static const struct config_enum_entry logging_mode_options[] = {
     {"tbl", LOG_MODE_TBL, false},
     {NULL, 0, false}};
 
-static std::unique_ptr<std::unordered_set<std::string>> ignored_users_set =
-    nullptr;
+static constexpr std::string_view default_uds_path = "/tmp/yagpcc_agent.sock";
 static bool ignored_users_guc_dirty = false;
-
-static void update_ignored_users(const char *new_guc_ignored_users) {
-  auto new_ignored_users_set =
-      std::make_unique<std::unordered_set<std::string>>();
-  if (new_guc_ignored_users != nullptr && new_guc_ignored_users[0] != '\0') {
-    /* Need a modifiable copy of string */
-    char *rawstring = ya_gpdb::pstrdup(new_guc_ignored_users);
-    List *elemlist;
-    ListCell *l;
-
-    /* Parse string into list of identifiers */
-    if (!ya_gpdb::split_identifier_string(rawstring, ',', &elemlist)) {
-      /* syntax error in list */
-      ya_gpdb::pfree(rawstring);
-      ya_gpdb::list_free(elemlist);
-      ereport(
-          LOG,
-          (errcode(ERRCODE_SYNTAX_ERROR),
-           errmsg(
-               "invalid list syntax in parameter yagpcc.ignored_users_list")));
-      return;
-    }
-    foreach (l, elemlist) {
-      new_ignored_users_set->insert((char *)lfirst(l));
-    }
-    ya_gpdb::pfree(rawstring);
-    ya_gpdb::list_free(elemlist);
-  }
-  ignored_users_set = std::move(new_ignored_users_set);
-}
 
 static void assign_ignored_users_hook(const char *, void *) {
   ignored_users_guc_dirty = true;
 }
 
-void Config::init() {
+void Config::init_gucs() {
   DefineCustomStringVariable(
       "yagpcc.uds_path", "Sets filesystem path of the agent socket", 0LL,
-      &guc_uds_path, "/tmp/yagpcc_agent.sock", PGC_SUSET,
+      &guc_uds_path, default_uds_path.data(), PGC_SUSET,
       GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC, 0LL, 0LL, 0LL);
 
   DefineCustomBoolVariable(
@@ -128,22 +97,40 @@ void Config::init() {
       GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC, NULL, NULL, NULL);
 }
 
-std::string Config::uds_path() { return guc_uds_path; }
-bool Config::enable_analyze() { return guc_enable_analyze; }
-bool Config::enable_cdbstats() { return guc_enable_cdbstats; }
-bool Config::enable_collector() { return guc_enable_collector; }
-bool Config::enable_utility() { return guc_enable_utility; }
-bool Config::report_nested_queries() { return guc_report_nested_queries; }
-size_t Config::max_text_size() { return guc_max_text_size; }
-size_t Config::max_plan_size() { return guc_max_plan_size * 1024; }
-int Config::min_analyze_time() { return guc_min_analyze_time; };
-int Config::logging_mode() { return guc_logging_mode; }
+void Config::update_ignored_users(const char *new_guc_ignored_users) {
+  auto new_ignored_users_set = std::make_unique<IgnoredUsers>();
+  if (new_guc_ignored_users != nullptr && new_guc_ignored_users[0] != '\0') {
+    /* Need a modifiable copy of string */
+    char *rawstring = ya_gpdb::pstrdup(new_guc_ignored_users);
+    List *elemlist;
+    ListCell *l;
 
-bool Config::filter_user(std::string username) {
-  if (!ignored_users_set) {
+    /* Parse string into list of identifiers */
+    if (!ya_gpdb::split_identifier_string(rawstring, ',', &elemlist)) {
+      /* syntax error in list */
+      ya_gpdb::pfree(rawstring);
+      ya_gpdb::list_free(elemlist);
+      ereport(
+          LOG,
+          (errcode(ERRCODE_SYNTAX_ERROR),
+           errmsg(
+               "invalid list syntax in parameter yagpcc.ignored_users_list")));
+      return;
+    }
+    foreach (l, elemlist) {
+      new_ignored_users_set->insert((char *)lfirst(l));
+    }
+    ya_gpdb::pfree(rawstring);
+    ya_gpdb::list_free(elemlist);
+  }
+  ignored_users_ = std::move(new_ignored_users_set);
+}
+
+bool Config::filter_user(const std::string &username) const {
+  if (!ignored_users_) {
     return true;
   }
-  return ignored_users_set->find(username) != ignored_users_set->end();
+  return ignored_users_->find(username) != ignored_users_->end();
 }
 
 void Config::sync() {
@@ -151,4 +138,14 @@ void Config::sync() {
     update_ignored_users(guc_ignored_users);
     ignored_users_guc_dirty = false;
   }
+  uds_path_ = guc_uds_path ? guc_uds_path : default_uds_path;
+  enable_analyze_ = guc_enable_analyze;
+  enable_cdbstats_ = guc_enable_cdbstats;
+  enable_collector_ = guc_enable_collector;
+  enable_utility_ = guc_enable_utility;
+  report_nested_queries_ = guc_report_nested_queries;
+  max_text_size_ = static_cast<size_t>(guc_max_text_size);
+  max_plan_size_ = static_cast<size_t>(guc_max_plan_size);
+  min_analyze_time_ = guc_min_analyze_time;
+  logging_mode_ = guc_logging_mode;
 }

--- a/gpcontrib/yagp_hooks_collector/src/Config.cpp
+++ b/gpcontrib/yagp_hooks_collector/src/Config.cpp
@@ -27,7 +27,6 @@ static const struct config_enum_entry logging_mode_options[] = {
     {"tbl", LOG_MODE_TBL, false},
     {NULL, 0, false}};
 
-static constexpr char default_uds_path[] = "/tmp/yagpcc_agent.sock";
 static bool ignored_users_guc_dirty = false;
 
 static void assign_ignored_users_hook(const char *, void *) {
@@ -37,7 +36,7 @@ static void assign_ignored_users_hook(const char *, void *) {
 void Config::init_gucs() {
   DefineCustomStringVariable(
       "yagpcc.uds_path", "Sets filesystem path of the agent socket", 0LL,
-      &guc_uds_path, default_uds_path, PGC_SUSET,
+      &guc_uds_path, "/tmp/yagpcc_agent.sock", PGC_SUSET,
       GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC, 0LL, 0LL, 0LL);
 
   DefineCustomBoolVariable(

--- a/gpcontrib/yagp_hooks_collector/src/Config.h
+++ b/gpcontrib/yagp_hooks_collector/src/Config.h
@@ -1,23 +1,44 @@
 #pragma once
 
+#include <memory>
 #include <string>
+#include <unordered_set>
 
 #define LOG_MODE_UDS 0
 #define LOG_MODE_TBL 1
 
+using IgnoredUsers = std::unordered_set<std::string>;
+
 class Config {
 public:
-  static void init();
-  static std::string uds_path();
-  static bool enable_analyze();
-  static bool enable_cdbstats();
-  static bool enable_collector();
-  static bool enable_utility();
-  static bool filter_user(std::string username);
-  static bool report_nested_queries();
-  static size_t max_text_size();
-  static size_t max_plan_size();
-  static int min_analyze_time();
-  static int logging_mode();
-  static void sync();
+  static void init_gucs();
+
+  void sync();
+
+  const std::string &uds_path() const { return uds_path_; }
+  bool enable_analyze() const { return enable_analyze_; }
+  bool enable_cdbstats() const { return enable_cdbstats_; }
+  bool enable_collector() const { return enable_collector_; }
+  bool enable_utility() const { return enable_utility_; }
+  bool report_nested_queries() const { return report_nested_queries_; }
+  size_t max_text_size() const { return max_text_size_; }
+  size_t max_plan_size() const { return max_plan_size_ * 1024; }
+  int min_analyze_time() const { return min_analyze_time_; }
+  int logging_mode() const { return logging_mode_; }
+  bool filter_user(const std::string &username) const;
+
+private:
+  void update_ignored_users(const char *new_guc_ignored_users);
+
+  std::unique_ptr<IgnoredUsers> ignored_users_;
+  std::string uds_path_;
+  bool enable_analyze_;
+  bool enable_cdbstats_;
+  bool enable_collector_;
+  bool enable_utility_;
+  bool report_nested_queries_;
+  size_t max_text_size_;
+  size_t max_plan_size_;
+  int min_analyze_time_;
+  int logging_mode_;
 };

--- a/gpcontrib/yagp_hooks_collector/src/EventSender.cpp
+++ b/gpcontrib/yagp_hooks_collector/src/EventSender.cpp
@@ -47,7 +47,7 @@ bool EventSender::verify_query(QueryDesc *query_desc, QueryState state,
 
     // Register qkey for a nested query we won't report,
     // so we can detect nesting_level > 0 and skip reporting at end/done.
-    if (!need_report_nested_query(config) && nesting_level > 0) {
+    if (!need_report_nested_query() && nesting_level > 0) {
       QueryKey::register_qkey(query_desc, nesting_level);
       return false;
     }
@@ -69,10 +69,10 @@ bool EventSender::verify_query(QueryDesc *query_desc, QueryState state,
     break;
   }
 
-  if (filter_query(query_desc, config)) {
+  if (filter_query(query_desc)) {
     return false;
   }
-  if (!nesting_is_valid(query_desc, nesting_level, config)) {
+  if (!nesting_is_valid(query_desc, nesting_level)) {
     return false;
   }
 
@@ -315,7 +315,7 @@ void EventSender::collect_query_done(QueryDesc *query_desc, bool utility,
 
   report_query_done(query_desc, query, status, utility, edata);
 
-  if (need_report_nested_query(config))
+  if (need_report_nested_query())
     update_nested_counters(query_desc);
 
   queries.erase(QueryKey::from_qdesc(query_desc));
@@ -484,6 +484,20 @@ bool EventSender::qdesc_submitted(QueryDesc *query_desc) {
     return false;
   }
   return queries.find(QueryKey::from_qdesc(query_desc)) != queries.end();
+}
+
+bool EventSender::nesting_is_valid(QueryDesc *query_desc, int nesting_level) {
+  return need_report_nested_query() ||
+         is_top_level_query(query_desc, nesting_level);
+}
+
+bool EventSender::need_report_nested_query() {
+  return config.report_nested_queries() && Gp_session_role == GP_ROLE_DISPATCH;
+}
+
+bool EventSender::filter_query(QueryDesc *query_desc) {
+  return gp_command_count == 0 || query_desc->sourceText == nullptr ||
+         !config.enable_collector() || config.filter_user(get_user_name());
 }
 
 EventSender::QueryItem::QueryItem(QueryState st)

--- a/gpcontrib/yagp_hooks_collector/src/EventSender.cpp
+++ b/gpcontrib/yagp_hooks_collector/src/EventSender.cpp
@@ -1,4 +1,3 @@
-#include "Config.h"
 #include "UDSConnector.h"
 #include "memory/gpdbwrappers.h"
 #include "log/LogOps.h"
@@ -22,10 +21,8 @@ extern "C" {
 #include "ProtoUtils.h"
 
 #define need_collect_analyze()                                                 \
-  (Gp_role == GP_ROLE_DISPATCH && Config::min_analyze_time() >= 0 &&           \
-   Config::enable_analyze())
-
-static bool enable_utility = Config::enable_utility();
+  (Gp_role == GP_ROLE_DISPATCH && config.min_analyze_time() >= 0 &&            \
+   config.enable_analyze())
 
 bool EventSender::verify_query(QueryDesc *query_desc, QueryState state,
                                bool utility) {
@@ -38,19 +35,19 @@ bool EventSender::verify_query(QueryDesc *query_desc, QueryState state,
 
   switch (state) {
   case QueryState::SUBMIT:
-    // Cache enable_utility at SUBMIT to ensure consistent behavior at DONE.
-    // Without caching, a query that sets enable_utility to false from true
-    // would be accepted at SUBMIT (guc is true) but rejected at DONE (guc
-    // is false), causing a leak.
-    enable_utility = Config::enable_utility();
-    if (utility && enable_utility == false) {
+    // Cache GUCs once at SUBMIT. Synced GUCs are visible to all subsequent
+    // states. Without caching, a query that unsets/sets filtering GUCs would
+    // see different filter criteria at DONE, because at SUBMIT the query was
+    // not executed yet, causing DONE to be skipped/added.
+    config.sync();
+
+    if (utility && !config.enable_utility()) {
       return false;
     }
-    // Sync config in case current query changes it.
-    Config::sync();
+
     // Register qkey for a nested query we won't report,
     // so we can detect nesting_level > 0 and skip reporting at end/done.
-    if (!need_report_nested_query() && nesting_level > 0) {
+    if (!need_report_nested_query(config) && nesting_level > 0) {
       QueryKey::register_qkey(query_desc, nesting_level);
       return false;
     }
@@ -65,17 +62,17 @@ bool EventSender::verify_query(QueryDesc *query_desc, QueryState state,
     }
     break;
   case QueryState::DONE:
-    if (utility && enable_utility == false) {
+    if (utility && !config.enable_utility()) {
       return false;
     }
   default:
     break;
   }
 
-  if (filter_query(query_desc)) {
+  if (filter_query(query_desc, config)) {
     return false;
   }
-  if (!nesting_is_valid(query_desc, nesting_level)) {
+  if (!nesting_is_valid(query_desc, nesting_level, config)) {
     return false;
   }
 
@@ -85,9 +82,9 @@ bool EventSender::verify_query(QueryDesc *query_desc, QueryState state,
 bool EventSender::log_query_req(const yagpcc::SetQueryReq &req,
                                 const std::string &event, bool utility) {
   bool clear_big_fields = false;
-  switch (Config::logging_mode()) {
+  switch (config.logging_mode()) {
   case LOG_MODE_UDS:
-    clear_big_fields = UDSConnector::report_query(req, event);
+    clear_big_fields = UDSConnector::report_query(req, event, config);
     break;
   case LOG_MODE_TBL:
     ya_gpdb::insert_log(req, utility);
@@ -135,12 +132,12 @@ void EventSender::executor_before_start(QueryDesc *query_desc, int eflags) {
     return;
   }
 
-  if (Gp_role == GP_ROLE_DISPATCH && Config::enable_analyze() &&
+  if (Gp_role == GP_ROLE_DISPATCH && config.enable_analyze() &&
       (eflags & EXEC_FLAG_EXPLAIN_ONLY) == 0) {
     query_desc->instrument_options |= INSTRUMENT_BUFFERS;
     query_desc->instrument_options |= INSTRUMENT_ROWS;
     query_desc->instrument_options |= INSTRUMENT_TIMER;
-    if (Config::enable_cdbstats()) {
+    if (config.enable_cdbstats()) {
       query_desc->instrument_options |= INSTRUMENT_CDB;
       if (!query_desc->showstatctx) {
         instr_time starttime;
@@ -161,7 +158,7 @@ void EventSender::executor_after_start(QueryDesc *query_desc, int /* eflags*/) {
   auto query_msg = query.message.get();
   *query_msg->mutable_start_time() = current_ts();
   update_query_state(query, QueryState::START, false /* utility */);
-  set_query_plan(query_msg, query_desc);
+  set_query_plan(query_msg, query_desc, config);
   if (need_collect_analyze()) {
     // Set up to track total elapsed time during query run.
     // Make sure the space is allocated in the per-query
@@ -214,7 +211,7 @@ void EventSender::collect_query_submit(QueryDesc *query_desc, bool utility) {
   set_query_info(query_msg);
   set_qi_nesting_level(query_msg, nesting_level);
   set_qi_slice_id(query_msg);
-  set_query_text(query_msg, query_desc);
+  set_query_text(query_msg, query_desc, config);
   if (log_query_req(*query_msg, "submit", utility)) {
     clear_big_fields(query_msg);
   }
@@ -271,8 +268,8 @@ void EventSender::report_query_done(QueryDesc *query_desc, QueryItem &query,
       ereport(DEBUG3,
               (errmsg("YAGPCC query sourceText: %s", query_desc->sourceText)));
     } else {
-      set_qi_error_message(query_msg,
-                           error_flushed ? edata->message : elog_message());
+      set_qi_error_message(
+          query_msg, error_flushed ? edata->message : elog_message(), config);
     }
   }
   if (prev_state == START) {
@@ -318,7 +315,7 @@ void EventSender::collect_query_done(QueryDesc *query_desc, bool utility,
 
   report_query_done(query_desc, query, status, utility, edata);
 
-  if (need_report_nested_query())
+  if (need_report_nested_query(config))
     update_nested_counters(query_desc);
 
   queries.erase(QueryKey::from_qdesc(query_desc));
@@ -331,8 +328,8 @@ void EventSender::ic_metrics_collect() {
   if (Gp_interconnect_type != INTERCONNECT_TYPE_UDPIFC) {
     return;
   }
-  if (!proto_verified || gp_command_count == 0 || !Config::enable_collector() ||
-      Config::filter_user(get_user_name())) {
+  if (!proto_verified || gp_command_count == 0 || !config.enable_collector() ||
+      config.filter_user(get_user_name())) {
     return;
   }
   // we also would like to know nesting level here and filter queries BUT we
@@ -374,15 +371,18 @@ void EventSender::analyze_stats_collect(QueryDesc *query_desc) {
   ya_gpdb::instr_end_loop(query_desc->totaltime);
 
   double ms = query_desc->totaltime->total * 1000.0;
-  if (ms >= Config::min_analyze_time()) {
+  if (ms >= config.min_analyze_time()) {
     auto &query = get_query(query_desc);
     auto *query_msg = query.message.get();
-    set_analyze_plan_text(query_desc, query_msg);
+    set_analyze_plan_text(query_desc, query_msg, config);
   }
 }
 
 EventSender::EventSender() {
-  if (Config::enable_collector()) {
+  // Perform initial sync to get default GUC values
+  config.sync();
+
+  if (config.enable_collector()) {
     try {
       GOOGLE_PROTOBUF_VERIFY_VERSION;
       proto_verified = true;

--- a/gpcontrib/yagp_hooks_collector/src/EventSender.h
+++ b/gpcontrib/yagp_hooks_collector/src/EventSender.h
@@ -122,6 +122,9 @@ private:
                           QueryMetricsStatus status, ErrorData *edata = NULL);
   void update_nested_counters(QueryDesc *query_desc);
   bool qdesc_submitted(QueryDesc *query_desc);
+  bool nesting_is_valid(QueryDesc *query_desc, int nesting_level);
+  bool need_report_nested_query();
+  bool filter_query(QueryDesc *query_desc);
 
   bool proto_verified = false;
   int nesting_level = 0;

--- a/gpcontrib/yagp_hooks_collector/src/EventSender.h
+++ b/gpcontrib/yagp_hooks_collector/src/EventSender.h
@@ -14,6 +14,7 @@ extern "C" {
 #undef typeid
 
 #include "memory/gpdbwrappers.h"
+#include "Config.h"
 
 class UDSConnector;
 struct QueryDesc;
@@ -106,8 +107,8 @@ private:
     explicit QueryItem(QueryState st);
   };
 
-  static bool log_query_req(const yagpcc::SetQueryReq &req,
-                            const std::string &event, bool utility);
+  bool log_query_req(const yagpcc::SetQueryReq &req, const std::string &event,
+                     bool utility);
   bool verify_query(QueryDesc *query_desc, QueryState state, bool utility);
   void update_query_state(QueryItem &query, QueryState new_state, bool utility,
                           bool success = true);
@@ -130,4 +131,6 @@ private:
   ICStatistics ic_statistics;
 #endif
   std::unordered_map<QueryKey, QueryItem> queries;
+
+  Config config;
 };

--- a/gpcontrib/yagp_hooks_collector/src/PgUtils.cpp
+++ b/gpcontrib/yagp_hooks_collector/src/PgUtils.cpp
@@ -66,16 +66,17 @@ bool is_top_level_query(QueryDesc *query_desc, int nesting_level) {
   return query_desc->yagp_query_key->nesting_level == 0;
 }
 
-bool nesting_is_valid(QueryDesc *query_desc, int nesting_level) {
-  return need_report_nested_query() ||
+bool nesting_is_valid(QueryDesc *query_desc, int nesting_level,
+                      const Config &config) {
+  return need_report_nested_query(config) ||
          is_top_level_query(query_desc, nesting_level);
 }
 
-bool need_report_nested_query() {
-  return Config::report_nested_queries() && Gp_session_role == GP_ROLE_DISPATCH;
+bool need_report_nested_query(const Config &config) {
+  return config.report_nested_queries() && Gp_session_role == GP_ROLE_DISPATCH;
 }
 
-bool filter_query(QueryDesc *query_desc) {
+bool filter_query(QueryDesc *query_desc, const Config &config) {
   return gp_command_count == 0 || query_desc->sourceText == nullptr ||
-         !Config::enable_collector() || Config::filter_user(get_user_name());
+         !config.enable_collector() || config.filter_user(get_user_name());
 }

--- a/gpcontrib/yagp_hooks_collector/src/PgUtils.cpp
+++ b/gpcontrib/yagp_hooks_collector/src/PgUtils.cpp
@@ -65,18 +65,3 @@ bool is_top_level_query(QueryDesc *query_desc, int nesting_level) {
   }
   return query_desc->yagp_query_key->nesting_level == 0;
 }
-
-bool nesting_is_valid(QueryDesc *query_desc, int nesting_level,
-                      const Config &config) {
-  return need_report_nested_query(config) ||
-         is_top_level_query(query_desc, nesting_level);
-}
-
-bool need_report_nested_query(const Config &config) {
-  return config.report_nested_queries() && Gp_session_role == GP_ROLE_DISPATCH;
-}
-
-bool filter_query(QueryDesc *query_desc, const Config &config) {
-  return gp_command_count == 0 || query_desc->sourceText == nullptr ||
-         !config.enable_collector() || config.filter_user(get_user_name());
-}

--- a/gpcontrib/yagp_hooks_collector/src/PgUtils.h
+++ b/gpcontrib/yagp_hooks_collector/src/PgUtils.h
@@ -1,3 +1,5 @@
+#pragma once
+
 extern "C" {
 #include "postgres.h"
 #include "commands/explain.h"
@@ -5,10 +7,13 @@ extern "C" {
 
 #include <string>
 
+class Config;
+
 std::string get_user_name();
 std::string get_db_name();
 std::string get_rg_name();
 bool is_top_level_query(QueryDesc *query_desc, int nesting_level);
-bool nesting_is_valid(QueryDesc *query_desc, int nesting_level);
-bool need_report_nested_query();
-bool filter_query(QueryDesc *query_desc);
+bool nesting_is_valid(QueryDesc *query_desc, int nesting_level,
+                      const Config &config);
+bool need_report_nested_query(const Config &config);
+bool filter_query(QueryDesc *query_desc, const Config &config);

--- a/gpcontrib/yagp_hooks_collector/src/PgUtils.h
+++ b/gpcontrib/yagp_hooks_collector/src/PgUtils.h
@@ -1,5 +1,3 @@
-#pragma once
-
 extern "C" {
 #include "postgres.h"
 #include "commands/explain.h"
@@ -7,13 +5,7 @@ extern "C" {
 
 #include <string>
 
-class Config;
-
 std::string get_user_name();
 std::string get_db_name();
 std::string get_rg_name();
 bool is_top_level_query(QueryDesc *query_desc, int nesting_level);
-bool nesting_is_valid(QueryDesc *query_desc, int nesting_level,
-                      const Config &config);
-bool need_report_nested_query(const Config &config);
-bool filter_query(QueryDesc *query_desc, const Config &config);

--- a/gpcontrib/yagp_hooks_collector/src/ProtoUtils.cpp
+++ b/gpcontrib/yagp_hooks_collector/src/ProtoUtils.cpp
@@ -80,7 +80,8 @@ std::string trim_str_shrink_utf8(const char *str, size_t len, size_t lim) {
   return std::string(str, cut_pos);
 }
 
-void set_query_plan(yagpcc::SetQueryReq *req, QueryDesc *query_desc) {
+void set_query_plan(yagpcc::SetQueryReq *req, QueryDesc *query_desc,
+                    const Config &config) {
   if (Gp_session_role == GP_ROLE_DISPATCH && query_desc->plannedstmt) {
     auto qi = req->mutable_query_info();
     qi->set_generator(query_desc->plannedstmt->planGen == PLANGEN_OPTIMIZER
@@ -91,10 +92,10 @@ void set_query_plan(yagpcc::SetQueryReq *req, QueryDesc *query_desc) {
     ExplainState es = ya_gpdb::get_explain_state(query_desc, true);
     if (es.str) {
       *qi->mutable_plan_text() = trim_str_shrink_utf8(es.str->data, es.str->len,
-                                                      Config::max_plan_size());
+                                                      config.max_plan_size());
       StringInfo norm_plan = ya_gpdb::gen_normplan(es.str->data);
       *qi->mutable_template_plan_text() = trim_str_shrink_utf8(
-          norm_plan->data, norm_plan->len, Config::max_plan_size());
+          norm_plan->data, norm_plan->len, config.max_plan_size());
       qi->set_plan_id(
           hash_any((unsigned char *)norm_plan->data, norm_plan->len));
       qi->set_query_id(query_desc->plannedstmt->queryId);
@@ -105,15 +106,16 @@ void set_query_plan(yagpcc::SetQueryReq *req, QueryDesc *query_desc) {
   }
 }
 
-void set_query_text(yagpcc::SetQueryReq *req, QueryDesc *query_desc) {
+void set_query_text(yagpcc::SetQueryReq *req, QueryDesc *query_desc,
+                    const Config &config) {
   if (Gp_session_role == GP_ROLE_DISPATCH && query_desc->sourceText) {
     auto qi = req->mutable_query_info();
     *qi->mutable_query_text() = trim_str_shrink_utf8(
         query_desc->sourceText, strlen(query_desc->sourceText),
-        Config::max_text_size());
+        config.max_text_size());
     char *norm_query = ya_gpdb::gen_normquery(query_desc->sourceText);
     *qi->mutable_template_query_text() = trim_str_shrink_utf8(
-        norm_query, strlen(norm_query), Config::max_text_size());
+        norm_query, strlen(norm_query), config.max_text_size());
   }
 }
 
@@ -148,10 +150,11 @@ void set_qi_slice_id(yagpcc::SetQueryReq *req) {
   aqi->set_slice_id(currentSliceId);
 }
 
-void set_qi_error_message(yagpcc::SetQueryReq *req, const char *err_msg) {
+void set_qi_error_message(yagpcc::SetQueryReq *req, const char *err_msg,
+                          const Config &config) {
   auto aqi = req->mutable_add_info();
   *aqi->mutable_error_message() =
-      trim_str_shrink_utf8(err_msg, strlen(err_msg), Config::max_text_size());
+      trim_str_shrink_utf8(err_msg, strlen(err_msg), config.max_text_size());
 }
 
 void set_metric_instrumentation(yagpcc::MetricInstrumentation *metrics,
@@ -255,7 +258,8 @@ double protots_to_double(const google::protobuf::Timestamp &ts) {
   return double(ts.seconds()) + double(ts.nanos()) / 1000000000.0;
 }
 
-void set_analyze_plan_text(QueryDesc *query_desc, yagpcc::SetQueryReq *req) {
+void set_analyze_plan_text(QueryDesc *query_desc, yagpcc::SetQueryReq *req,
+                           const Config &config) {
   // Make sure it is a valid txn and it is not an utility
   // statement for ExplainPrintPlan() later.
   if (!IsTransactionState() || !query_desc->plannedstmt) {
@@ -264,15 +268,15 @@ void set_analyze_plan_text(QueryDesc *query_desc, yagpcc::SetQueryReq *req) {
   MemoryContext oldcxt =
       ya_gpdb::mem_ctx_switch_to(query_desc->estate->es_query_cxt);
   ExplainState es = ya_gpdb::get_analyze_state(
-      query_desc, query_desc->instrument_options && Config::enable_analyze());
+      query_desc, query_desc->instrument_options && config.enable_analyze());
   ya_gpdb::mem_ctx_switch_to(oldcxt);
   if (es.str) {
     // Remove last line break.
     if (es.str->len > 0 && es.str->data[es.str->len - 1] == '\n') {
       es.str->data[--es.str->len] = '\0';
     }
-    auto trimmed_analyze = trim_str_shrink_utf8(es.str->data, es.str->len,
-                                                Config::max_plan_size());
+    auto trimmed_analyze =
+        trim_str_shrink_utf8(es.str->data, es.str->len, config.max_plan_size());
     req->mutable_query_info()->set_analyze_text(trimmed_analyze);
     ya_gpdb::pfree(es.str->data);
   }

--- a/gpcontrib/yagp_hooks_collector/src/ProtoUtils.h
+++ b/gpcontrib/yagp_hooks_collector/src/ProtoUtils.h
@@ -4,19 +4,24 @@
 
 struct QueryDesc;
 struct ICStatistics;
+class Config;
 
 google::protobuf::Timestamp current_ts();
-void set_query_plan(yagpcc::SetQueryReq *req, QueryDesc *query_desc);
-void set_query_text(yagpcc::SetQueryReq *req, QueryDesc *query_desc);
+void set_query_plan(yagpcc::SetQueryReq *req, QueryDesc *query_desc,
+                    const Config &config);
+void set_query_text(yagpcc::SetQueryReq *req, QueryDesc *query_desc,
+                    const Config &config);
 void clear_big_fields(yagpcc::SetQueryReq *req);
 void set_query_info(yagpcc::SetQueryReq *req);
 void set_qi_nesting_level(yagpcc::SetQueryReq *req, int nesting_level);
 void set_qi_slice_id(yagpcc::SetQueryReq *req);
-void set_qi_error_message(yagpcc::SetQueryReq *req, const char *err_msg);
+void set_qi_error_message(yagpcc::SetQueryReq *req, const char *err_msg,
+                          const Config &config);
 void set_gp_metrics(yagpcc::GPMetrics *metrics, QueryDesc *query_desc,
                     int nested_calls, double nested_time);
 void set_ic_stats(yagpcc::MetricInstrumentation *metrics,
                   const ICStatistics *ic_statistics);
 yagpcc::SetQueryReq create_query_req(yagpcc::QueryStatus status);
 double protots_to_double(const google::protobuf::Timestamp &ts);
-void set_analyze_plan_text(QueryDesc *query_desc, yagpcc::SetQueryReq *message);
+void set_analyze_plan_text(QueryDesc *query_desc, yagpcc::SetQueryReq *message,
+                           const Config &config);

--- a/gpcontrib/yagp_hooks_collector/src/UDSConnector.cpp
+++ b/gpcontrib/yagp_hooks_collector/src/UDSConnector.cpp
@@ -26,10 +26,11 @@ static void inline log_tracing_failure(const yagpcc::SetQueryReq &req,
 }
 
 bool UDSConnector::report_query(const yagpcc::SetQueryReq &req,
-                                const std::string &event) {
+                                const std::string &event,
+                                const Config &config) {
   sockaddr_un address;
   address.sun_family = AF_UNIX;
-  std::string uds_path = Config::uds_path();
+  const std::string &uds_path = config.uds_path();
   if (uds_path.size() >= sizeof(address.sun_path)) {
     ereport(WARNING, (errmsg("UDS path is too long for socket buffer")));
     YagpStat::report_error();

--- a/gpcontrib/yagp_hooks_collector/src/UDSConnector.h
+++ b/gpcontrib/yagp_hooks_collector/src/UDSConnector.h
@@ -6,6 +6,6 @@ class Config;
 
 class UDSConnector {
 public:
-  static bool report_query(const yagpcc::SetQueryReq &req,
+  bool static report_query(const yagpcc::SetQueryReq &req,
                            const std::string &event, const Config &config);
 };

--- a/gpcontrib/yagp_hooks_collector/src/UDSConnector.h
+++ b/gpcontrib/yagp_hooks_collector/src/UDSConnector.h
@@ -2,8 +2,10 @@
 
 #include "protos/yagpcc_set_service.pb.h"
 
+class Config;
+
 class UDSConnector {
 public:
-  bool static report_query(const yagpcc::SetQueryReq &req,
-                           const std::string &event);
+  static bool report_query(const yagpcc::SetQueryReq &req,
+                           const std::string &event, const Config &config);
 };

--- a/gpcontrib/yagp_hooks_collector/src/hook_wrappers.cpp
+++ b/gpcontrib/yagp_hooks_collector/src/hook_wrappers.cpp
@@ -69,7 +69,7 @@ R cpp_call(T *obj, R (T::*func)(Args...), Args... args) {
 }
 
 void hooks_init() {
-  Config::init();
+  Config::init_gucs();
   YagpStat::init();
   previous_ExecutorStart_hook = ExecutorStart_hook;
   ExecutorStart_hook = ya_ExecutorStart_hook;
@@ -222,8 +222,9 @@ static void ya_process_utility_hook(Node *parsetree, const char *queryString,
     }
 
     get_sender()->decr_depth();
-    cpp_call(get_sender(), &EventSender::query_metrics_collect, METRICS_QUERY_DONE,
-         (void *)query_desc, true /* utility */, (ErrorData *)NULL);
+    cpp_call(get_sender(), &EventSender::query_metrics_collect,
+             METRICS_QUERY_DONE, (void *)query_desc, true /* utility */,
+             (ErrorData *)NULL);
 
     pfree(query_desc);
   }
@@ -238,8 +239,9 @@ static void ya_process_utility_hook(Node *parsetree, const char *queryString,
     MemoryContextSwitchTo(oldctx);
 
     get_sender()->decr_depth();
-    cpp_call(get_sender(), &EventSender::query_metrics_collect, METRICS_QUERY_ERROR,
-         (void *)query_desc, true /* utility */, edata);
+    cpp_call(get_sender(), &EventSender::query_metrics_collect,
+             METRICS_QUERY_ERROR, (void *)query_desc, true /* utility */,
+             edata);
 
     pfree(query_desc);
     ReThrowError(edata);

--- a/gpcontrib/yagp_hooks_collector/src/hook_wrappers.cpp
+++ b/gpcontrib/yagp_hooks_collector/src/hook_wrappers.cpp
@@ -222,9 +222,8 @@ static void ya_process_utility_hook(Node *parsetree, const char *queryString,
     }
 
     get_sender()->decr_depth();
-    cpp_call(get_sender(), &EventSender::query_metrics_collect,
-             METRICS_QUERY_DONE, (void *)query_desc, true /* utility */,
-             (ErrorData *)NULL);
+    cpp_call(get_sender(), &EventSender::query_metrics_collect, METRICS_QUERY_DONE,
+         (void *)query_desc, true /* utility */, (ErrorData *)NULL);
 
     pfree(query_desc);
   }
@@ -239,9 +238,8 @@ static void ya_process_utility_hook(Node *parsetree, const char *queryString,
     MemoryContextSwitchTo(oldctx);
 
     get_sender()->decr_depth();
-    cpp_call(get_sender(), &EventSender::query_metrics_collect,
-             METRICS_QUERY_ERROR, (void *)query_desc, true /* utility */,
-             edata);
+    cpp_call(get_sender(), &EventSender::query_metrics_collect, METRICS_QUERY_ERROR,
+         (void *)query_desc, true /* utility */, edata);
 
     pfree(query_desc);
     ReThrowError(edata);


### PR DESCRIPTION
The extension logs `SUBMIT` and `DONE` events for each query. Previously, filtering [1] GUCs (`enable_utility`, `ignored_users_list`, etc.) were read directly at each hook (`SUBMIT`/`DONE`) call. This caused incorrect behavior when a query modified these GUCs: the query would pass filtering at `SUBMIT` but fail at `DONE` (or vice versa), leaving query state not freed.

Fix by caching GUC values once at `SUBMIT`. The cached values are used for all subsequent states (`START`, `END`, `DONE`) of that query. This ensures consistent filtering across the query lifecycle.

Implementation changes:

Convert Config from static methods to instance members
Add Config instance to EventSender, synced at SUBMIT
Pass Config reference to functions that need GUC values
Test was added in `yagp_guc_cache.sql`.

1. filtering GUC - a GUC that participates in decision on whether to process query or not, this is done in `EventSender::verify_query()`