### PR TITLE
Fix backport of streaming WAL archiving status feature

### DIFF
--- a/src/backend/replication/walreceiver.c
+++ b/src/backend/replication/walreceiver.c
@@ -114,6 +114,16 @@ static struct
 
 /* Last archived WAL segment file obtained from the primary */
 static char primary_last_archived[MAX_XFN_CHARS + 1];
+static TimeLineID primary_last_archived_tli = 0;
+static XLogSegNo primary_last_archived_segno = 0;
+
+/*
+ * Last segment we successfully marked as .done. Used to optimize
+ * ProcessArchivalReport() by generating expected filenames instead
+ * of scanning the archive_status directory.
+ */
+static TimeLineID last_processed_tli = 0;
+static XLogSegNo last_processed_segno = 0;
 
 static StringInfoData reply_message;
 static StringInfoData incoming_message;
@@ -1116,10 +1126,32 @@ XLogWalRcvClose(XLogRecPtr recptr)
 	 * wal_sender_archiving_status_interval is non-zero and archiving is
 	 * enabled. This will enable creation of .ready files instead of .done.
 	 * The .ready files will be transitioned to .done files after receiving
-	 * WAL archiving status update messages from the primary segment.
+	 * WAL archiving status update messages from the primary segment. We
+	 * optimize by checking if this segment is already covered by the last
+	 * archival report from the primary. If so, create .done directly.
+	 * Otherwise, create .ready.
 	 */
-	if (XLogArchivingStatusReportingActive())
-		XLogArchiveNotify(xlogfname);
+	if (XLogArchivingStatusReportingActive()) {
+		/*
+		 * Check if this segment is already archived on primary.
+		 * If we're on the same timeline and this segment is <= last archived,
+		 * mark it .done immediately. Otherwise create .ready.
+		 *
+		 * We don't check ancestor timeline cases here to avoid reading timeline
+		 * history files on every segment close. ProcessArchivalReport() will
+		 * handle marking ancestor timeline segments as .done when it scans
+		 * the archive_status directory.
+		 */
+		if (primary_last_archived_tli == recvFileTLI &&
+			recvSegNo <= primary_last_archived_segno)
+		{
+			XLogArchiveForceDone(xlogfname);
+		}
+		else
+		{
+			XLogArchiveNotify(xlogfname);
+		}
+	}
 	else
 		XLogArchiveForceDone(xlogfname);
 
