### PR TITLE
Fix the pg_rewind_fail_missing_xlog test

### DIFF
--- a/src/test/isolation2/expected/pg_rewind_fail_missing_xlog.out
+++ b/src/test/isolation2/expected/pg_rewind_fail_missing_xlog.out
@@ -534,10 +534,10 @@ server closed the connection unexpectedly
 -- Test 5: Ensure that replication slot's restart_lsn advances and WAL files
 -- that are older than the minimum restart_lsn get removed/recycled.
 
--- Create an unlogged table on the primary that remembers replication slot's last restart_lsn and number of WAL files.
-1U: CREATE UNLOGGED TABLE unlogged_wal_retention_test(restart_lsn_before pg_lsn, wal_count_before int);
+-- Create an unlogged table on the primary that remembers replication slot's last restart_lsn and the oldest WAL segment name.
+1U: CREATE UNLOGGED TABLE unlogged_wal_retention_test(restart_lsn_before pg_lsn, oldest_wal_seg text);
 CREATE
-1U: INSERT INTO unlogged_wal_retention_test SELECT (select restart_lsn FROM pg_replication_slots WHERE slot_name = 'internal_wal_replication_slot') as restart_lsn_before, (select count(*) from pg_ls_dir('./pg_xlog')) as wal_count_before;
+1U: INSERT INTO unlogged_wal_retention_test SELECT (select restart_lsn FROM pg_replication_slots WHERE slot_name = 'internal_wal_replication_slot'), (select pg_ls_dir from pg_ls_dir('./pg_xlog') where pg_ls_dir ~ '^[0-9A-F]{24}$' order by pg_ls_dir limit 1);
 INSERT 1
 5: CHECKPOINT;
 CHECKPOINT
@@ -552,14 +552,14 @@ CHECKPOINT
 ----------
  t        
 (1 row)
--- Some old WALs should be removed
-1U: select ((select count(*)::int from pg_ls_dir('./pg_xlog')) - wal_count_before) < 0 FROM unlogged_wal_retention_test;
- ?column? 
-----------
- t        
+-- Some old WALs should be removed/recycled.
+1U: select exists(select pg_ls_dir from pg_ls_dir('./pg_xlog') intersect select oldest_wal_seg from unlogged_wal_retention_test);
+ exists 
+--------
+ f      
 (1 row)
--- Record the restart_lsn and the WAL file count.
-1U: UPDATE unlogged_wal_retention_test SET restart_lsn_before = (SELECT restart_lsn from pg_replication_slots WHERE slot_name = 'internal_wal_replication_slot'), wal_count_before = (select count(*) from pg_ls_dir('./pg_xlog'));
+-- Record the restart_lsn.
+1U: UPDATE unlogged_wal_retention_test SET restart_lsn_before = (SELECT restart_lsn from pg_replication_slots WHERE slot_name = 'internal_wal_replication_slot');
 UPDATE 1
 -- Write some records to a newer WAL file.
 1U: SELECT pg_switch_xlog is not null FROM pg_switch_xlog();
@@ -575,8 +575,8 @@ INSERT 3
 ----------
  t        
 (1 row)
---- Record the WAL file count.
-1U: UPDATE unlogged_wal_retention_test SET wal_count_before = (select count(*) from pg_ls_dir('./pg_xlog'));
+-- Record the oldest WAL file name.
+1U: UPDATE unlogged_wal_retention_test SET oldest_wal_seg = (select pg_ls_dir from pg_ls_dir('./pg_xlog') where pg_ls_dir ~ '^[0-9A-F]{24}$' order by pg_ls_dir limit 1);
 UPDATE 1
 
 -- Hang the wal sender before writing more wals.
@@ -620,11 +620,11 @@ INSERT 3
 -- Trigger old WAL removal.
 1U: CHECKPOINT;
 CHECKPOINT
--- And the WAL file(s) older than the redo lsn that we previously kept should now be removed.
-1U: select ((select count(*)::int from pg_ls_dir('./pg_xlog')) - wal_count_before) < 0 FROM unlogged_wal_retention_test;
- ?column? 
-----------
- t        
+-- And the WAL file(s) older than the redo lsn that we previously kept should now be removed/recycled.
+1U: select exists(select pg_ls_dir from pg_ls_dir('./pg_xlog') intersect select oldest_wal_seg from unlogged_wal_retention_test);
+ exists 
+--------
+ f      
 (1 row)
 1U: SELECT pg_xlog_location_diff(restart_lsn, (select pg_controldata_redo_lsn(setting) FROM pg_settings WHERE name = 'data_directory')) = 0 from pg_replication_slots WHERE slot_name = 'internal_wal_replication_slot';
  ?column? 

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -6,7 +6,7 @@ test: lockmodes
 # Put test prepare_limit near to test lockmodes since both of them reboot the
 # cluster during testing. Usually the 2nd reboot should be faster.
 test: prepare_limit
-#test: pg_rewind_fail_missing_xlog
+test: pg_rewind_fail_missing_xlog
 test: prepared_xact_deadlock_pg_rewind
 test: ao_partition_lock query_gp_partitions_view
 test: dml_on_root_locks_all_parts

--- a/src/test/isolation2/sql/pg_rewind_fail_missing_xlog.sql
+++ b/src/test/isolation2/sql/pg_rewind_fail_missing_xlog.sql
@@ -251,24 +251,24 @@ INSERT INTO tst_missing_tbl values(2),(1),(5);
 -- Test 5: Ensure that replication slot's restart_lsn advances and WAL files
 -- that are older than the minimum restart_lsn get removed/recycled.
 
