### PR TITLE
Fix pg_basebackup connection

### DIFF
--- a/src/bin/pg_basebackup/pg_basebackup.c
+++ b/src/bin/pg_basebackup/pg_basebackup.c
@@ -1588,8 +1588,18 @@ GetRestoreCommandHint(PQExpBufferData conninfo_buf)
 	PGconn   *regular_conn;
 	PGresult *restore_cmd_hint_res;
 	char	 *restore_cmd_hint = NULL;
+	PQExpBufferData conninfo_buf_copy;
 
-	regular_conn = PQconnectdb(conninfo_buf.data);
+	/*
+	 * conninfo_buf doesn't include dbname. Without it, libpq defaults to connecting
+	 * to a database with the same name as the username, which may not exist.
+	 * Use the 'postgres' database which always exists. Also use utility mode
+	 * to connect to primary segments.
+	 */
+	initPQExpBuffer(&conninfo_buf_copy);
+	appendPQExpBuffer(&conninfo_buf_copy, "%s dbname=postgres options='-c gp_session_role=utility'", conninfo_buf.data);
+	regular_conn = PQconnectdb(conninfo_buf_copy.data);
+	termPQExpBuffer(&conninfo_buf_copy);
 
 	if (PQstatus(regular_conn) != CONNECTION_OK)
 	{

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -172,7 +172,7 @@ test: uao/concurrent_inserts_hash_crash_row
 
 test: reorganize_after_ao_vacuum_skip_drop truncate_after_ao_vacuum_skip_drop mark_all_aoseg_await_drop
 # below test(s) inject faults so each of them need to be in a separate group
-#test: segwalrep/master_xlog_switch
+test: segwalrep/master_xlog_switch
 test: idle_gang_cleaner
 
 # Tests on Append-Optimized tables (column-oriented).
@@ -254,8 +254,8 @@ test: segwalrep/dtm_recovery_on_standby
 test: segwalrep/commit_blocking_on_standby
 test: segwalrep/max_slot_wal_keep_size
 test: segwalrep/dtx_recovery_wait_lsn
-#test: pg_basebackup
-#test: pg_basebackup_with_tablespaces
+test: pg_basebackup
+test: pg_basebackup_with_tablespaces
 test: segwalrep/hintbit_throttle
 test: fts_manual_probe
 test: fts_session_reset


### PR DESCRIPTION
The GetRestoreCommandHint() fails because libpq defaults to username for database name (which may not exist) and Greenplum blocks direct primary segment connections (this is done in [1]). Add explicit dbname=postgres and gp_session_role=utility to connection string.

[1] postinit.c
```c
	else if ((Gp_session_role == GP_ROLE_DISPATCH) && !IS_QUERY_DISPATCHER())
	{
		ereport(FATAL,
				(errcode(ERRCODE_CANNOT_CONNECT_NOW),
				 errmsg("connections to primary segments are not allowed"),
				 errdetail("This database instance is running as a primary segment in a Greenplum cluster and does not permit direct connections."),
				 errhint("To force a connection anyway (dangerous!), use utility mode.")));
	}
```