### PR TITLE
Fix gpexpand not changing content-id for wal-g cmd

### DIFF
--- a/gpMgmt/bin/lib/gpconfigurenewsegment
+++ b/gpMgmt/bin/lib/gpconfigurenewsegment
@@ -9,7 +9,7 @@ import shutil
 from optparse import Option, OptionGroup, OptionParser, OptionValueError, SUPPRESS_USAGE
 
 from gppylib.gpparseopts import OptParser, OptChecker
-from gppylib.commands.gp import ModifyConfSetting, SegmentStart, SegmentStop
+from gppylib.commands.gp import GpConfigHelper, ModifyConfSetting, SegmentStart, SegmentStop
 from gppylib.commands.pg import PgBaseBackup
 from gppylib.db import dbconn
 from gppylib.commands import unix
@@ -244,6 +244,24 @@ class ConfExpSegCmd(Command):
                 except:
                     self.set_results(modifyConfCmd.get_results())
                     raise
+
+                # Update --content-id flag in wal-g for archive-restore GUCs if present
+                for guc in ['archive_command', 'restore_command_hint']:
+                    read_cmd = GpConfigHelper('Read %s' % guc, self.datadir, guc, getParameter=True)
+                    read_cmd.run(validateAfter=True)
+
+                    val = read_cmd.get_value()
+                    if not read_cmd.was_successful() or not val:
+                        continue
+
+                    new_val = re.sub(r'(--content-id(?:=|\s+))-?\d+', r'\g<1>' + str(self.contentid), val)
+                    if new_val != val:
+                        write_cmd = GpConfigHelper('Update %s' % guc, self.datadir, guc, value=new_val)
+                        try:
+                            write_cmd.run(validateAfter=True)
+                        except Exception:
+                            self.set_results(write_cmd.get_results())
+                            raise
 
             # We might need to stop the segment if the last setup failed past this point
             if os.path.exists('%s/postmaster.pid' % self.datadir):