@@ -1364,13 +1396,20 @@ ProcessWalSndrMessage(XLogRecPtr walEnd, TimestampTz sendTime)
 }
 
 /*
- * Create .done files, based on the primary's last archival report.
+ * Process archival report from primary.
+ *
+ * The primary sends us the last WAL segment it has archived. We scan the
+ * archive_status directory for .ready files and mark segments on the same
+ * timeline as .done if they're <= the reported segment.
  */
 static void
 ProcessArchivalReport(void)
 {
-	DIR		   *xldir;
-	struct dirent *xlde;
+	TimeLineID	reported_tli;
+	XLogSegNo	reported_segno;
+	char		status_path[MAXPGPATH];
+	bool		use_direct_check = false;
+	XLogSegNo	start_segno;
 
 	elog(DEBUG2, "received archival report from primary: %s", primary_last_archived);
 
@@ -1378,34 +1417,164 @@ ProcessArchivalReport(void)
 		return;
 
 	/* Check that the wal filename reported by primary looks valid */
-	if (strlen(primary_last_archived) < 24 ||
-		strspn(primary_last_archived, "0123456789ABCDEF") != 24)
+	if (!IsXLogFileName(primary_last_archived))
+	{
+		elog(DEBUG2, "invalid WAL filename in archival report: %s",
+			 primary_last_archived);
 		return;
+	}
 
-	xldir = AllocateDir(XLOGDIR);
-	if (xldir == NULL)
-		ereport(ERROR,
-			(errcode_for_file_access(),
-			errmsg("could not open transaction log directory \"%s\": %m",
-				XLOGDIR)));
-	while ((xlde = ReadDir(xldir, XLOGDIR)) != NULL)
+	XLogFromFileName(primary_last_archived, &reported_tli, &reported_segno);
+
+	/* Remember the last archived segment for XLogWalRcvClose() */
+	primary_last_archived_tli = reported_tli;
+	primary_last_archived_segno = reported_segno;
+
+	/*
+	 * Optimization: If the new report is on the same timeline as the last
+	 * processed segment and moves forward, we can directly check for .ready
+	 * files for segments between last_processed_segno and reported_segno
+	 * instead of scanning the entire archive_status directory.
+	 *
+	 * Fall back to directory scan if:
+	 * - Timeline changed (need to handle ancestor timelines)
+	 * - This is the first report (last_processed_tli == 0)
+	 * - Reported segment is not ahead (nothing new to process)
+	 */
+	if (last_processed_tli == reported_tli &&
+		last_processed_tli != 0 &&
+		reported_segno > last_processed_segno)
+	{
+		use_direct_check = true;
+		start_segno = last_processed_segno + 1;
+	}
+
+	if (use_direct_check)
 	{
 		/*
-		 * We ignore the timeline part of the XLOG segment identifiers in
-		 * deciding whether a segment is still needed.  This ensures that we
-		 * won't prematurely remove a segment from a parent timeline.
-		 *
-		 * We use the alphanumeric sorting property of the filenames to decide
-		 * which ones are earlier than the lastoff segment.
+		 * Direct check: generate filenames for expected segments.
+		 * XLogArchiveForceDone() will handle the case where .ready doesn't
+		 * exist or .done already exists, so no need to stat() first.
 		 */
-		if (strlen(xlde->d_name) == 24 &&
-			strspn(xlde->d_name, "0123456789ABCDEF") == 24 &&
-			strcmp(xlde->d_name + 8, primary_last_archived + 8) <= 0)
+		XLogSegNo	segno;
+
+		for (segno = start_segno; segno <= reported_segno; segno++)
 		{
-			XLogArchiveForceDone(xlde->d_name);
+			char		walfile[MAXFNAMELEN];
+
+			/* Generate WAL filename and mark as archived */
+			XLogFileName(walfile, reported_tli, segno);
+			XLogArchiveForceDone(walfile);
+			elog(DEBUG3, "marked WAL segment %s as archived (primary archived up to %s)",
+				 walfile, primary_last_archived);
+
+			/* Track the last segment we processed */
+			last_processed_tli = reported_tli;
+			last_processed_segno = segno;
 		}
 	}
-	FreeDir(xldir);
+	else
+	{
+		/*
+		 * Directory scan: needed when timeline changed or first report.
+		 * This handles both same-timeline and ancestor-timeline cases.
+		 */
+		DIR		   *status_dir;
+		struct dirent *status_de;
+		List	   *tli_history = NIL;
+
+		snprintf(status_path, MAXPGPATH, XLOGDIR "/archive_status");
+		status_dir = AllocateDir(status_path);
+		if (status_dir == NULL)
+		{
+			elog(DEBUG2, "could not open archive_status directory: %m");
+			return;
+		}
+
+		while ((status_de = ReadDir(status_dir, status_path)) != NULL)
+		{
+			char	   *ready_suffix;
+			char		walfile[MAXPGPATH];
+			TimeLineID	file_tli;
+			XLogSegNo	file_segno;
+
+			/* Look for .ready files only */
+			ready_suffix = strstr(status_de->d_name, ".ready");
+			if (ready_suffix == NULL || ready_suffix[6] != '\0')
+				continue;
+
+			/* Extract WAL filename (remove .ready suffix) */
+			strlcpy(walfile, status_de->d_name, ready_suffix - status_de->d_name + 1);
+
+			/* Parse the WAL filename */
+			if (!IsXLogFileName(walfile))
+				continue;
+
+			XLogFromFileName(walfile, &file_tli, &file_segno);
+
+			/*
+			 * Mark as .done if:
+			 * 1. Same timeline and segment <= reported segment, OR
+			 * 2. Ancestor timeline and segment is before the timeline switch point
+			 *
+			 * For ancestor timelines: if primary archived segment X on timeline T,
+			 * then all segments on ancestor timelines before the switch to T must
+			 * have been archived (they're required to reach timeline T).
+			 */
+			if (file_tli == reported_tli && file_segno <= reported_segno)
+			{
+				/* Same timeline, segment already archived */
+				XLogArchiveForceDone(walfile);
+				elog(DEBUG3, "marked WAL segment %s as archived (primary archived up to %s)",
+					 walfile, primary_last_archived);
+			}
+			else if (file_tli != reported_tli)
+			{
+				/*
+				 * Different timeline - check if it's an ancestor and if this
+				 * segment is before the timeline switch point. Only read timeline
+				 * history if we haven't already (lazy loading).
+				 *
+				 * Note: Timelines form a tree structure, not a linear sequence,
+				 * so we can't use < or > to compare them.
+				 */
+				if (tli_history == NIL)
+					tli_history = readTimeLineHistory(reported_tli);
+
+				if (tliInHistory(file_tli, tli_history))
+				{
+					XLogRecPtr	switchpoint;
+					XLogSegNo	switchpoint_segno;
+
+					/* Get the point where we switched away from this timeline */
+					switchpoint = tliSwitchPoint(file_tli, tli_history, NULL);
+
+					/*
+					 * If the segment is at or before the switch point, it must have
+					 * been archived (it's required to reach the reported timeline).
+					 * The segment containing the switch point belongs to the old
+					 * timeline up to the switch point and should be archived.
+					 */
+					XLByteToSeg(switchpoint, switchpoint_segno);
+					if (file_segno <= switchpoint_segno)
+					{
+						XLogArchiveForceDone(walfile);
+						elog(DEBUG3, "marked ancestor timeline segment %s as archived (before switch to timeline %u)",
+							 walfile, reported_tli);
+					}
+				}
+			}
+		}
+
+		FreeDir(status_dir);
+
+		/*
+		 * After a full directory scan following a timeline change, update
+		 * our tracking to the newly reported position for future optimizations.
+		 */
+		last_processed_tli = reported_tli;
+		last_processed_segno = reported_segno;
+	}
 
 	/*
 	 * Remember this location in pgstat as well. This makes it visible in

--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -3502,12 +3502,6 @@ WalSndKeepaliveIfNecessary(void)
 	TimestampTz ping_time;
 
 	/*
-	 * Send an archival status message, if necessary.
-	 */
-	if (XLogArchivingStatusReportingActive())
-		WalSndArchivalReportIfNecessary(GetCurrentTimestamp());
-
-	/*
 	 * Don't send keepalive messages if timeouts are globally disabled or
 	 * we're doing something not partaking in timeouts.
 	 */
@@ -3533,6 +3527,15 @@ WalSndKeepaliveIfNecessary(void)
 		if (pq_flush_if_writable() != 0)
 			WalSndShutdown();
 	}
