### PR TITLE
Use DatumGetCString for datum access.

### DIFF
--- a/src/backend/utils/hyperloglog/gp_hyperloglog.c
+++ b/src/backend/utils/hyperloglog/gp_hyperloglog.c
@@ -774,7 +774,7 @@ gp_hyperloglog_add_item(GpHLLCounter hllcounter, Datum element, int16 typlen, bo
 	else if (typlen == -2)
 	{
 		/* cstring */
-		hyperloglog = gp_hll_add_element(hyperloglog, DatumGetCString(element), strlen(element));
+		hyperloglog = gp_hll_add_element(hyperloglog, DatumGetCString(element), strlen(DatumGetCString(element)));
 	}
 	else if (typbyval)
 	{


### PR DESCRIPTION
Fixes compile warning in gp_hyperloglog util code.

Given these definitions, we can conclude there is no real issue.

```
\#define PointerGetDatum(X) ((Datum) (X))
static inline char *DatumGetCString(Datum d) { return (char* ) DatumGetPointer(d); }
```


warn

```
gp_hyperloglog.c: In function ‘gp_hyperloglog_add_item’:
gp_hyperloglog.c:777:96: warning: passing argument 1 of ‘strlen’ makes pointer from integer without a cast [-Wint-conversion]
  777 |                 hyperloglog = gp_hll_add_element(hyperloglog, DatumGetCString(element), strlen(element));
      |                                                                                                ^~~~~~~
      |                                                                                                |
      |                                                                                                Datum {aka long int}
In file included from gp_hyperloglog.c:59:
```


