### PR TITLE
Fix segfault when two SIGTERMs come

### DIFF
--- a/src/backend/replication/walreceiver.c
+++ b/src/backend/replication/walreceiver.c
@@ -777,19 +777,26 @@ WalRcvSigUsr1Handler(SIGNAL_ARGS)
 static void
 WalRcvShutdownHandler(SIGNAL_ARGS)
 {
-	int			save_errno = errno;
-
 	got_SIGTERM = true;
 
 	/*
-	 * The call of SetLatch(&WalRcv->latch) in SIGTERM handler
-	 * is changed to SetLatch(&MyProc->procLatch) due to it
-	 * can't be protected by SpinLock in the signal handler as
-	 * it could cause a deadlock.
+	 * MyProc is NULL when the process has already run the AuxiliaryProcKill
+	 * exit handler
 	 */
-	SetLatch(&MyProc->procLatch);
+	if (MyProc != NULL)
+	{
+		int			save_errno = errno;
 
-	errno = save_errno;
+		/*
+		 * The call of SetLatch(&WalRcv->latch) in SIGTERM handler
+		 * is changed to SetLatch(&MyProc->procLatch) due to it
+		 * can't be protected by SpinLock in the signal handler as
+		 * it could cause a deadlock.
+		 */
+		SetLatch(&MyProc->procLatch);
+
+		errno = save_errno;
+	}
 }
 
 /*


### PR DESCRIPTION
When WAL receiver gets SIGTERM the WalRcvShutdownHandler function is called
where the got_SIGTERM flag is set. Then got_SIGTERM is checked in
ProcessWalRcvInterrupts and FATAL is passed to ereport. It leads to calling of
proc_exit and AuxiliaryProcKill where MyProc become NULL.

Segfault occurred in SetLatch called from WalRcvShutdownHandler when SIGTERM
came again and MyProc had already been NULL.

Don't call SetLatch when MyProc is NULL. Save errno only when SetLatch is called
because errno doesn't change otherwise.