### PR TITLE
Remove dummy coding from pg_rewind's main.

### DIFF
--- a/src/bin/pg_rewind/pg_rewind.c
+++ b/src/bin/pg_rewind/pg_rewind.c
@@ -194,7 +194,7 @@ main(int argc, char **argv)
 				connstr_source = pg_strdup(optarg);
 				break;
 			case 4:             /* --source-segment-id */
-				instanceSegIndx = strtoll(optarg, optarg + strlen(optarg), 10);
+				instanceSegIndx = strtoll(optarg, NULL, 10);
 				break;
 		}
 	}


### PR DESCRIPTION
Do not pass any pointer to strtoll.

```
If endptr is not NULL, strtol() stores the address of the first invalid character in *endptr. If there were no digits at all, strtol() stores the original value of nptr in *endptr (and returns 0). In particular, if *nptr is not '\0' but **endptr is '\0' on return, the entire string is valid.
```

https://linux.die.net/man/3/strtoll

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
