### PR TITLE
Fix oversight of VACUUM NOWAIT coding.

### DIFF
--- a/gpcontrib/gp_aux_catalog/gp_aux_catalog.c
+++ b/gpcontrib/gp_aux_catalog/gp_aux_catalog.c
@@ -56,11 +56,14 @@ gpdb_binary_upgrade_insert_pro_tup(
     bool		nulls[Natts_pg_proc];
 	Datum		values[Natts_pg_proc];
     HeapTuple tuple;
+	NameData pname;
 
 	memset(values, 0, sizeof(values));
 	memset(nulls, false, sizeof(nulls));
 
-    values[Anum_pg_proc_proname - 1] = NameGetDatum(proname);
+	namestrcpy(&pname, proname);
+
+    values[Anum_pg_proc_proname - 1] = NameGetDatum(&pname);
 	values[Anum_pg_proc_pronamespace - 1] = ObjectIdGetDatum(PG_CATALOG_NAMESPACE);
 	values[Anum_pg_proc_proowner - 1] = ObjectIdGetDatum(BOOTSTRAP_SUPERUSERID);
 	values[Anum_pg_proc_prolang - 1] = ObjectIdGetDatum(ClanguageId);
@@ -161,10 +164,5 @@ gpdb_binary_upgrade_catalog_1_0_to_1_1(PG_FUNCTION_ARGS)
 Datum
 gp_acquire_sample_rows_vac(PG_FUNCTION_ARGS)
 {
-	
-	Oid			relOid = PG_GETARG_OID(0);
-	int32		targrows = PG_GETARG_INT32(1);
-	bool		inherited = PG_GETARG_BOOL(2);
-	int32		vacopts = PG_GETARG_INT32(3);
-	return gp_acquire_sample_rows_int(fcinfo,relOid,targrows,inherited,vacopts);
+	return gp_acquire_sample_rows_int(fcinfo);
 }

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -2403,27 +2403,21 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 	 * may result in different behaviour under different acl configuration.
 	 */
 
-	if (vacopts & VACOPT_NOWAIT)
-	{
 	initStringInfo(&str);
-
-		appendStringInfo(&str, "select gp_acquire_sample_rows_vac(%u, %d, '%s', %d);", 
+	
+	if (vacopts & VACOPT_NOWAIT)
+		appendStringInfo(&str, "select pg_catalog.gp_acquire_sample_rows_vac(%u, %d, '%s', %d);", 
 					 RelationGetRelid(onerel),
 					 perseg_targrows,
 					 inh ? "t" : "f",
 					 vacopts
 					);
-	}
-	else{
-
-	initStringInfo(&str);
-
+	else
 		appendStringInfo(&str, "select pg_catalog.gp_acquire_sample_rows(%u, %d, '%s');", 
 					 RelationGetRelid(onerel),
 					 perseg_targrows,
 					 inh ? "t" : "f"
 					);
-	}
 
 
 	/*

--- a/src/backend/commands/analyzefuncs.c
+++ b/src/backend/commands/analyzefuncs.c
@@ -49,7 +49,8 @@ typedef struct
 } gp_acquire_sample_rows_context;
 
 Datum
-gp_acquire_sample_rows_int(FunctionCallInfo fcinfo, Oid relOid,int32 targrows,bool inherited,int32 vacopts){
+gp_acquire_sample_rows_int(PG_FUNCTION_ARGS)
+{
 	FuncCallContext *funcctx = NULL;
 	gp_acquire_sample_rows_context *ctx;
 	MemoryContext oldcontext;
@@ -57,6 +58,13 @@ gp_acquire_sample_rows_int(FunctionCallInfo fcinfo, Oid relOid,int32 targrows,bo
 	TupleDesc	relDesc;
 	TupleDesc	outDesc;
 	int			live_natts;
+	Oid			relOid = PG_GETARG_OID(0);
+	int32		targrows = PG_GETARG_INT32(1);
+	bool		inherited = PG_GETARG_BOOL(2);
+	int32		vacopts = 0;
+
+	if (PG_NARGS() > 3)
+		vacopts = PG_GETARG_INT32(3);
 
 	if (targrows < 1)
 		elog(ERROR, "invalid targrows argument");
@@ -357,11 +365,7 @@ gp_acquire_sample_rows_int(FunctionCallInfo fcinfo, Oid relOid,int32 targrows,bo
 Datum
 gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 {
-	
-	Oid			relOid = PG_GETARG_OID(0);
-	int32		targrows = PG_GETARG_INT32(1);
-	bool		inherited = PG_GETARG_BOOL(2);
-	return gp_acquire_sample_rows_int(fcinfo, relOid, targrows, inherited, 0);
+	return gp_acquire_sample_rows_int(fcinfo);
 }
 
 

--- a/src/include/commands/vacuum.h
+++ b/src/include/commands/vacuum.h
@@ -235,7 +235,7 @@ extern int acquire_inherited_sample_rows(Relation onerel, int elevel,
 /* in commands/analyzefuncs.c */
 extern Datum gp_acquire_sample_rows(PG_FUNCTION_ARGS);
 extern Oid gp_acquire_sample_rows_col_type(Oid typid);
-
+extern Datum gp_acquire_sample_rows_int(PG_FUNCTION_ARGS);
 
 extern bool gp_use_fastanalyze;
 


### PR DESCRIPTION
```
In file included from gp_aux_catalog.c:18:
../../src/include/../backend/commands/analyzefuncs.c:52:1: warning: no previous prototype for ‘gp_acquire_sample_rows_int’ [-Wmissing-prototypes]
   52 | gp_acquire_sample_rows_int(FunctionCallInfo fcinfo, Oid relOid,int32 targrows,bool inherited,int32 vacopts)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
gp_aux_catalog.c: In function ‘gpdb_binary_upgrade_insert_pro_tup’:
gp_aux_catalog.c:63:53: warning: passing argument 1 of ‘NameGetDatum’ from incompatible pointer type [-Wincompatible-pointer-types]
   63 |     values[Anum_pg_proc_proname - 1] = NameGetDatum(proname);
      |                                                     ^~~~~~~
      |                                                     |
      |                                                     const char *
In file included from gp_aux_catalog.c:2:

```