### PR TITLE
Fix the fts_segment_reset test

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -3697,6 +3697,21 @@ CleanupBackend(int pid,
 
 	if (!EXIT_STATUS_0(exitstatus) && !EXIT_STATUS_1(exitstatus))
 	{
+
+#ifdef FAULT_INJECTOR
+		if (pmState == PM_RUN)
+		{
+			/*
+			 * Code below is for test purposes only. If a fault is set, it
+			 * will formally be completed without doing anything.
+			 *
+			 * Additional note: This check of pmState == PM_RUN is just extra
+			 * safety measurments. If we try to access this code not from
+			 * PM_RUN the behaviour can be unpredictable.
+			 */
+			SIMPLE_FAULT_INJECTOR("backend_abort_handling");
+		}
+#endif
 		HandleChildCrash(pid, exitstatus, _("server process"));
 		return;
 	}

--- a/src/test/isolation2/expected/fts_segment_reset.out
+++ b/src/test/isolation2/expected/fts_segment_reset.out
@@ -35,6 +35,19 @@ select gp_inject_fault_infinite('postmaster_server_loop_no_sigkill', 'skip', dbi
  Success:                 
 (1 row)
 
+-- We need to set fault at the handler of abort signal from backend
+-- so then we can wait until it is triggered. We need to do this because
+-- sometimes process of calling abort() (which is issued by the injection
+-- of 'panic' fault in the next lines of this test) and abortion itself can
+-- take a long time to complete. So, sometimes this test can give unexpected
+-- results, when you think that commands sended after issuing panic fault
+-- should fail, but they are being executed without any errors.
+select gp_inject_fault('backend_abort_handling', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
 -- Now bring down primary of seg0. There're a lot of ways to do that, in order
 -- to better emulate a real-world scnarios we're injecting a PANIC to do that.
 1:select gp_inject_fault('start_prepare', 'panic', dbid) from gp_segment_configuration where role = 'p' AND content = 0;
@@ -43,6 +56,14 @@ select gp_inject_fault_infinite('postmaster_server_loop_no_sigkill', 'skip', dbi
  Success:        
 (1 row)
 1&:create table fts_reset_t(a int);  <waiting ...>
+
+-- We now wait till our seg0 will start reaping it's childs and resetting.
+-- We can ignore the results of this command, because it can throw 3 things:
+-- error because we couldn't send command because seg0 already restarting;
+-- error because reaper killed backend on seg0 because it started reaping
+-- backends (previous panic fault injection)
+-- no error, because we managed to overrun reaper and sendeed results
+-- of wait_until_triggered back
 
 -- This should fail due to the seg0 in reset mode
 2&:create table fts_reset_t2(a int);  <waiting ...>

--- a/src/test/isolation2/expected/fts_segment_reset.out
+++ b/src/test/isolation2/expected/fts_segment_reset.out
@@ -40,7 +40,7 @@ select gp_inject_fault_infinite('postmaster_server_loop_no_sigkill', 'skip', dbi
 -- sometimes process of calling abort() (which is issued by the injection
 -- of 'panic' fault in the next lines of this test) and abortion itself can
 -- take a long time to complete. So, sometimes this test can give unexpected
--- results, when you think that commands sended after issuing panic fault
+-- results, when you think that commands sent after issuing panic fault
 -- should fail, but they are being executed without any errors.
 select gp_inject_fault('backend_abort_handling', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = 0;
  gp_inject_fault 
@@ -62,8 +62,8 @@ select gp_inject_fault('backend_abort_handling', 'skip', dbid) from gp_segment_c
 -- error because we couldn't send command because seg0 already restarting;
 -- error because reaper killed backend on seg0 because it started reaping
 -- backends (previous panic fault injection)
--- no error, because we managed to overrun reaper and sendeed results
--- of wait_until_triggered back
+-- no error, because we managed to overrun reaper and sent results
+-- of gp_wait_until_triggered_fault back
 
 -- This should fail due to the seg0 in reset mode
 2&:create table fts_reset_t2(a int);  <waiting ...>

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -259,7 +259,7 @@ test: segwalrep/dtx_recovery_wait_lsn
 test: segwalrep/hintbit_throttle
 test: fts_manual_probe
 test: fts_session_reset
-#test: fts_segment_reset
+test: fts_segment_reset
 test: fts_maintenance
 
 # Reindex tests

--- a/src/test/isolation2/sql/fts_segment_reset.sql
+++ b/src/test/isolation2/sql/fts_segment_reset.sql
@@ -26,11 +26,33 @@ from gp_segment_configuration where role = 'p' and content = 0;
 select gp_inject_fault_infinite('postmaster_server_loop_no_sigkill', 'skip', dbid) 
 from gp_segment_configuration where role = 'p' and content = 0;
 
+-- We need to set fault at the handler of abort signal from backend
+-- so then we can wait until it is triggered. We need to do this because
+-- sometimes process of calling abort() (which is issued by the injection
+-- of 'panic' fault in the next lines of this test) and abortion itself can
+-- take a long time to complete. So, sometimes this test can give unexpected
+-- results, when you think that commands sended after issuing panic fault
+-- should fail, but they are being executed without any errors.
+select gp_inject_fault('backend_abort_handling', 'skip', dbid)
+from gp_segment_configuration where role = 'p' and content = 0;
+
 -- Now bring down primary of seg0. There're a lot of ways to do that, in order
 -- to better emulate a real-world scnarios we're injecting a PANIC to do that.
 1:select gp_inject_fault('start_prepare', 'panic', dbid) 
 from gp_segment_configuration where role = 'p' AND content = 0;
 1&:create table fts_reset_t(a int);
+
+-- We now wait till our seg0 will start reaping it's childs and resetting.
+-- We can ignore the results of this command, because it can throw 3 things:
+-- error because we couldn't send command because seg0 already restarting;
+-- error because reaper killed backend on seg0 because it started reaping
+-- backends (previous panic fault injection)
+-- no error, because we managed to overrun reaper and sendeed results
+-- of wait_until_triggered back
+-- start_ignore
+select gp_wait_until_triggered_fault('backend_abort_handling', 1, dbid)
+from gp_segment_configuration where role = 'p' and content = 0;
+-- end_ignore
 
 -- This should fail due to the seg0 in reset mode
 2&:create table fts_reset_t2(a int);

--- a/src/test/isolation2/sql/fts_segment_reset.sql
+++ b/src/test/isolation2/sql/fts_segment_reset.sql
@@ -31,7 +31,7 @@ from gp_segment_configuration where role = 'p' and content = 0;
 -- sometimes process of calling abort() (which is issued by the injection
 -- of 'panic' fault in the next lines of this test) and abortion itself can
 -- take a long time to complete. So, sometimes this test can give unexpected
--- results, when you think that commands sended after issuing panic fault
+-- results, when you think that commands sent after issuing panic fault
 -- should fail, but they are being executed without any errors.
 select gp_inject_fault('backend_abort_handling', 'skip', dbid)
 from gp_segment_configuration where role = 'p' and content = 0;
@@ -47,8 +47,8 @@ from gp_segment_configuration where role = 'p' AND content = 0;
 -- error because we couldn't send command because seg0 already restarting;
 -- error because reaper killed backend on seg0 because it started reaping
 -- backends (previous panic fault injection)
--- no error, because we managed to overrun reaper and sendeed results
--- of wait_until_triggered back
+-- no error, because we managed to overrun reaper and sent results
+-- of gp_wait_until_triggered_fault back
 -- start_ignore
 select gp_wait_until_triggered_fault('backend_abort_handling', 1, dbid)
 from gp_segment_configuration where role = 'p' and content = 0;


### PR DESCRIPTION
The first commit is got from https://github.com/GreengageDB/greengage/pull/62
The second commit fixes typos in the first one

-------------------

Merge without squash