### PR TITLE
Refactor yagp_hooks_collector

### DIFF
--- a/gpcontrib/yagp_hooks_collector/src/Config.cpp
+++ b/gpcontrib/yagp_hooks_collector/src/Config.cpp
@@ -16,9 +16,9 @@ static bool guc_enable_cdbstats = true;
 static bool guc_enable_collector = true;
 static bool guc_report_nested_queries = true;
 static char *guc_ignored_users = nullptr;
-static int guc_max_text_size = 1 << 20;     // in bytes (1MB)
-static int guc_max_plan_size = 1024;        // in KB
-static int guc_min_analyze_time = 10000;    // in ms
+static int guc_max_text_size = 1 << 20;  // in bytes (1MB)
+static int guc_max_plan_size = 1024;     // in KB
+static int guc_min_analyze_time = 10000; // in ms
 static int guc_logging_mode = LOG_MODE_UDS;
 static bool guc_enable_utility = false;
 
@@ -143,8 +143,8 @@ void Config::sync() {
   enable_collector_ = guc_enable_collector;
   enable_utility_ = guc_enable_utility;
   report_nested_queries_ = guc_report_nested_queries;
-  max_text_size_ = static_cast<size_t>(guc_max_text_size);
-  max_plan_size_ = static_cast<size_t>(guc_max_plan_size);
+  max_text_size_ = guc_max_text_size;
+  max_plan_size_ = guc_max_plan_size;
   min_analyze_time_ = guc_min_analyze_time;
   logging_mode_ = guc_logging_mode;
 }

--- a/gpcontrib/yagp_hooks_collector/src/Config.h
+++ b/gpcontrib/yagp_hooks_collector/src/Config.h
@@ -21,8 +21,8 @@ public:
   bool enable_collector() const { return enable_collector_; }
   bool enable_utility() const { return enable_utility_; }
   bool report_nested_queries() const { return report_nested_queries_; }
-  size_t max_text_size() const { return max_text_size_; }
-  size_t max_plan_size() const { return max_plan_size_ * 1024; }
+  int max_text_size() const { return max_text_size_; }
+  int max_plan_size() const { return max_plan_size_ * 1024; }
   int min_analyze_time() const { return min_analyze_time_; }
   int logging_mode() const { return logging_mode_; }
   bool filter_user(const std::string &username) const;
@@ -37,8 +37,8 @@ private:
   bool enable_collector_;
   bool enable_utility_;
   bool report_nested_queries_;
-  size_t max_text_size_;
-  size_t max_plan_size_;
+  int max_text_size_;
+  int max_plan_size_;
   int min_analyze_time_;
   int logging_mode_;
 };