+
+	/*
+	 * Send an archival status message, if feature is enabled and
+	 * not during backup.
+	 */
+	if (XLogArchivingStatusReportingActive() &&
+		(MyWalSnd->state == WALSNDSTATE_CATCHUP ||
+		 MyWalSnd->state == WALSNDSTATE_STREAMING))
+		WalSndArchivalReportIfNecessary(GetCurrentTimestamp());
 }
 
 /*
@@ -3594,7 +3597,12 @@ WalSndArchivalReportIfNecessary(TimestampTz now)
 
 		last_archival_report_timestamp = global_stats->stats_timestamp;
 
-		if (strcmp(last_archived_file, archiver_stats->last_archived_wal) != 0)
+		/*
+	 	 * Only send a report if the last archived WAL has changed AND
+	 	 * it is a WAL segments, not backup history file or other archived file.
+	 	 */
+		if (strcmp(last_archived_file, archiver_stats->last_archived_wal) != 0 &&
+			IsXLogFileName(archiver_stats->last_archived_wal))
 		{
 			strlcpy(last_archived_file, archiver_stats->last_archived_wal,
 										sizeof(last_archived_file));

--- a/src/test/recovery/t/121_streaming_and_archiving.pl
+++ b/src/test/recovery/t/121_streaming_and_archiving.pl
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use PostgresNode;
 use TestLib;
-use Test::More tests => 17;
+use Test::More tests => 19;
 use File::Copy;
 
 my $node_master;
@@ -218,4 +218,102 @@ ok( !-f "$standby_data/$walfile_ready3",
 	".ready file does not exist on standby for WAL segment $current_walfile3 when wal_sender_archiving_status_interval=50ms"
 );
 
-done_testing();
+##################### Timeline switch: divergent segment not marked .done #####################
+# After promotion (TLI 1 -> 2), a .ready for a TLI1 segment whose number
+# falls past the switch point must NOT be marked .done by TLI2 archive
+# status reports.
+
+# Setup primary with feature enabled
+my $node_master_tli = get_new_node('master_tli');
+$node_master_tli->init(has_archiving => 1, allows_streaming => 1);
+$node_master_tli->append_conf('postgresql.conf',
+	'wal_sender_archiving_status_interval = 100ms');
+$node_master_tli->start;
+
+# Setup standby with feature enabled
+$node_master_tli->backup('my_backup_tli');
+my $node_standby_tli = get_new_node('standby_tli');
+$node_standby_tli->init_from_backup($node_master_tli, 'my_backup_tli',
+	has_streaming => 1);
+$node_standby_tli->append_conf('postgresql.conf',
+	'wal_sender_archiving_status_interval = 100ms');
+$node_standby_tli->start;
+
+# Generate WAL on TLI 1, let standby catch up
+$node_master_tli->safe_psql('postgres', 'CREATE TABLE t(a int)');
+$node_master_tli->safe_psql('postgres', 'SELECT pg_switch_xlog()');
+$node_master_tli->wait_for_catchup($node_standby_tli, 'write',
+	$node_master_tli->lsn('insert'));
+
+# Promote to TLI2
+$node_standby_tli->promote;
+$node_standby_tli->poll_query_until('postgres',
+	"SELECT NOT pg_is_in_recovery()")
+	or die "Timed out waiting for promotion";
+$node_master_tli->stop;
+
+# Fix archive on promoted standby
+my $archive_dir_tli = $node_master_tli->archive_dir;
+$node_standby_tli->safe_psql('postgres', qq{
+	ALTER SYSTEM SET archive_command TO 'cp %p $archive_dir_tli/%f';
+	SELECT pg_reload_conf();
+});
+
+# Advance WAL past the switch point
+for my $i (1..3) {
+	$node_standby_tli->safe_psql('postgres', 'INSERT INTO t VALUES(1)');
+	$node_standby_tli->safe_psql('postgres', 'SELECT pg_switch_xlog()');
+}
+
+# Archive segment from TLI2
+my $tli2_segment = $node_standby_tli->safe_psql('postgres',
+	"SELECT pg_xlogfile_name(pg_switch_xlog())");
+$node_standby_tli->safe_psql('postgres', 'CHECKPOINT');
+wait_until_file_exists("$archive_dir_tli/$tli2_segment",
+	"TLI 2 segment archived");
+
+# Create a new standby from the promoted node.  We plant a .ready file for
+# a fake TLI-1 segment with the same segment number as the archived TLI-2
+# segment -- that number is past the switch point, simulating a divergent
+# WAL segment from the old timeline branch.
+$node_standby_tli->backup('my_backup_tli2');
+my $node_new_standby_tli = get_new_node('new_standby_tli');
+$node_new_standby_tli->init_from_backup($node_standby_tli, 'my_backup_tli2',
+	has_streaming => 1);
+$node_new_standby_tli->append_conf('postgresql.conf',
+	'wal_sender_archiving_status_interval = 100ms');
+
+my $divergent_seg = $tli2_segment;
+$divergent_seg =~ s/^00000002/00000001/;
+my $new_standby_tli_data = $node_new_standby_tli->data_dir;
+my $divergent_ready = "$new_standby_tli_data/pg_xlog/archive_status/$divergent_seg.ready";
+my $divergent_done  = "$new_standby_tli_data/pg_xlog/archive_status/$divergent_seg.done";
+
+# Plant both the .ready marker and a dummy WAL file.
+open(my $fh, '>', $divergent_ready) or die "Cannot create .ready: $!";
+close $fh;
+open($fh, '>', "$new_standby_tli_data/pg_xlog/$divergent_seg") or die "Cannot create WAL file: $!";
+close $fh;
+
+$node_new_standby_tli->start;
+
+# Generate another TLI2 segment and archive it. Then wait for the new
+# standby to show .done for that segment -- it received and processed
+# the archival report, so any effect on the divergent .ready would
+# already have happened.
+$node_standby_tli->safe_psql('postgres', 'INSERT INTO t VALUES(1)');
+my $probe_seg = $node_standby_tli->safe_psql('postgres',
+	"SELECT pg_xlogfile_name(pg_switch_xlog())");
+$node_standby_tli->safe_psql('postgres', 'CHECKPOINT');
+wait_until_file_exists("$archive_dir_tli/$probe_seg",
+	"probe segment archived on promoted node");
+my $probe_done = "$new_standby_tli_data/pg_xlog/archive_status/$probe_seg.done";
+wait_until_file_exists($probe_done,
+	".done for probe segment on new standby (proves report was processed)");
+
+# The divergent TLI1 wal (past switch point) and its .ready file
+# must survive TLI2 reports.
+ok(-f $divergent_ready,
+	"divergent TLI-1 .ready not removed by TLI-2 archive reports");
+ok(!-f $divergent_done,
+	"divergent TLI-1 .done not created by TLI-2 archive reports");


### PR DESCRIPTION
The Greenplum backport [1] of the WAL archiving status reporting feature [0] had bugs that could cause WAL loss or unnecessary archival traffic.

ProcessArchivalReport() scanned pg_xlog/ instead of pg_xlog/archive_status/, so it compared against actual WAL files rather than .ready status markers. It also ignored timeline switches [3].

The walsender side sent archival reports during startup, backup, and stopping phases when it should only report during streaming/catchup AND when global timeouts enabled. It also did not filter the reported filenames to WAL segments, causing unnecessary archival traffic.

Apply fixes from V3 [2] of the upstream patch:
  - Scan archive_status/ for .ready files instead of pg_xlog/
  - Only mark ancestor-timeline segments .done if before the switch point, leave divergent segments alone.
  - Skip full directory scan when timeline is unchanged.
  - In XLogWalRcvClose(), create .done instead of .ready when the segment is already covered by the last archival report
  - Send archival reports only during streaming/catchup phase
  - Filter reported files to WAL segments only

The only new thing is the test that promotes a standby (TLI 1 to 2). Purposely create a TLI1 wal segment and .ready file for it past the switch point on a new standby and verify it is not incorrectly marked as .done by TLI2 archival report.

[0] https://www.postgresql.org/message-id/5550D20D.6090703%40iki.fi
[1] https://github.com/open-gpdb/gpdb/commit/4f2db1929df1b5eed28f33505955636096bb4e8b
[2] https://www.postgresql.org/message-id/D4B53AE3-B7AF-4BE6-9CB6-44956B05DE72%40yandex-team.ru
[3] Timeline switches problem:
When timeline switches between two archive reports, stand-by could erroneously delete wal segments.
After promotion to a newer timeline, it would mark ancestor-timeline .ready files as .done even for segments
past the switch point, which belong to the divergent old-timeline branch and must not be touched.
In the example below, the switch point is segment 39. Let's say the first archival report was at segment 30 and
the next at segment 50. The prior patch would delete (first mark to .done) erroneously segments 40 and 41.
```
(Timeline 1)
     /
... 39 -- 40 -- 41 (40.ready and 41.ready should not be moved to .done)
     \
     (Timeline 2)
        \
        40 -- 41 -- 42 -- 43 -- ... --- 50 (current master is here)
```
