### PR TITLE
Define prototypes for ZSTD custom allocation functions.

### DIFF
--- a/src/include/storage/buffile.h
+++ b/src/include/storage/buffile.h
@@ -71,4 +71,12 @@ extern BufFile *BufFileCreateNamedTemp_ForceDefaultSpace(const char *fileName, b
 extern BufFile *BufFileOpenNamedTemp_ForceDefaultSpace(const char *fileName,
 													   bool interXact);
 
+#ifdef HAVE_LIBZSTD
+
+extern void *customAlloc(void *opaque, size_t size);
+
+extern void customFree(void *opaque, void *address);
+
+#endif		/* HAVE_ZSTD */
+
 #endif   /* BUFFILE_H */


### PR DESCRIPTION
fixes:

```
buffile.c:1039:1: warning: no previous prototype for ‘customAlloc’ [-Wmissing-prototypes]
 1039 | customAlloc(void *opaque, size_t size)
      | ^~~~~~~~~~~
buffile.c:1045:1: warning: no previous prototype for ‘customFree’ [-Wmissing-prototypes]
 1045 | customFree(void *opaque, void *address)
      | ^~~~~~~~~~

```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
