### PR TITLE
[yagp_hooks_collector] Fix sigsegv during edata access

### DIFF
--- a/gpcontrib/yagp_hooks_collector/src/EventSender.cpp
+++ b/gpcontrib/yagp_hooks_collector/src/EventSender.cpp
@@ -263,7 +263,7 @@ void EventSender::report_query_done(QueryDesc *query_desc, QueryItem &query,
   query_msg->set_query_status(query_status);
   if (status == METRICS_QUERY_ERROR) {
     bool error_flushed = elog_message() == NULL;
-    if (error_flushed && edata->message == NULL) {
+    if (error_flushed && (edata == NULL || edata->message == NULL)) {
       ereport(WARNING, (errmsg("YAGPCC missing error message")));
       ereport(DEBUG3,
               (errmsg("YAGPCC query sourceText: %s", query_desc->sourceText)));


### PR DESCRIPTION
We faced an issue - segments fail with backtrace
```
#7  0x00007f9b2adbf2e0 in set_qi_error_message (req=0x55f24a6011f0) at src/ProtoUtils.cpp:124
#8  0x00007f9b2adc30d9 in EventSender::collect_query_done (this=0x55f24a5489f0, query_desc=0x55f24a71ca68, status=METRICS_QUERY_ERROR) at src/EventSender.cpp:222
#9  0x00007f9b2adc23e1 in EventSender::query_metrics_collect (this=0x55f24a5489f0, status=METRICS_QUERY_ERROR, arg=0x55f24a71ca68) at src/EventSender.cpp:53
```
the root cause here is we're trying to send info about error message in a hooks collector. For some queries ErrorData struckture could be NULL despite the fact that an error has occurred. it depends on error type and location of the error. So we should check if we had info about error details before using it. 