--- a/gpcontrib/yagp_hooks_collector/src/UDSConnector.cpp
+++ b/gpcontrib/yagp_hooks_collector/src/UDSConnector.cpp
@@ -28,68 +28,77 @@ static void inline log_tracing_failure(const yagpcc::SetQueryReq &req,
 bool UDSConnector::report_query(const yagpcc::SetQueryReq &req,
                                 const std::string &event,
                                 const Config &config) {
-  sockaddr_un address;
+  sockaddr_un address{};
   address.sun_family = AF_UNIX;
-  const std::string &uds_path = config.uds_path();
+  const auto &uds_path = config.uds_path();
+
   if (uds_path.size() >= sizeof(address.sun_path)) {
     ereport(WARNING, (errmsg("UDS path is too long for socket buffer")));
     YagpStat::report_error();
     return false;
   }
-  strcpy(address.sun_path, uds_path.c_str());
-  bool success = true;
-  auto sockfd = socket(AF_UNIX, SOCK_STREAM, 0);
-  if (sockfd != -1) {
-    if (fcntl(sockfd, F_SETFL, O_NONBLOCK) != -1) {
-      if (connect(sockfd, (sockaddr *)&address, sizeof(address)) != -1) {
-        auto data_size = req.ByteSize();
-        auto total_size = data_size + sizeof(uint32_t);
-        uint8_t *buf = (uint8_t *)ya_gpdb::palloc(total_size);
-        uint32_t *size_payload = (uint32_t *)buf;
-        *size_payload = data_size;
-        req.SerializeWithCachedSizesToArray(buf + sizeof(uint32_t));
-        int64_t sent = 0, sent_total = 0;
-        do {
-          sent = send(sockfd, buf + sent_total, total_size - sent_total,
-                      MSG_DONTWAIT);
-          if (sent > 0)
-            sent_total += sent;
-        } while (
-            sent > 0 && size_t(sent_total) != total_size &&
-            // the line below is a small throttling hack:
-            // if a message does not fit a single packet, we take a nap
-            // before sending the next one.
-            // Otherwise, MSG_DONTWAIT send might overflow the UDS
-            (std::this_thread::sleep_for(std::chrono::milliseconds(1)), true));
-        if (sent < 0) {
-          log_tracing_failure(req, event);
-          success = false;
-          YagpStat::report_bad_send(total_size);
-        } else {
-          YagpStat::report_send(total_size);
-        }
-        ya_gpdb::pfree(buf);
-      } else {
-        // log the error and go on
-        log_tracing_failure(req, event);
-        success = false;
-        YagpStat::report_bad_connection();
-      }
-    } else {
-      // That's a very important error that should never happen, so make it
-      // visible to an end-user and admins.
-      ereport(WARNING,
-              (errmsg("Unable to create non-blocking socket connection %s",
-                      strerror(errno))));
-      success = false;
-      YagpStat::report_error();
-    }
-    close(sockfd);
-  } else {
-    // log the error and go on
+  std::strcpy(address.sun_path, uds_path.c_str());
+
+  const auto sockfd = socket(AF_UNIX, SOCK_STREAM, 0);
+  if (sockfd == -1) {
     log_tracing_failure(req, event);
-    success = false;
     YagpStat::report_error();
+    return false;
   }
-  return success;
+
+  // Close socket automatically on error path.
+  struct SockGuard {
+    int fd;
+    ~SockGuard() { close(fd); }
+  } sock_guard{sockfd};
+
+  if (fcntl(sockfd, F_SETFL, O_NONBLOCK) == -1) {
+    // That's a very important error that should never happen, so make it
+    // visible to an end-user and admins.
+    ereport(WARNING,
+            (errmsg("Unable to create non-blocking socket connection %m")));
+    YagpStat::report_error();
+    return false;
+  }
+
+  if (connect(sockfd, reinterpret_cast<sockaddr *>(&address),
+              sizeof(address)) == -1) {
+    log_tracing_failure(req, event);
+    YagpStat::report_bad_connection();
+    return false;
+  }
+
+  const auto data_size = req.ByteSize();
+  const auto total_size = data_size + sizeof(uint32_t);
+  auto *buf = static_cast<uint8_t *>(ya_gpdb::palloc(total_size));
+  // Free buf automatically on error path.
+  struct BufGuard {
+    void *p;
+    ~BufGuard() { ya_gpdb::pfree(p); }
+  } buf_guard{buf};
+
+  *reinterpret_cast<uint32_t *>(buf) = data_size;
+  req.SerializeWithCachedSizesToArray(buf + sizeof(uint32_t));
+
+  int64_t sent = 0, sent_total = 0;
+  do {
+    sent =
+        send(sockfd, buf + sent_total, total_size - sent_total, MSG_DONTWAIT);
+    if (sent > 0)
+      sent_total += sent;
+  } while (sent > 0 && size_t(sent_total) != total_size &&
+           // the line below is a small throttling hack:
+           // if a message does not fit a single packet, we take a nap
+           // before sending the next one.
+           // Otherwise, MSG_DONTWAIT send might overflow the UDS
+           (std::this_thread::sleep_for(std::chrono::milliseconds(1)), true));
+
+  if (sent < 0) {
+    log_tracing_failure(req, event);
+    YagpStat::report_bad_send(total_size);
+    return false;
+  }
+
+  YagpStat::report_send(total_size);
+  return true;
 }

--- a/gpcontrib/yagp_hooks_collector/src/UDSConnector.cpp
+++ b/gpcontrib/yagp_hooks_collector/src/UDSConnector.cpp
@@ -37,7 +37,7 @@ bool UDSConnector::report_query(const yagpcc::SetQueryReq &req,
     YagpStat::report_error();
     return false;
   }
-  std::strcpy(address.sun_path, uds_path.c_str());
+  strcpy(address.sun_path, uds_path.c_str());
 
   const auto sockfd = socket(AF_UNIX, SOCK_STREAM, 0);
   if (sockfd == -1) {

--- a/gpcontrib/yagp_hooks_collector/src/hook_wrappers.cpp
+++ b/gpcontrib/yagp_hooks_collector/src/hook_wrappers.cpp
@@ -222,8 +222,9 @@ static void ya_process_utility_hook(Node *parsetree, const char *queryString,
     }
 
     get_sender()->decr_depth();
-    cpp_call(get_sender(), &EventSender::query_metrics_collect, METRICS_QUERY_DONE,
-         (void *)query_desc, true /* utility */, (ErrorData *)NULL);
+    cpp_call(get_sender(), &EventSender::query_metrics_collect,
+             METRICS_QUERY_DONE, (void *)query_desc, true /* utility */,
+             (ErrorData *)NULL);
 
     pfree(query_desc);
   }
@@ -238,8 +239,9 @@ static void ya_process_utility_hook(Node *parsetree, const char *queryString,
     MemoryContextSwitchTo(oldctx);
 
     get_sender()->decr_depth();
-    cpp_call(get_sender(), &EventSender::query_metrics_collect, METRICS_QUERY_ERROR,
-         (void *)query_desc, true /* utility */, edata);
+    cpp_call(get_sender(), &EventSender::query_metrics_collect,
+             METRICS_QUERY_ERROR, (void *)query_desc, true /* utility */,
+             edata);
 
     pfree(query_desc);
     ReThrowError(edata);

--- a/gpcontrib/yagp_hooks_collector/src/yagp_hooks_collector.c
+++ b/gpcontrib/yagp_hooks_collector/src/yagp_hooks_collector.c
@@ -31,56 +31,41 @@ PG_FUNCTION_INFO_V1(yagp_test_uds_stop_server);
 static int server_fd = -1;
 static char *sock_path = NULL;
 
-void
-_PG_init(void)
-{
+void _PG_init(void) {
   if (Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_EXECUTE)
     hooks_init();
 }
 
-void
-_PG_fini(void)
-{
+void _PG_fini(void) {
   if (Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_EXECUTE)
     hooks_deinit();
 }
 
-Datum
-yagp_stat_messages_reset(PG_FUNCTION_ARGS)
-{
+Datum yagp_stat_messages_reset(PG_FUNCTION_ARGS) {
   yagp_functions_reset();
   PG_RETURN_VOID();
 }
 
-Datum
-yagp_stat_messages(PG_FUNCTION_ARGS)
-{
+Datum yagp_stat_messages(PG_FUNCTION_ARGS) {
   return yagp_functions_get(fcinfo);
 }
 
-Datum
-yagp_init_log(PG_FUNCTION_ARGS)
-{
+Datum yagp_init_log(PG_FUNCTION_ARGS) {
   init_log();
   PG_RETURN_VOID();
 }
 
-Datum
-yagp_truncate_log(PG_FUNCTION_ARGS)
-{
+Datum yagp_truncate_log(PG_FUNCTION_ARGS) {
   truncate_log();
   PG_RETURN_VOID();
 }
 
-Datum
-yagp_test_uds_start_server(PG_FUNCTION_ARGS)
-{
+Datum yagp_test_uds_start_server(PG_FUNCTION_ARGS) {
   char *path = text_to_cstring(PG_GETARG_TEXT_PP(0));
   struct sockaddr_un addr = {.sun_family = AF_UNIX};
 
   if (strlen(path) >= sizeof(addr.sun_path))
-    ereport(ERROR,
-            (errmsg("path too long")));
+    ereport(ERROR, (errmsg("path too long")));
 
   yagp_test_uds_stop_server(NULL);
 
@@ -91,29 +76,23 @@ yagp_test_uds_start_server(PG_FUNCTION_ARGS)
 
   if ((server_fd = socket(AF_UNIX, SOCK_STREAM, 0)) < 0 ||
       bind(server_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0 ||
-      listen(server_fd, TEST_MAX_CONNECTIONS) < 0)
-  {
+      listen(server_fd, TEST_MAX_CONNECTIONS) < 0) {
     yagp_test_uds_stop_server(NULL);
-    ereport(ERROR,
-            (errmsg("socket setup failed: %m")));
+    ereport(ERROR, (errmsg("socket setup failed: %m")));
   }
 
   PG_RETURN_VOID();
 }
 
-Datum
-yagp_test_uds_receive(PG_FUNCTION_ARGS)
-{
+Datum yagp_test_uds_receive(PG_FUNCTION_ARGS) {
   int timeout_ms = PG_GETARG_INT32(0);
   int64 total = 0;
   struct pollfd pfd = {.fd = server_fd, .events = POLLIN};
 
   if (server_fd < 0)
-    ereport(ERROR,
-            (errmsg("server not started")));
+    ereport(ERROR, (errmsg("server not started")));
 
-  for (;;)
-  {
+  for (;;) {
     int rc;
 
     CHECK_FOR_INTERRUPTS();
@@ -121,26 +100,22 @@ yagp_test_uds_receive(PG_FUNCTION_ARGS)
     if (rc > 0)
       break;
     if (rc < 0 && errno != EINTR)
-      ereport(ERROR,
-              (errmsg("poll: %m")));
+      ereport(ERROR, (errmsg("poll: %m")));
     timeout_ms -= TEST_POLL_TIMEOUT_MS;
     if (timeout_ms <= 0)
       PG_RETURN_INT64(0);
   }
 
-  if (pfd.revents & POLLIN)
-  {
+  if (pfd.revents & POLLIN) {
     char buf[TEST_RCV_BUF_SIZE];
     int client;
     ssize_t n;
 
     client = accept(server_fd, NULL, NULL);
     if (client < 0)
-      ereport(ERROR,
-              (errmsg("accept: %m")));
+      ereport(ERROR, (errmsg("accept: %m")));
 
-    while ((n = recv(client, buf, sizeof(buf), 0)) != 0)
-    {
+    while ((n = recv(client, buf, sizeof(buf), 0)) != 0) {
       if (n > 0)
         total += n;
       else if (errno != EINTR)
@@ -153,16 +128,12 @@ yagp_test_uds_receive(PG_FUNCTION_ARGS)
   PG_RETURN_INT64(total);
 }
 
-Datum
-yagp_test_uds_stop_server(PG_FUNCTION_ARGS)
-{
-  if (server_fd >= 0)
-  {
+Datum yagp_test_uds_stop_server(PG_FUNCTION_ARGS) {
+  if (server_fd >= 0) {
     close(server_fd);
     server_fd = -1;
   }
-  if (sock_path)
-  {
+  if (sock_path) {
     unlink(sock_path);
     pfree(sock_path);
     sock_path = NULL;

--- a/gpcontrib/yagp_hooks_collector/src/yagp_hooks_collector.c
+++ b/gpcontrib/yagp_hooks_collector/src/yagp_hooks_collector.c
@@ -31,43 +31,56 @@ PG_FUNCTION_INFO_V1(yagp_test_uds_stop_server);
 static int server_fd = -1;
 static char *sock_path = NULL;
 
-void _PG_init(void) {
-  if (Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_EXECUTE) {
+void
+_PG_init(void)
+{
+  if (Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_EXECUTE)
     hooks_init();
-  }
 }
 
-void _PG_fini(void) {
-  if (Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_EXECUTE) {
+void
+_PG_fini(void)
+{
+  if (Gp_role == GP_ROLE_DISPATCH || Gp_role == GP_ROLE_EXECUTE)
     hooks_deinit();
-  }
 }
 
-Datum yagp_stat_messages_reset(PG_FUNCTION_ARGS) {
+Datum
+yagp_stat_messages_reset(PG_FUNCTION_ARGS)
+{
   yagp_functions_reset();
   PG_RETURN_VOID();
 }
 
-Datum yagp_stat_messages(PG_FUNCTION_ARGS) {
+Datum
+yagp_stat_messages(PG_FUNCTION_ARGS)
+{
   return yagp_functions_get(fcinfo);
 }
 
-Datum yagp_init_log(PG_FUNCTION_ARGS) {
+Datum
+yagp_init_log(PG_FUNCTION_ARGS)
+{
   init_log();
   PG_RETURN_VOID();
 }
 
-Datum yagp_truncate_log(PG_FUNCTION_ARGS) {
+Datum
+yagp_truncate_log(PG_FUNCTION_ARGS)
+{
   truncate_log();
   PG_RETURN_VOID();
 }
 
-Datum yagp_test_uds_start_server(PG_FUNCTION_ARGS) {
+Datum
+yagp_test_uds_start_server(PG_FUNCTION_ARGS)
+{
   char *path = text_to_cstring(PG_GETARG_TEXT_PP(0));
   struct sockaddr_un addr = {.sun_family = AF_UNIX};
 
   if (strlen(path) >= sizeof(addr.sun_path))
-    ereport(ERROR, (errmsg("path too long")));
+    ereport(ERROR,
+            (errmsg("path too long")));
 
   yagp_test_uds_stop_server(NULL);
 
@@ -78,44 +91,56 @@ Datum yagp_test_uds_start_server(PG_FUNCTION_ARGS) {
 
   if ((server_fd = socket(AF_UNIX, SOCK_STREAM, 0)) < 0 ||
       bind(server_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0 ||
-      listen(server_fd, TEST_MAX_CONNECTIONS) < 0) {
-    yagp_test_uds_stop_server(fcinfo);
-    ereport(ERROR, (errmsg("socket setup failed: %m")));
+      listen(server_fd, TEST_MAX_CONNECTIONS) < 0)
+  {
+    yagp_test_uds_stop_server(NULL);
+    ereport(ERROR,
+            (errmsg("socket setup failed: %m")));
   }
 
   PG_RETURN_VOID();
 }
 
-Datum yagp_test_uds_receive(PG_FUNCTION_ARGS) {
+Datum
+yagp_test_uds_receive(PG_FUNCTION_ARGS)
+{
   int timeout_ms = PG_GETARG_INT32(0);
   int64 total = 0;
-  char buf[TEST_RCV_BUF_SIZE];
-  int rc;
   struct pollfd pfd = {.fd = server_fd, .events = POLLIN};
 
   if (server_fd < 0)
-    ereport(ERROR, (errmsg("server not started")));
+    ereport(ERROR,
+            (errmsg("server not started")));
 
-  for (;;) {
+  for (;;)
+  {
+    int rc;
+
     CHECK_FOR_INTERRUPTS();
     rc = poll(&pfd, 1, Min(timeout_ms, TEST_POLL_TIMEOUT_MS));
     if (rc > 0)
       break;
     if (rc < 0 && errno != EINTR)
-      ereport(ERROR, (errmsg("poll: %m")));
+      ereport(ERROR,
+              (errmsg("poll: %m")));
     timeout_ms -= TEST_POLL_TIMEOUT_MS;
     if (timeout_ms <= 0)
       PG_RETURN_INT64(0);
   }
 
-  if (pfd.revents & POLLIN) {
-    int client = accept(server_fd, NULL, NULL);
+  if (pfd.revents & POLLIN)
+  {
+    char buf[TEST_RCV_BUF_SIZE];
+    int client;
     ssize_t n;
 
+    client = accept(server_fd, NULL, NULL);
     if (client < 0)
-      ereport(ERROR, (errmsg("accept: %m")));
+      ereport(ERROR,
+              (errmsg("accept: %m")));
 
-    while ((n = recv(client, buf, sizeof(buf), 0)) != 0) {
+    while ((n = recv(client, buf, sizeof(buf), 0)) != 0)
+    {
       if (n > 0)
         total += n;
       else if (errno != EINTR)
@@ -128,12 +153,16 @@ Datum yagp_test_uds_receive(PG_FUNCTION_ARGS) {
   PG_RETURN_INT64(total);
 }
 
-Datum yagp_test_uds_stop_server(PG_FUNCTION_ARGS) {
-  if (server_fd >= 0) {
+Datum
+yagp_test_uds_stop_server(PG_FUNCTION_ARGS)
+{
+  if (server_fd >= 0)
+  {
     close(server_fd);
     server_fd = -1;
   }
-  if (sock_path) {
+  if (sock_path)
+  {
     unlink(sock_path);
     pfree(sock_path);
     sock_path = NULL;


### PR DESCRIPTION
Refactor code:
1. Rewrite report_query(), the code is more readable and exception save, all resources are freed if exception occurs.
2. Apply clang-format.
3. Align max_{text/plan}_size types with types of their corresponding GUCs.