--- a/src/test/isolation2/expected/gpexpand_archive_restore_conf.out
+++ b/src/test/isolation2/expected/gpexpand_archive_restore_conf.out
@@ -1,0 +1,966 @@
+-- Verify that gpexpand correctly updates segment-specific flags for wal-g in
+-- archive_command and restore_command_hint when initializing new segments.
+--
+-- Previously, these GUCs were copied verbatim from the template segment
+-- (content 0), causing new segments to invoke archiving with an incorrect
+-- content-id (possible overwriting archive or restoring other's data).
+
+-- Cleanup any previous state
+!\retcode yes | gpexpand -c;
+-- start_ignore
+20260217:07:55:15:867274 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 6.28.8-python+dev.197.g05e6484876 build dev'
+20260217:07:55:16:867274 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 9.4.26 (Greenplum Database 6.28.8-python+dev.197.g05e6484876 build dev) on x86_64-unknown-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04.2) 11.4.0, 64-bit compiled on Feb 12 2026 14:27:36 (with assert checking)'
+20260217:07:55:16:867274 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Querying gpexpand schema for current expansion state
+
+System Expansion is used to add segments to an existing GPDB array.
+gpexpand did not detect a System Expansion that is in progress.
+
+Before initiating a System Expansion, you need to provision and burn-in
+the new hardware.  Please be sure to run gpcheckperf to make sure the
+new hardware is working properly.
+
+Please refer to the Admin Guide for more information.
+
+Would you like to initiate a new System Expansion Yy|Nn (default=N):
+> 
+Enter a comma separated list of new hosts you want
+to add to your array.  Do not include interface hostnames.
+**Enter a blank line to only add segments to existing hosts**[]:
+> 20260217:07:55:16:867274 gpexpand:da6db2bb5ee4:gpadmin-[ERROR]:-gpexpand failed: You must be adding two or more hosts when expanding a system with mirroring enabled. 
+
+Exiting...
+20260217:07:55:16:867274 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Shutting down gpexpand...
+yes: standard output: Broken pipe
+
+-- end_ignore
+(exited with code 3)
+!\retcode gpshrink -c;
+-- start_ignore
+20260217:07:55:16:867316 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 6.28.8-python+dev.197.g05e6484876 build dev'
+20260217:07:55:16:867316 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 9.4.26 (Greenplum Database 6.28.8-python+dev.197.g05e6484876 build dev) on x86_64-unknown-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04.2) 11.4.0, 64-bit compiled on Feb 12 2026 14:27:36 (with assert checking)'
+20260217:07:55:17:867316 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Removing gpshrink schema
+20260217:07:55:17:867316 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Cleanup Finished.  exiting...
+
+-- end_ignore
+(exited with code 0)
+!\retcode rm -r /tmp/datadirs/;
+-- start_ignore
+rm: cannot remove '/tmp/datadirs/': No such file or directory
+
+-- end_ignore
+(exited with code 1)
+
+-- Set GUCs on all segments, hardcode --content-id to 0
+!\retcode gpconfig -c restore_command_hint -v '/bin/true';
+-- start_ignore
+20260217:07:55:18:867392 gpconfig:da6db2bb5ee4:gpadmin-[INFO]:-completed successfully with parameters '-c restore_command_hint -v /bin/true'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpconfig -c archive_command -v 'wal-g seg wal-push %p --content-id=0';
+-- start_ignore
+20260217:07:55:18:867566 gpconfig:da6db2bb5ee4:gpadmin-[INFO]:-completed successfully with parameters '-c archive_command -v 'wal-g seg wal-push %p --content-id=0''
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
+-- start_ignore
+20260217:07:55:18:867753 gpstop:da6db2bb5ee4:gpadmin-[INFO]:-Starting gpstop with args: -u
+20260217:07:55:18:867753 gpstop:da6db2bb5ee4:gpadmin-[INFO]:-Gathering information and validating the environment...
+20260217:07:55:18:867753 gpstop:da6db2bb5ee4:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
+20260217:07:55:18:867753 gpstop:da6db2bb5ee4:gpadmin-[INFO]:-Obtaining Segment details from master...
+20260217:07:55:19:867753 gpstop:da6db2bb5ee4:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.28.8-python+dev.197.g05e6484876 build dev'
+20260217:07:55:19:867753 gpstop:da6db2bb5ee4:gpadmin-[INFO]:-Signalling all postmaster processes to reload
+
+-- end_ignore
+(exited with code 0)
+
+-- Prepare expansion configuration
+!\retcode echo "localhost|localhost|7008|/tmp/datadirs/dbfast4/demoDataDir3|9|3|p localhost|localhost|7009|/tmp/datadirs/dbfast_mirror4/demoDataDir3|10|3|m" > /tmp/testexpand;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+-- Expand
+!\retcode gpexpand -i /tmp/testexpand;
+-- start_ignore
+20260217:07:55:19:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 6.28.8-python+dev.197.g05e6484876 build dev'
+20260217:07:55:19:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 9.4.26 (Greenplum Database 6.28.8-python+dev.197.g05e6484876 build dev) on x86_64-unknown-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04.2) 11.4.0, 64-bit compiled on Feb 12 2026 14:27:36 (with assert checking)'
+20260217:07:55:19:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Querying gpexpand schema for current expansion state
+20260217:07:55:20:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Successfully finished pg_controldata /home/gpadmin/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0 for dbid 2:
+stdout: pg_control version number:            9420600
+Catalog version number:               301908232
+Database system identifier:           7607734725579485657
+Database cluster state:               in production
+pg_control last modified:             Tue 17 Feb 2026 07:55:15 AM GMT
+Latest checkpoint location:           0/C2E0168
+Prior checkpoint location:            0/C2E00B8
+Latest checkpoint's REDO location:    0/C2E0168
+Latest checkpoint's REDO WAL file:    000000010000000000000003
+Latest checkpoint's TimeLineID:       1
+Latest checkpoint's PrevTimeLineID:   1
+Latest checkpoint's full_page_writes: on
+Latest checkpoint's NextXID:          0/807
+Latest checkpoint's NextOID:          57351
+Latest checkpoint's NextRelfilenode:  24576
+Latest checkpoint's NextMultiXactId:  1
+Latest checkpoint's NextMultiOffset:  0
+Latest checkpoint's oldestXID:        702
+Latest checkpoint's oldestXID's DB:   1
+Latest checkpoint's oldestActiveXID:  0
+Latest checkpoint's oldestMultiXid:   1
+Latest checkpoint's oldestMulti's DB: 1
+Time of latest checkpoint:            Tue 17 Feb 2026 07:55:15 AM GMT
+Fake LSN counter for unlogged rels:   0/1
+Minimum recovery ending location:     0/0
+Min recovery ending loc's timeline:   0
+Backup start location:                0/0
+Backup end location:                  0/0
+End-of-backup record required:        no
+Current wal_level setting:            archive
+Current wal_log_hints setting:        off
+Current max_connections setting:      750
+Current max_worker_processes setting: 14
+Current max_prepared_xacts setting:   250
+Current max_locks_per_xact setting:   128
+Maximum data alignment:               8
+Database block size:                  32768
+Blocks per segment of large relation: 32768
+WAL block size:                       32768
+Bytes per WAL segment:                67108864
+Maximum length of identifiers:        64
+Maximum columns in an index:          32
+Maximum size of a TOAST chunk:        8140
+Size of a large-object chunk:         8192
+Date/time type storage:               64-bit integers
+Float4 argument passing:              by value
+Float8 argument passing:              by value
+Data page checksum version:           1
+
+stderr: 
+20260217:07:55:20:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Successfully finished pg_controldata /home/gpadmin/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror1/demoDataDir0 for dbid 5:
+stdout: pg_control version number:            9420600
+Catalog version number:               301908232
+Database system identifier:           7607734725579485657
+Database cluster state:               in archive recovery
+pg_control last modified:             Tue 17 Feb 2026 07:51:43 AM GMT
+Latest checkpoint location:           0/C16B498
+Prior checkpoint location:            0/C0A5D08
+Latest checkpoint's REDO location:    0/C16B498
+Latest checkpoint's REDO WAL file:    000000010000000000000003
+Latest checkpoint's TimeLineID:       1
+Latest checkpoint's PrevTimeLineID:   1
+Latest checkpoint's full_page_writes: on
+Latest checkpoint's NextXID:          0/786
+Latest checkpoint's NextOID:          40965
+Latest checkpoint's NextRelfilenode:  24576
+Latest checkpoint's NextMultiXactId:  1
+Latest checkpoint's NextMultiOffset:  0
+Latest checkpoint's oldestXID:        702
+Latest checkpoint's oldestXID's DB:   1
+Latest checkpoint's oldestActiveXID:  0
+Latest checkpoint's oldestMultiXid:   1
+Latest checkpoint's oldestMulti's DB: 1
+Time of latest checkpoint:            Tue 17 Feb 2026 07:50:51 AM GMT
+Fake LSN counter for unlogged rels:   0/1
+Minimum recovery ending location:     0/C2DE9B0
+Min recovery ending loc's timeline:   1
+Backup start location:                0/0
+Backup end location:                  0/0
+End-of-backup record required:        no
+Current wal_level setting:            archive
+Current wal_log_hints setting:        off
+Current max_connections setting:      750
+Current max_worker_processes setting: 14
+Current max_prepared_xacts setting:   250
+Current max_locks_per_xact setting:   128
+Maximum data alignment:               8
+Database block size:                  32768
+Blocks per segment of large relation: 32768
+WAL block size:                       32768
+Bytes per WAL segment:                67108864
+Maximum length of identifiers:        64
+Maximum columns in an index:          32
+Maximum size of a TOAST chunk:        8140
+Size of a large-object chunk:         8192
+Date/time type storage:               64-bit integers
+Float4 argument passing:              by value
+Float8 argument passing:              by value
+Data page checksum version:           1
+
+stderr: 
+20260217:07:55:20:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Successfully finished pg_controldata /home/gpadmin/gpdb/gpAux/gpdemo/datadirs/dbfast2/demoDataDir1 for dbid 3:
+stdout: pg_control version number:            9420600
+Catalog version number:               301908232
+Database system identifier:           7607734725473739221
+Database cluster state:               in production
+pg_control last modified:             Tue 17 Feb 2026 07:55:15 AM GMT
+Latest checkpoint location:           0/C2DFE90
+Prior checkpoint location:            0/C2DFDE0
+Latest checkpoint's REDO location:    0/C2DFE90
+Latest checkpoint's REDO WAL file:    000000010000000000000003
+Latest checkpoint's TimeLineID:       1
+Latest checkpoint's PrevTimeLineID:   1
+Latest checkpoint's full_page_writes: on
+Latest checkpoint's NextXID:          0/812
+Latest checkpoint's NextOID:          57351
+Latest checkpoint's NextRelfilenode:  24576
+Latest checkpoint's NextMultiXactId:  1
+Latest checkpoint's NextMultiOffset:  0
+Latest checkpoint's oldestXID:        702
+Latest checkpoint's oldestXID's DB:   1
+Latest checkpoint's oldestActiveXID:  0
+Latest checkpoint's oldestMultiXid:   1
+Latest checkpoint's oldestMulti's DB: 1
+Time of latest checkpoint:            Tue 17 Feb 2026 07:55:15 AM GMT
+Fake LSN counter for unlogged rels:   0/1
+Minimum recovery ending location:     0/0
+Min recovery ending loc's timeline:   0
+Backup start location:                0/0
+Backup end location:                  0/0
+End-of-backup record required:        no
+Current wal_level setting:            archive
+Current wal_log_hints setting:        off
+Current max_connections setting:      750
+Current max_worker_processes setting: 14
+Current max_prepared_xacts setting:   250
+Current max_locks_per_xact setting:   128
+Maximum data alignment:               8
+Database block size:                  32768
+Blocks per segment of large relation: 32768
+WAL block size:                       32768
+Bytes per WAL segment:                67108864
+Maximum length of identifiers:        64
+Maximum columns in an index:          32
+Maximum size of a TOAST chunk:        8140
+Size of a large-object chunk:         8192
+Date/time type storage:               64-bit integers
+Float4 argument passing:              by value
+Float8 argument passing:              by value
+Data page checksum version:           1
+
+stderr: 
+20260217:07:55:20:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Successfully finished pg_controldata /home/gpadmin/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror2/demoDataDir1 for dbid 6:
+stdout: pg_control version number:            9420600
+Catalog version number:               301908232
+Database system identifier:           7607734725473739221
+Database cluster state:               in archive recovery
+pg_control last modified:             Tue 17 Feb 2026 07:51:43 AM GMT
+Latest checkpoint location:           0/C16AB68
+Prior checkpoint location:            0/C0A58C8
+Latest checkpoint's REDO location:    0/C16AB68
+Latest checkpoint's REDO WAL file:    000000010000000000000003
+Latest checkpoint's TimeLineID:       1
+Latest checkpoint's PrevTimeLineID:   1
+Latest checkpoint's full_page_writes: on
+Latest checkpoint's NextXID:          0/787
+Latest checkpoint's NextOID:          40965
+Latest checkpoint's NextRelfilenode:  24576
+Latest checkpoint's NextMultiXactId:  1
+Latest checkpoint's NextMultiOffset:  0
+Latest checkpoint's oldestXID:        702
+Latest checkpoint's oldestXID's DB:   1
+Latest checkpoint's oldestActiveXID:  0
+Latest checkpoint's oldestMultiXid:   1
+Latest checkpoint's oldestMulti's DB: 1
+Time of latest checkpoint:            Tue 17 Feb 2026 07:50:51 AM GMT
+Fake LSN counter for unlogged rels:   0/1
+Minimum recovery ending location:     0/C2DE6F0
+Min recovery ending loc's timeline:   1
+Backup start location:                0/0
+Backup end location:                  0/0
+End-of-backup record required:        no
+Current wal_level setting:            archive
+Current wal_log_hints setting:        off
+Current max_connections setting:      750
+Current max_worker_processes setting: 14
+Current max_prepared_xacts setting:   250
+Current max_locks_per_xact setting:   128
+Maximum data alignment:               8
+Database block size:                  32768
+Blocks per segment of large relation: 32768
+WAL block size:                       32768
+Bytes per WAL segment:                67108864
+Maximum length of identifiers:        64
+Maximum columns in an index:          32
+Maximum size of a TOAST chunk:        8140
+Size of a large-object chunk:         8192
+Date/time type storage:               64-bit integers
+Float4 argument passing:              by value
+Float8 argument passing:              by value
+Data page checksum version:           1
+
+stderr: 
+20260217:07:55:20:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Successfully finished pg_controldata /home/gpadmin/gpdb/gpAux/gpdemo/datadirs/dbfast3/demoDataDir2 for dbid 4:
+stdout: pg_control version number:            9420600
+Catalog version number:               301908232
+Database system identifier:           7607734725488865751
+Database cluster state:               in production
+pg_control last modified:             Tue 17 Feb 2026 07:55:15 AM GMT
+Latest checkpoint location:           0/C2DF5E0
+Prior checkpoint location:            0/C2DF530
+Latest checkpoint's REDO location:    0/C2DF5E0
+Latest checkpoint's REDO WAL file:    000000010000000000000003
+Latest checkpoint's TimeLineID:       1
+Latest checkpoint's PrevTimeLineID:   1
+Latest checkpoint's full_page_writes: on
+Latest checkpoint's NextXID:          0/815
+Latest checkpoint's NextOID:          57351
+Latest checkpoint's NextRelfilenode:  24576
+Latest checkpoint's NextMultiXactId:  1
+Latest checkpoint's NextMultiOffset:  0
+Latest checkpoint's oldestXID:        702
+Latest checkpoint's oldestXID's DB:   1
+Latest checkpoint's oldestActiveXID:  0
+Latest checkpoint's oldestMultiXid:   1
+Latest checkpoint's oldestMulti's DB: 1
+Time of latest checkpoint:            Tue 17 Feb 2026 07:55:15 AM GMT
+Fake LSN counter for unlogged rels:   0/1
+Minimum recovery ending location:     0/0
+Min recovery ending loc's timeline:   0
+Backup start location:                0/0
+Backup end location:                  0/0
+End-of-backup record required:        no
+Current wal_level setting:            archive
+Current wal_log_hints setting:        off
+Current max_connections setting:      750
+Current max_worker_processes setting: 14
+Current max_prepared_xacts setting:   250
+Current max_locks_per_xact setting:   128
+Maximum data alignment:               8
+Database block size:                  32768
+Blocks per segment of large relation: 32768
+WAL block size:                       32768
+Bytes per WAL segment:                67108864
+Maximum length of identifiers:        64
+Maximum columns in an index:          32
+Maximum size of a TOAST chunk:        8140
+Size of a large-object chunk:         8192
+Date/time type storage:               64-bit integers
+Float4 argument passing:              by value
+Float8 argument passing:              by value
+Data page checksum version:           1
+
+stderr: 
+20260217:07:55:20:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Successfully finished pg_controldata /home/gpadmin/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror3/demoDataDir2 for dbid 7:
+stdout: pg_control version number:            9420600
+Catalog version number:               301908232
+Database system identifier:           7607734725488865751
+Database cluster state:               in archive recovery
+pg_control last modified:             Tue 17 Feb 2026 07:51:43 AM GMT
+Latest checkpoint location:           0/C16AD88
+Prior checkpoint location:            0/C0A5C28
+Latest checkpoint's REDO location:    0/C16AD88
+Latest checkpoint's REDO WAL file:    000000010000000000000003
+Latest checkpoint's TimeLineID:       1
+Latest checkpoint's PrevTimeLineID:   1
+Latest checkpoint's full_page_writes: on
+Latest checkpoint's NextXID:          0/793
+Latest checkpoint's NextOID:          40965
+Latest checkpoint's NextRelfilenode:  24576
+Latest checkpoint's NextMultiXactId:  1
+Latest checkpoint's NextMultiOffset:  0
+Latest checkpoint's oldestXID:        702
+Latest checkpoint's oldestXID's DB:   1
+Latest checkpoint's oldestActiveXID:  0
+Latest checkpoint's oldestMultiXid:   1
+Latest checkpoint's oldestMulti's DB: 1
+Time of latest checkpoint:            Tue 17 Feb 2026 07:50:51 AM GMT
+Fake LSN counter for unlogged rels:   0/1
+Minimum recovery ending location:     0/C2DDE40
+Min recovery ending loc's timeline:   1
+Backup start location:                0/0
+Backup end location:                  0/0
+End-of-backup record required:        no
+Current wal_level setting:            archive
+Current wal_log_hints setting:        off
+Current max_connections setting:      750
+Current max_worker_processes setting: 14
+Current max_prepared_xacts setting:   250
+Current max_locks_per_xact setting:   128
+Maximum data alignment:               8
+Database block size:                  32768
+Blocks per segment of large relation: 32768
+WAL block size:                       32768
+Bytes per WAL segment:                67108864
+Maximum length of identifiers:        64
+Maximum columns in an index:          32
+Maximum size of a TOAST chunk:        8140
+Size of a large-object chunk:         8192
+Date/time type storage:               64-bit integers
+Float4 argument passing:              by value
+Float8 argument passing:              by value
+Data page checksum version:           1
+
+stderr: 
+20260217:07:55:20:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Heap checksum setting consistent across cluster
+20260217:07:55:20:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Syncing Greenplum Database extensions
+20260217:07:55:21:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-The packages on localhost are consistent.
+20260217:07:55:21:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Locking catalog
+20260217:07:55:21:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Locked catalog
+20260217:07:55:21:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Creating segment template
+20260217:07:55:22:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Copying postgresql.conf from existing segment into template
+20260217:07:55:23:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Copying pg_hba.conf from existing segment into template
+20260217:07:55:23:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Creating schema tar file
+20260217:07:55:23:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Distributing template tar file to new hosts
+20260217:07:55:24:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Configuring new segments (primary)
+20260217:07:55:24:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-{'localhost': '/tmp/datadirs/dbfast4/demoDataDir3:7008:true:false:9:3::-1:'}
+20260217:07:55:25:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Cleaning up temporary template files
+20260217:07:55:26:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Cleaning up databases in new segments.
+20260217:07:55:27:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Unlocking catalog
+20260217:07:55:27:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Unlocked catalog
+20260217:07:55:27:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Creating expansion schema
+20260217:07:55:28:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Populating gpexpand.status_detail with data from database template1
+20260217:07:55:28:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Populating gpexpand.status_detail with data from database postgres
+20260217:07:55:29:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Populating gpexpand.status_detail with data from database isolation2test
+20260217:07:55:30:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Starting new mirror segment synchronization
+20260217:07:55:35:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-************************************************
+20260217:07:55:35:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Initialization of the system expansion complete.
+20260217:07:55:35:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-To begin table expansion onto the new segments
+20260217:07:55:35:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-rerun gpexpand
+20260217:07:55:35:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-************************************************
+20260217:07:55:35:867781 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Exiting...
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpexpand -i /tmp/testexpand;
+-- start_ignore
+20260217:07:55:35:869174 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 6.28.8-python+dev.197.g05e6484876 build dev'
+20260217:07:55:35:869174 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 9.4.26 (Greenplum Database 6.28.8-python+dev.197.g05e6484876 build dev) on x86_64-unknown-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04.2) 11.4.0, 64-bit compiled on Feb 12 2026 14:27:36 (with assert checking)'
+20260217:07:55:35:869174 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Querying gpexpand schema for current expansion state
+20260217:07:55:36:869174 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-EXPANSION COMPLETED SUCCESSFULLY
+20260217:07:55:36:869174 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Exiting...
+
+-- end_ignore
+(exited with code 0)
+
+-- Get the new segment's datadir (content=3)
+!\retcode psql -d postgres -Aqt -c "SELECT datadir FROM gp_segment_configuration WHERE content = 3 AND role = 'p'" > /tmp/new_segment_datadir;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+-- Confirm that the --content-id flag within archive_command has been
+-- updated to match the new segment's content. The restore_command_hint
+-- lacks --content-id flag and should be unchanged.
+! grep "^archive_command" $(cat /tmp/new_segment_datadir)/postgresql.conf;
+archive_command='wal-g seg wal-push %p --content-id=3'
+
+! grep "^restore_command_hint" $(cat /tmp/new_segment_datadir)/postgresql.conf;
+restore_command_hint='/bin/true'
+
+
+-- Cleanup
+!\retcode gpconfig -r restore_command_hint;
+-- start_ignore
+20260217:07:55:37:869236 gpconfig:da6db2bb5ee4:gpadmin-[INFO]:-completed successfully with parameters '-r restore_command_hint'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpconfig -r archive_command;
+-- start_ignore
+20260217:07:55:38:869466 gpconfig:da6db2bb5ee4:gpadmin-[INFO]:-completed successfully with parameters '-r archive_command'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -u;
+-- start_ignore
+20260217:07:55:38:869702 gpstop:da6db2bb5ee4:gpadmin-[INFO]:-Starting gpstop with args: -u
+20260217:07:55:38:869702 gpstop:da6db2bb5ee4:gpadmin-[INFO]:-Gathering information and validating the environment...
+20260217:07:55:38:869702 gpstop:da6db2bb5ee4:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
+20260217:07:55:38:869702 gpstop:da6db2bb5ee4:gpadmin-[INFO]:-Obtaining Segment details from master...
+20260217:07:55:38:869702 gpstop:da6db2bb5ee4:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.28.8-python+dev.197.g05e6484876 build dev'
+20260217:07:55:38:869702 gpstop:da6db2bb5ee4:gpadmin-[INFO]:-Signalling all postmaster processes to reload
+
+-- end_ignore
+(exited with code 0)
+
+!\retcode gpshrink -i /tmp/testexpand;
+-- start_ignore
+20260217:07:55:39:869765 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 6.28.8-python+dev.197.g05e6484876 build dev'
+20260217:07:55:39:869765 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 9.4.26 (Greenplum Database 6.28.8-python+dev.197.g05e6484876 build dev) on x86_64-unknown-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04.2) 11.4.0, 64-bit compiled on Feb 12 2026 14:27:36 (with assert checking)'
+20260217:07:55:40:869765 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Successfully finished pg_controldata /home/gpadmin/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0 for dbid 2:
+stdout: pg_control version number:            9420600
+Catalog version number:               301908232
+Database system identifier:           7607734725579485657
+Database cluster state:               in production
+pg_control last modified:             Tue 17 Feb 2026 07:55:15 AM GMT
+Latest checkpoint location:           0/C2E0168
+Prior checkpoint location:            0/C2E00B8
+Latest checkpoint's REDO location:    0/C2E0168
+Latest checkpoint's REDO WAL file:    000000010000000000000003
+Latest checkpoint's TimeLineID:       1
+Latest checkpoint's PrevTimeLineID:   1
+Latest checkpoint's full_page_writes: on
+Latest checkpoint's NextXID:          0/807
+Latest checkpoint's NextOID:          57351
+Latest checkpoint's NextRelfilenode:  24576
+Latest checkpoint's NextMultiXactId:  1
+Latest checkpoint's NextMultiOffset:  0
+Latest checkpoint's oldestXID:        702
+Latest checkpoint's oldestXID's DB:   1
+Latest checkpoint's oldestActiveXID:  0
+Latest checkpoint's oldestMultiXid:   1
+Latest checkpoint's oldestMulti's DB: 1
+Time of latest checkpoint:            Tue 17 Feb 2026 07:55:15 AM GMT
+Fake LSN counter for unlogged rels:   0/1
+Minimum recovery ending location:     0/0
+Min recovery ending loc's timeline:   0
+Backup start location:                0/0
+Backup end location:                  0/0
+End-of-backup record required:        no
+Current wal_level setting:            archive
+Current wal_log_hints setting:        off
+Current max_connections setting:      750
+Current max_worker_processes setting: 14
+Current max_prepared_xacts setting:   250
+Current max_locks_per_xact setting:   128
+Maximum data alignment:               8
+Database block size:                  32768
+Blocks per segment of large relation: 32768
+WAL block size:                       32768
+Bytes per WAL segment:                67108864
+Maximum length of identifiers:        64
+Maximum columns in an index:          32
+Maximum size of a TOAST chunk:        8140
+Size of a large-object chunk:         8192
+Date/time type storage:               64-bit integers
+Float4 argument passing:              by value
+Float8 argument passing:              by value
+Data page checksum version:           1
+
+stderr: 
+20260217:07:55:40:869765 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Successfully finished pg_controldata /home/gpadmin/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror1/demoDataDir0 for dbid 5:
+stdout: pg_control version number:            9420600
+Catalog version number:               301908232
+Database system identifier:           7607734725579485657
+Database cluster state:               in archive recovery
+pg_control last modified:             Tue 17 Feb 2026 07:51:43 AM GMT
+Latest checkpoint location:           0/C16B498
+Prior checkpoint location:            0/C0A5D08
+Latest checkpoint's REDO location:    0/C16B498
+Latest checkpoint's REDO WAL file:    000000010000000000000003
+Latest checkpoint's TimeLineID:       1
+Latest checkpoint's PrevTimeLineID:   1
+Latest checkpoint's full_page_writes: on
+Latest checkpoint's NextXID:          0/786
+Latest checkpoint's NextOID:          40965
+Latest checkpoint's NextRelfilenode:  24576
+Latest checkpoint's NextMultiXactId:  1
+Latest checkpoint's NextMultiOffset:  0
+Latest checkpoint's oldestXID:        702
+Latest checkpoint's oldestXID's DB:   1
+Latest checkpoint's oldestActiveXID:  0
+Latest checkpoint's oldestMultiXid:   1
+Latest checkpoint's oldestMulti's DB: 1
+Time of latest checkpoint:            Tue 17 Feb 2026 07:50:51 AM GMT
+Fake LSN counter for unlogged rels:   0/1
+Minimum recovery ending location:     0/C2DE9B0
+Min recovery ending loc's timeline:   1
+Backup start location:                0/0
+Backup end location:                  0/0
+End-of-backup record required:        no
+Current wal_level setting:            archive
+Current wal_log_hints setting:        off
+Current max_connections setting:      750
+Current max_worker_processes setting: 14
+Current max_prepared_xacts setting:   250
+Current max_locks_per_xact setting:   128
+Maximum data alignment:               8
+Database block size:                  32768
+Blocks per segment of large relation: 32768
+WAL block size:                       32768
+Bytes per WAL segment:                67108864
+Maximum length of identifiers:        64
+Maximum columns in an index:          32
+Maximum size of a TOAST chunk:        8140
+Size of a large-object chunk:         8192
+Date/time type storage:               64-bit integers
+Float4 argument passing:              by value
+Float8 argument passing:              by value
+Data page checksum version:           1
+
+stderr: 
+20260217:07:55:40:869765 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Successfully finished pg_controldata /home/gpadmin/gpdb/gpAux/gpdemo/datadirs/dbfast2/demoDataDir1 for dbid 3:
+stdout: pg_control version number:            9420600
+Catalog version number:               301908232
+Database system identifier:           7607734725473739221
+Database cluster state:               in production
+pg_control last modified:             Tue 17 Feb 2026 07:55:15 AM GMT
+Latest checkpoint location:           0/C2DFE90
+Prior checkpoint location:            0/C2DFDE0
+Latest checkpoint's REDO location:    0/C2DFE90
+Latest checkpoint's REDO WAL file:    000000010000000000000003
+Latest checkpoint's TimeLineID:       1
+Latest checkpoint's PrevTimeLineID:   1
+Latest checkpoint's full_page_writes: on
+Latest checkpoint's NextXID:          0/812
+Latest checkpoint's NextOID:          57351
+Latest checkpoint's NextRelfilenode:  24576
+Latest checkpoint's NextMultiXactId:  1
+Latest checkpoint's NextMultiOffset:  0
+Latest checkpoint's oldestXID:        702
+Latest checkpoint's oldestXID's DB:   1
+Latest checkpoint's oldestActiveXID:  0
+Latest checkpoint's oldestMultiXid:   1
+Latest checkpoint's oldestMulti's DB: 1
+Time of latest checkpoint:            Tue 17 Feb 2026 07:55:15 AM GMT
+Fake LSN counter for unlogged rels:   0/1
+Minimum recovery ending location:     0/0
+Min recovery ending loc's timeline:   0
+Backup start location:                0/0
+Backup end location:                  0/0
+End-of-backup record required:        no
+Current wal_level setting:            archive
+Current wal_log_hints setting:        off
+Current max_connections setting:      750
+Current max_worker_processes setting: 14
+Current max_prepared_xacts setting:   250
+Current max_locks_per_xact setting:   128
+Maximum data alignment:               8
+Database block size:                  32768
+Blocks per segment of large relation: 32768
+WAL block size:                       32768
+Bytes per WAL segment:                67108864
+Maximum length of identifiers:        64
+Maximum columns in an index:          32
+Maximum size of a TOAST chunk:        8140
+Size of a large-object chunk:         8192
+Date/time type storage:               64-bit integers
+Float4 argument passing:              by value
+Float8 argument passing:              by value
+Data page checksum version:           1
+
+stderr: 
+20260217:07:55:40:869765 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Successfully finished pg_controldata /home/gpadmin/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror2/demoDataDir1 for dbid 6:
+stdout: pg_control version number:            9420600
+Catalog version number:               301908232
+Database system identifier:           7607734725473739221
+Database cluster state:               in archive recovery
+pg_control last modified:             Tue 17 Feb 2026 07:51:43 AM GMT
+Latest checkpoint location:           0/C16AB68
+Prior checkpoint location:            0/C0A58C8
+Latest checkpoint's REDO location:    0/C16AB68
+Latest checkpoint's REDO WAL file:    000000010000000000000003
+Latest checkpoint's TimeLineID:       1
+Latest checkpoint's PrevTimeLineID:   1
+Latest checkpoint's full_page_writes: on
+Latest checkpoint's NextXID:          0/787
+Latest checkpoint's NextOID:          40965
+Latest checkpoint's NextRelfilenode:  24576
+Latest checkpoint's NextMultiXactId:  1
+Latest checkpoint's NextMultiOffset:  0
+Latest checkpoint's oldestXID:        702
+Latest checkpoint's oldestXID's DB:   1
+Latest checkpoint's oldestActiveXID:  0
+Latest checkpoint's oldestMultiXid:   1
+Latest checkpoint's oldestMulti's DB: 1
+Time of latest checkpoint:            Tue 17 Feb 2026 07:50:51 AM GMT
+Fake LSN counter for unlogged rels:   0/1
+Minimum recovery ending location:     0/C2DE6F0
+Min recovery ending loc's timeline:   1
+Backup start location:                0/0
+Backup end location:                  0/0
+End-of-backup record required:        no
+Current wal_level setting:            archive
+Current wal_log_hints setting:        off
+Current max_connections setting:      750
+Current max_worker_processes setting: 14
+Current max_prepared_xacts setting:   250
+Current max_locks_per_xact setting:   128
+Maximum data alignment:               8
+Database block size:                  32768
+Blocks per segment of large relation: 32768
+WAL block size:                       32768
+Bytes per WAL segment:                67108864
+Maximum length of identifiers:        64
+Maximum columns in an index:          32
+Maximum size of a TOAST chunk:        8140
+Size of a large-object chunk:         8192
+Date/time type storage:               64-bit integers
+Float4 argument passing:              by value
+Float8 argument passing:              by value
+Data page checksum version:           1
+
+stderr: 
+20260217:07:55:40:869765 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Successfully finished pg_controldata /home/gpadmin/gpdb/gpAux/gpdemo/datadirs/dbfast_mirror3/demoDataDir2 for dbid 7:
+stdout: pg_control version number:            9420600
+Catalog version number:               301908232
+Database system identifier:           7607734725488865751
+Database cluster state:               in archive recovery
+pg_control last modified:             Tue 17 Feb 2026 07:51:43 AM GMT
+Latest checkpoint location:           0/C16AD88
+Prior checkpoint location:            0/C0A5C28
+Latest checkpoint's REDO location:    0/C16AD88
+Latest checkpoint's REDO WAL file:    000000010000000000000003
+Latest checkpoint's TimeLineID:       1
+Latest checkpoint's PrevTimeLineID:   1
+Latest checkpoint's full_page_writes: on
+Latest checkpoint's NextXID:          0/793
+Latest checkpoint's NextOID:          40965
+Latest checkpoint's NextRelfilenode:  24576
+Latest checkpoint's NextMultiXactId:  1
+Latest checkpoint's NextMultiOffset:  0
+Latest checkpoint's oldestXID:        702
+Latest checkpoint's oldestXID's DB:   1
+Latest checkpoint's oldestActiveXID:  0
+Latest checkpoint's oldestMultiXid:   1
+Latest checkpoint's oldestMulti's DB: 1
+Time of latest checkpoint:            Tue 17 Feb 2026 07:50:51 AM GMT
+Fake LSN counter for unlogged rels:   0/1
+Minimum recovery ending location:     0/C2DDE40
+Min recovery ending loc's timeline:   1
+Backup start location:                0/0
+Backup end location:                  0/0
+End-of-backup record required:        no
+Current wal_level setting:            archive
+Current wal_log_hints setting:        off
+Current max_connections setting:      750
+Current max_worker_processes setting: 14
+Current max_prepared_xacts setting:   250
+Current max_locks_per_xact setting:   128
+Maximum data alignment:               8
+Database block size:                  32768
+Blocks per segment of large relation: 32768
+WAL block size:                       32768
+Bytes per WAL segment:                67108864
+Maximum length of identifiers:        64
+Maximum columns in an index:          32
+Maximum size of a TOAST chunk:        8140
+Size of a large-object chunk:         8192
+Date/time type storage:               64-bit integers
+Float4 argument passing:              by value
+Float8 argument passing:              by value
+Data page checksum version:           1
+
+stderr: 
+20260217:07:55:40:869765 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Successfully finished pg_controldata /home/gpadmin/gpdb/gpAux/gpdemo/datadirs/dbfast3/demoDataDir2 for dbid 4:
+stdout: pg_control version number:            9420600
+Catalog version number:               301908232
+Database system identifier:           7607734725488865751
+Database cluster state:               in production
+pg_control last modified:             Tue 17 Feb 2026 07:55:15 AM GMT
+Latest checkpoint location:           0/C2DF5E0
+Prior checkpoint location:            0/C2DF530
+Latest checkpoint's REDO location:    0/C2DF5E0
+Latest checkpoint's REDO WAL file:    000000010000000000000003
+Latest checkpoint's TimeLineID:       1
+Latest checkpoint's PrevTimeLineID:   1
+Latest checkpoint's full_page_writes: on
+Latest checkpoint's NextXID:          0/815
+Latest checkpoint's NextOID:          57351
+Latest checkpoint's NextRelfilenode:  24576
+Latest checkpoint's NextMultiXactId:  1
+Latest checkpoint's NextMultiOffset:  0
+Latest checkpoint's oldestXID:        702
+Latest checkpoint's oldestXID's DB:   1
+Latest checkpoint's oldestActiveXID:  0
+Latest checkpoint's oldestMultiXid:   1
+Latest checkpoint's oldestMulti's DB: 1
+Time of latest checkpoint:            Tue 17 Feb 2026 07:55:15 AM GMT
+Fake LSN counter for unlogged rels:   0/1
+Minimum recovery ending location:     0/0
+Min recovery ending loc's timeline:   0
+Backup start location:                0/0
+Backup end location:                  0/0
+End-of-backup record required:        no
+Current wal_level setting:            archive
+Current wal_log_hints setting:        off
+Current max_connections setting:      750
+Current max_worker_processes setting: 14
+Current max_prepared_xacts setting:   250
+Current max_locks_per_xact setting:   128
+Maximum data alignment:               8
+Database block size:                  32768
+Blocks per segment of large relation: 32768
+WAL block size:                       32768
+Bytes per WAL segment:                67108864
+Maximum length of identifiers:        64
+Maximum columns in an index:          32
+Maximum size of a TOAST chunk:        8140
+Size of a large-object chunk:         8192
+Date/time type storage:               64-bit integers
+Float4 argument passing:              by value
+Float8 argument passing:              by value
+Data page checksum version:           1
+
+stderr: 
+20260217:07:55:40:869765 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Successfully finished pg_controldata /tmp/datadirs/dbfast4/demoDataDir3 for dbid 9:
+stdout: pg_control version number:            9420600
+Catalog version number:               301908232
+Database system identifier:           7607734669120621985
+Database cluster state:               in production
+pg_control last modified:             Tue 17 Feb 2026 07:55:33 AM GMT
+Latest checkpoint location:           0/38000028
+Prior checkpoint location:            0/340000E0
+Latest checkpoint's REDO location:    0/38000028
+Latest checkpoint's REDO WAL file:    00000001000000000000000E
+Latest checkpoint's TimeLineID:       1
+Latest checkpoint's PrevTimeLineID:   1
+Latest checkpoint's full_page_writes: on
+Latest checkpoint's NextXID:          0/803
+Latest checkpoint's NextOID:          57348
+Latest checkpoint's NextRelfilenode:  32768
+Latest checkpoint's NextMultiXactId:  1
+Latest checkpoint's NextMultiOffset:  0
+Latest checkpoint's oldestXID:        702
+Latest checkpoint's oldestXID's DB:   1
+Latest checkpoint's oldestActiveXID:  0
+Latest checkpoint's oldestMultiXid:   1
+Latest checkpoint's oldestMulti's DB: 1
+Time of latest checkpoint:            Tue 17 Feb 2026 07:55:33 AM GMT
+Fake LSN counter for unlogged rels:   0/1
+Minimum recovery ending location:     0/0
+Min recovery ending loc's timeline:   0
+Backup start location:                0/0
+Backup end location:                  0/0
+End-of-backup record required:        no
+Current wal_level setting:            archive
+Current wal_log_hints setting:        off
+Current max_connections setting:      750
+Current max_worker_processes setting: 14
+Current max_prepared_xacts setting:   250
+Current max_locks_per_xact setting:   128
+Maximum data alignment:               8
+Database block size:                  32768
+Blocks per segment of large relation: 32768
+WAL block size:                       32768
+Bytes per WAL segment:                67108864
+Maximum length of identifiers:        64
+Maximum columns in an index:          32
+Maximum size of a TOAST chunk:        8140
+Size of a large-object chunk:         8192
+Date/time type storage:               64-bit integers
+Float4 argument passing:              by value
+Float8 argument passing:              by value
+Data page checksum version:           1
+
+stderr: 
+20260217:07:55:40:869765 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Successfully finished pg_controldata /tmp/datadirs/dbfast_mirror4/demoDataDir3 for dbid 10:
+stdout: pg_control version number:            9420600
+Catalog version number:               301908232
+Database system identifier:           7607734669120621985
+Database cluster state:               in archive recovery
+pg_control last modified:             Tue 17 Feb 2026 07:55:34 AM GMT
+Latest checkpoint location:           0/38000028
+Prior checkpoint location:            0/38000028
+Latest checkpoint's REDO location:    0/38000028
+Latest checkpoint's REDO WAL file:    00000001000000000000000E
+Latest checkpoint's TimeLineID:       1
+Latest checkpoint's PrevTimeLineID:   1
+Latest checkpoint's full_page_writes: on
+Latest checkpoint's NextXID:          0/803
+Latest checkpoint's NextOID:          57348
+Latest checkpoint's NextRelfilenode:  32768
+Latest checkpoint's NextMultiXactId:  1
+Latest checkpoint's NextMultiOffset:  0
+Latest checkpoint's oldestXID:        702
+Latest checkpoint's oldestXID's DB:   1
+Latest checkpoint's oldestActiveXID:  0
+Latest checkpoint's oldestMultiXid:   1
+Latest checkpoint's oldestMulti's DB: 1
+Time of latest checkpoint:            Tue 17 Feb 2026 07:55:33 AM GMT
+Fake LSN counter for unlogged rels:   0/1
+Minimum recovery ending location:     0/380000D0
+Min recovery ending loc's timeline:   1
+Backup start location:                0/0
+Backup end location:                  0/0
+End-of-backup record required:        no
+Current wal_level setting:            archive
+Current wal_log_hints setting:        off
+Current max_connections setting:      750
+Current max_worker_processes setting: 14
+Current max_prepared_xacts setting:   250
+Current max_locks_per_xact setting:   128
+Maximum data alignment:               8
+Database block size:                  32768
+Blocks per segment of large relation: 32768
+WAL block size:                       32768
+Bytes per WAL segment:                67108864
+Maximum length of identifiers:        64
+Maximum columns in an index:          32
+Maximum size of a TOAST chunk:        8140
+Size of a large-object chunk:         8192
+Date/time type storage:               64-bit integers
+Float4 argument passing:              by value
+Float8 argument passing:              by value
+Data page checksum version:           1
+
+stderr: 
+20260217:07:55:40:869765 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Heap checksum setting consistent across cluster
+20260217:07:55:40:869765 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Locking catalog
+20260217:07:55:40:869765 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Locked catalog
+20260217:07:55:40:869765 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Unlocking catalog
+20260217:07:55:40:869765 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Unlocked catalog
+20260217:07:55:40:869765 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Creating shrink schema
+20260217:07:55:41:869765 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Populating gpshrink.status_detail with data from database template1
+20260217:07:55:41:869765 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Populating gpshrink.status_detail with data from database postgres
+20260217:07:55:42:869765 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Populating gpshrink.status_detail with data from database isolation2test
+20260217:07:55:42:869765 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-************************************************
+20260217:07:55:42:869765 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Initialization of the system shrink complete.
+20260217:07:55:42:869765 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-To begin table shrink onto the new segments
+20260217:07:55:42:869765 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-rerun gpshrink
+20260217:07:55:42:869765 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-************************************************
+20260217:07:55:42:869765 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Exiting...
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpshrink -i /tmp/testexpand;
+-- start_ignore
+20260217:07:55:42:870155 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 6.28.8-python+dev.197.g05e6484876 build dev'
+20260217:07:55:42:870155 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 9.4.26 (Greenplum Database 6.28.8-python+dev.197.g05e6484876 build dev) on x86_64-unknown-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04.2) 11.4.0, 64-bit compiled on Feb 12 2026 14:27:36 (with assert checking)'
+20260217:07:55:44:870155 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Shrinking postgres.gpexpand.status
+20260217:07:55:45:870155 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Finished shrinking postgres.gpexpand.status
+20260217:07:55:46:870155 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Shrinking postgres.gpexpand.status_detail
+20260217:07:55:46:870155 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Finished shrinking postgres.gpexpand.status_detail
+20260217:07:55:47:870155 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Shrinking postgres.gpshrink.status_detail
+20260217:07:55:47:870155 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Finished shrinking postgres.gpshrink.status_detail
+20260217:07:55:47:870155 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Shrinking postgres.gpshrink.status
+20260217:07:55:47:870155 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Finished shrinking postgres.gpshrink.status
+20260217:07:55:49:870155 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-SHRINK COMPLETED SUCCESSFULLY
+20260217:07:55:49:870155 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Locking catalog
+20260217:07:55:49:870155 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Locked catalog
+20260217:07:55:49:870155 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Unlocking catalog
+20260217:07:55:49:870155 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Unlocked catalog
+20260217:07:55:50:870155 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Exiting...
+
+-- end_ignore
+(exited with code 0)
+
+!\retcode yes | gpexpand -c;
+-- start_ignore
+20260217:07:55:50:870500 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 6.28.8-python+dev.197.g05e6484876 build dev'
+20260217:07:55:50:870500 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 9.4.26 (Greenplum Database 6.28.8-python+dev.197.g05e6484876 build dev) on x86_64-unknown-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04.2) 11.4.0, 64-bit compiled on Feb 12 2026 14:27:36 (with assert checking)'
+20260217:07:55:50:870500 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Querying gpexpand schema for current expansion state
+
+
+Do you want to dump the gpexpand.status_detail table to file? Yy|Nn (default=Y):
+> 20260217:07:55:50:870500 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Dumping gpexpand.status_detail to /home/gpadmin/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1/gpexpand.status_detail
+20260217:07:55:51:870500 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Removing gpexpand schema
+20260217:07:55:51:870500 gpexpand:da6db2bb5ee4:gpadmin-[INFO]:-Cleanup Finished.  exiting...
+yes: standard output: Broken pipe
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpshrink -c;
+-- start_ignore
+20260217:07:55:51:870544 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 6.28.8-python+dev.197.g05e6484876 build dev'
+20260217:07:55:51:870544 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 9.4.26 (Greenplum Database 6.28.8-python+dev.197.g05e6484876 build dev) on x86_64-unknown-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04.2) 11.4.0, 64-bit compiled on Feb 12 2026 14:27:36 (with assert checking)'
+20260217:07:55:51:870544 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Removing gpshrink schema
+20260217:07:55:52:870544 gpshrink:da6db2bb5ee4:gpadmin-[INFO]:-Cleanup Finished.  exiting...
+
+-- end_ignore
+(exited with code 0)
+!\retcode rm -r /tmp/datadirs/;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+!\retcode rm /tmp/new_segment_datadir;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+

