### PR TITLE
Fix AOCS sampling with large values

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -99,24 +99,25 @@ open_datumstreamread_segfile(
  * the block directory.
  */
 static void
-open_all_datumstreamread_segfiles(Relation rel,
-								  AOCSFileSegInfo *segInfo,
-								  DatumStreamRead **ds,
-								  int *proj_atts,
-								  int num_proj_atts,
-								  AppendOnlyBlockDirectory *blockDirectory)
+open_all_datumstreamread_segfiles(AOCSScanDesc scan, AOCSFileSegInfo *segInfo)
 {
+	Relation	rel = scan->aos_rel;
 	char	   *basepath = relpathbackend(rel->rd_node, rel->rd_backend, MAIN_FORKNUM);
 	int			i;
 
-	Assert(proj_atts);
+	Assert(scan->proj_atts);
 
-	for (i = 0; i < num_proj_atts; i++)
+	for (i = 0; i < scan->num_proj_atts; i++)
 	{
-		int			attno = proj_atts[i];
+		int			attno = scan->proj_atts[i];
 
-		open_datumstreamread_segfile(basepath, rel->rd_node, segInfo, ds[attno], attno);
-		datumstreamread_block(ds[attno], blockDirectory, attno);
+		open_datumstreamread_segfile(basepath, rel->rd_node, segInfo, scan->ds[attno], attno);
+
+		/* skip reading block for ANALYZE */
+		if (scan->targrow >= 0)
+			continue;
+
+		datumstreamread_block(scan->ds[attno], scan->blockDirectory, attno);
 	}
 
 	pfree(basepath);
@@ -398,12 +399,7 @@ open_next_scan_seg(AOCSScanDesc scan)
 											firstSequence);
 				}
 
-				open_all_datumstreamread_segfiles(scan->aos_rel,
-												  curSegInfo,
-												  scan->ds,
-												  scan->proj_atts,
-												  scan->num_proj_atts,
-												  scan->blockDirectory);
+				open_all_datumstreamread_segfiles(scan, curSegInfo);
 
 				return scan->cur_seg;
 			}
@@ -550,6 +546,7 @@ aocs_beginscan_internal(Relation relation,
 	aocs_initscan(scan);
 
 	scan->blockDirectory = NULL;
+	scan->targrow = -1;
 
 	AppendOnlyVisimap_Init(&scan->visibilityMap,
 						   relation->rd_appendonly->visimaprelid,

--- a/src/include/cdb/cdbaocsam.h
+++ b/src/include/cdb/cdbaocsam.h
@@ -164,6 +164,7 @@ typedef struct AOCSScanDescData
 	 * which starts from 0.
 	 * In other words, if we have seg0 rownums: [1, 100], seg1 rownums: [1, 200]
 	 * If targrow = 150, then we are referring to seg1's rownum=51.
+	 * -1 means that targrow is not set.
 	 */
 	int64			targrow;
 

--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -1016,3 +1016,17 @@ select relhassubclass from gp_dist_random('pg_class') where relname = 'test_tb_1
  f
 (3 rows)
 
+-- Check than gp_acquire_sample_rows works without errors when
+-- gp_use_fastanalyze is enabled and AOCS table contains large values
+set gp_use_fastanalyze = on;
+create table t1
+with (appendoptimized = true, orientation = column)
+as select i, repeat('A', 40000) from generate_series(1, 500) i
+distributed by (i);
+select count(*)
+from (select pg_catalog.gp_acquire_sample_rows('t1'::regclass, 10, 'f')) a;
+ count 
+-------
+    33
+(1 row)
+

--- a/src/test/regress/sql/analyze.sql
+++ b/src/test/regress/sql/analyze.sql
@@ -506,3 +506,15 @@ select relhassubclass from gp_dist_random('pg_class') where relname = 'test_tb_1
 ANALYZE;
 select relhassubclass from pg_class where relname = 'test_tb_14644';
 select relhassubclass from gp_dist_random('pg_class') where relname = 'test_tb_14644';
+
+-- Check than gp_acquire_sample_rows works without errors when
+-- gp_use_fastanalyze is enabled and AOCS table contains large values
+set gp_use_fastanalyze = on;
+
+create table t1
+with (appendoptimized = true, orientation = column)
+as select i, repeat('A', 40000) from generate_series(1, 500) i
+distributed by (i);
+
+select count(*)
+from (select pg_catalog.gp_acquire_sample_rows('t1'::regclass, 10, 'f')) a;


### PR DESCRIPTION
The gp_acquire_sample_rows function is called when the ANALYZE query is
executed. The error occurred when gp_acquire_sample_rows was called for AOCS
table with values which was more than block size and gp_use_fastanalyze was
enabled. The error manifested itself in the datumstreamread_nth function,
because largeObjectState was DatumStreamLargeObjectState_HaveAoContent.

The fast ANALYZE for AO tables implementation was got from Cloudberry (see
23aef441a827a77f3338e81950a0e66a26f6eaf7). Cloudberry calls aocs_gettuple first
time when a data block has not been read yet, because the required tuple may not
be in the first block. Cloudberry skips reading the block in
open_all_datumstreamread_segfiles when the SO_TYPE_ANALYZE flag is set
(when AOCSScanDesc is created in aoco_acquire_sample_rows). This skipping was
not backported to OpenGPDB later. The error is fixed with backporting of
the skipping.

The targrow field is used instead of flag to don't break ABI.

Pass AOCSScanDesc to open_all_datumstreamread_segfiles instead of fields of this
structure.