### PR TITLE
Flag for yezzey test

### DIFF
--- a/yezzey_test/yproxy.conf
+++ b/yezzey_test/yproxy.conf
@@ -23,3 +23,6 @@ backup_storage:
   storage_bucket: "gpyezzey"
   storage_region: "us-west-2"
   storage_type: "s3"
+
+vacuum:
+  check_backup: false


### PR DESCRIPTION
Old deletion for users without backups 
check backup used only here:
func (dh *BasicGarbageMgr) ListGarbageFiles(bucket string, msg message.DeleteMessage) 

	if dh.Cnf.CheckBackup {
		firstBackupLSN, err = dh.BackupInterractor.GetFirstLSN(msg.Segnum)
		if err != nil {
			ylogger.Zero.Error().AnErr("err", err).Msg("failed to get first lsn") //return or just assume there are no backups?
			return nil, err
		}
		ylogger.Zero.Info().Uint64("lsn", firstBackupLSN).Msg("first backup LSN")
	} else {
		firstBackupLSN = ^uint64(0)
		ylogger.Zero.Info().Uint64("lsn", firstBackupLSN).Msg("omit first backup LSN")
	} .....