--- a/src/test/isolation2/isolation2_expandshrink_schedule
+++ b/src/test/isolation2/isolation2_expandshrink_schedule
@@ -1,3 +1,4 @@
 # Tests for gpexpand and gpshrink
 # Keep for single schedule due to redistribute all the table in all database
 test: gpexpand_gpshrink
+test: gpexpand_archive_restore_conf

--- a/src/test/isolation2/sql/gpexpand_archive_restore_conf.sql
+++ b/src/test/isolation2/sql/gpexpand_archive_restore_conf.sql
@@ -1,0 +1,48 @@
+-- Verify that gpexpand correctly updates segment-specific flags for wal-g in
+-- archive_command and restore_command_hint when initializing new segments.
+--
+-- Previously, these GUCs were copied verbatim from the template segment
+-- (content 0), causing new segments to invoke archiving with an incorrect
+-- content-id (possible overwriting archive or restoring other's data).
+
+-- Cleanup any previous state
+!\retcode yes | gpexpand -c;
+!\retcode gpshrink -c;
+!\retcode rm -r /tmp/datadirs/;
+
+-- Set GUCs on all segments, hardcode --content-id to 0
+!\retcode gpconfig -c restore_command_hint -v '/bin/true';
+!\retcode gpconfig -c archive_command -v 'wal-g seg wal-push %p --content-id=0';
+!\retcode gpstop -u;
+
+-- Prepare expansion configuration
+!\retcode echo "localhost|localhost|7008|/tmp/datadirs/dbfast4/demoDataDir3|9|3|p
+localhost|localhost|7009|/tmp/datadirs/dbfast_mirror4/demoDataDir3|10|3|m" > /tmp/testexpand;
+
+-- Expand
+!\retcode gpexpand -i /tmp/testexpand;
+!\retcode gpexpand -i /tmp/testexpand;
+
+-- Get the new segment's datadir (content=3)
+!\retcode psql -d postgres -Aqt -c "SELECT datadir FROM gp_segment_configuration
+WHERE content = 3 AND role = 'p'" > /tmp/new_segment_datadir;
+
+-- Confirm that the --content-id flag within archive_command has been
+-- updated to match the new segment's content. The restore_command_hint
+-- lacks --content-id flag and should be unchanged.
+! grep "^archive_command" $(cat /tmp/new_segment_datadir)/postgresql.conf;
+! grep "^restore_command_hint" $(cat /tmp/new_segment_datadir)/postgresql.conf;
+
+-- Cleanup
+!\retcode gpconfig -r restore_command_hint;
+!\retcode gpconfig -r archive_command;
+!\retcode gpstop -u;
+
+!\retcode gpshrink -i /tmp/testexpand;
+!\retcode gpshrink -i /tmp/testexpand;
+
+!\retcode yes | gpexpand -c;
+!\retcode gpshrink -c;
+!\retcode rm -r /tmp/datadirs/;
+!\retcode rm /tmp/new_segment_datadir;
+


### PR DESCRIPTION
When expanding a cluster, gpexpand copies the postgresql.conf file directly from the template segment (content 0). This causes issues for tools like wal-g which use a --content-id flag in archive_command and restore_command_hint.

Previously, new segments inherited --content-id=0 from the template. This caused them to push WAL segments to the wrong location, potentially overwriting segment 0's segments.

This fix ensures the content ID in archive_command and restore_command_hint is updated to match the new segment's ID during expansion. If the commands do not contain the --content-id flag, they remain unchanged.