--- Create an unlogged table on the primary that remembers replication slot's last restart_lsn and number of WAL files.
-1U: CREATE UNLOGGED TABLE unlogged_wal_retention_test(restart_lsn_before pg_lsn, wal_count_before int);
-1U: INSERT INTO unlogged_wal_retention_test SELECT (select restart_lsn FROM pg_replication_slots WHERE slot_name = 'internal_wal_replication_slot') as restart_lsn_before, (select count(*) from pg_ls_dir('./pg_xlog')) as wal_count_before;
+-- Create an unlogged table on the primary that remembers replication slot's last restart_lsn and the oldest WAL segment name.
+1U: CREATE UNLOGGED TABLE unlogged_wal_retention_test(restart_lsn_before pg_lsn, oldest_wal_seg text);
+1U: INSERT INTO unlogged_wal_retention_test SELECT (select restart_lsn FROM pg_replication_slots WHERE slot_name = 'internal_wal_replication_slot'), (select pg_ls_dir from pg_ls_dir('./pg_xlog') where pg_ls_dir ~ '^[0-9A-F]{24}$' order by pg_ls_dir limit 1);
 5: CHECKPOINT;
 -- Replication slot's restart_lsn should advance to the checkpoint's redo location.
 1U: SELECT pg_xlog_location_diff(restart_lsn, restart_lsn_before) > 0 from pg_replication_slots, unlogged_wal_retention_test WHERE slot_name = 'internal_wal_replication_slot';
 1U: SELECT pg_xlog_location_diff(restart_lsn, (select pg_controldata_redo_lsn(setting) FROM pg_settings WHERE name = 'data_directory')) = 0 from pg_replication_slots WHERE slot_name = 'internal_wal_replication_slot';
--- Some old WALs should be removed
-1U: select ((select count(*)::int from pg_ls_dir('./pg_xlog')) - wal_count_before) < 0 FROM unlogged_wal_retention_test;
--- Record the restart_lsn and the WAL file count.
-1U: UPDATE unlogged_wal_retention_test SET restart_lsn_before = (SELECT restart_lsn from pg_replication_slots WHERE slot_name = 'internal_wal_replication_slot'), wal_count_before = (select count(*) from pg_ls_dir('./pg_xlog'));
+-- Some old WALs should be removed/recycled.
+1U: select exists(select pg_ls_dir from pg_ls_dir('./pg_xlog') intersect select oldest_wal_seg from unlogged_wal_retention_test);
+-- Record the restart_lsn.
+1U: UPDATE unlogged_wal_retention_test SET restart_lsn_before = (SELECT restart_lsn from pg_replication_slots WHERE slot_name = 'internal_wal_replication_slot');
 -- Write some records to a newer WAL file.
 1U: SELECT pg_switch_xlog is not null FROM pg_switch_xlog();
 5: INSERT INTO tst_missing_tbl values(2),(1),(5);
 -- Replication slot's restart_lsn should NOT change regardless mirror has received more wals.
 1U: select pg_xlog_location_diff(restart_lsn, restart_lsn_before) = 0 FROM pg_replication_slots, unlogged_wal_retention_test WHERE slot_name = 'internal_wal_replication_slot';
---- Record the WAL file count.
-1U: UPDATE unlogged_wal_retention_test SET wal_count_before = (select count(*) from pg_ls_dir('./pg_xlog'));
+-- Record the oldest WAL file name.
+1U: UPDATE unlogged_wal_retention_test SET oldest_wal_seg = (select pg_ls_dir from pg_ls_dir('./pg_xlog') where pg_ls_dir ~ '^[0-9A-F]{24}$' order by pg_ls_dir limit 1);
 
 -- Hang the wal sender before writing more wals.
 5: SELECT gp_inject_fault('wal_sender_loop', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 1;
@@ -288,8 +288,8 @@ INSERT INTO tst_missing_tbl values(2),(1),(5);
 1U: SELECT pg_xlog_location_diff(restart_lsn, restart_lsn_before) > 0 from pg_replication_slots, unlogged_wal_retention_test WHERE slot_name = 'internal_wal_replication_slot';
 -- Trigger old WAL removal.
 1U: CHECKPOINT;
--- And the WAL file(s) older than the redo lsn that we previously kept should now be removed.
-1U: select ((select count(*)::int from pg_ls_dir('./pg_xlog')) - wal_count_before) < 0 FROM unlogged_wal_retention_test;
+-- And the WAL file(s) older than the redo lsn that we previously kept should now be removed/recycled.
+1U: select exists(select pg_ls_dir from pg_ls_dir('./pg_xlog') intersect select oldest_wal_seg from unlogged_wal_retention_test);
 1U: SELECT pg_xlog_location_diff(restart_lsn, (select pg_controldata_redo_lsn(setting) FROM pg_settings WHERE name = 'data_directory')) = 0 from pg_replication_slots WHERE slot_name = 'internal_wal_replication_slot';
 
 -- Cleanup


### PR DESCRIPTION
The test did not take into account that WAL segments can not only be removed,
but also recycled. So we should check the oldest WAL segment name, but not
number of WAL files.
Updating the column about WAL is removed from one UPDATE query, because
this value is never used and rewritten later.