### PR TITLE
Fix the fts_maintenance test

### DIFF
--- a/src/test/isolation2/expected/fts_maintenance.out
+++ b/src/test/isolation2/expected/fts_maintenance.out
@@ -1,5 +1,13 @@
 -- Faster FTS probes
 -- Let FTS detect/declare failure sooner
+
+-- start_matchsubs
+-- m/Is the server running on host "\d+.\d+.\d+.\d+" and accepting/
+-- s/Is the server running on host "\d+.\d+.\d+.\d+" and accepting/Is the server running on host "X.X.X.X" and accepting/
+-- m/seg1 \d+.\d+.\d+.\d+:/
+-- s/seg1 \d+.\d+.\d+.\d+:/seg1 X.X.X.X:/
+-- end_matchsubs
+
 !\retcode gpconfig -c gp_fts_probe_interval -v 10 --masteronly;
 (exited with code 0)
 !\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -260,7 +260,7 @@ test: segwalrep/hintbit_throttle
 test: fts_manual_probe
 test: fts_session_reset
 #test: fts_segment_reset
-#test: fts_maintenance
+test: fts_maintenance
 
 # Reindex tests
 test: reindex/abort_reindex

--- a/src/test/isolation2/sql/fts_maintenance.sql
+++ b/src/test/isolation2/sql/fts_maintenance.sql
@@ -1,5 +1,13 @@
 -- Faster FTS probes
 -- Let FTS detect/declare failure sooner 
+
+-- start_matchsubs
+-- m/Is the server running on host "\d+.\d+.\d+.\d+" and accepting/
+-- s/Is the server running on host "\d+.\d+.\d+.\d+" and accepting/Is the server running on host "X.X.X.X" and accepting/
+-- m/seg1 \d+.\d+.\d+.\d+:/
+-- s/seg1 \d+.\d+.\d+.\d+:/seg1 X.X.X.X:/
+-- end_matchsubs
+
 !\retcode gpconfig -c gp_fts_probe_interval -v 10 --masteronly;
 !\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;
 !\retcode gpconfig -c statement_timeout -v 2min;


### PR DESCRIPTION
Replace IP address with X.X.X.X to make the test passed regardless of segment IP.
The IP address replacement makes it possible to pass the test on CI.
