### PR TITLE
correct addition of total bytes sent

### DIFF
--- a/gpcontrib/yagp_hooks_collector/src/UDSConnector.cpp
+++ b/gpcontrib/yagp_hooks_collector/src/UDSConnector.cpp
@@ -52,7 +52,8 @@ bool UDSConnector::report_query(const yagpcc::SetQueryReq &req,
         do {
           sent = send(sockfd, buf + sent_total, total_size - sent_total,
                       MSG_DONTWAIT);
-          sent_total += sent;
+          if (sent > 0)
+            sent_total += sent;
         } while (
             sent > 0 && size_t(sent_total) != total_size &&
             // the line below is a small throttling hack:


### PR DESCRIPTION
`send()` may return `-1` in case of an error, do not add -1 to total_bytes sent.