### PR TITLE
Add oids mappings with objects names

### DIFF
--- a/gpcontrib/pgaudit/expected/pgaudit.out
+++ b/gpcontrib/pgaudit/expected/pgaudit.out
@@ -639,7 +639,7 @@ SELECT count(*)
 	  FROM pg_class
 	 LIMIT 1
  ) subquery;
-NOTICE:  AUDIT: SESSION,15,1,AST_SEL,SELECT,,,"{QUERY...}{r XXXX pg_catalog.pg_class {relname,relnamespace,reltype,reloftype,relowner,relam,relfilenode,reltablespace,relpages,reltuples,relallvisible,reltoastrelid,relhasindex,relisshared,relpersistence,relkind,relstorage,relnatts,relchecks,relhasoids,relhaspkey,relhasrules,relhastriggers,relhassubclass,relispopulated,relreplident,relfrozenxid,relminmxid,relacl,reloptions}}{f XXXX pg_catalog.int8 {}}",<none>
+NOTICE:  AUDIT: SESSION,15,1,AST_SEL,SELECT,,,"{QUERY...}{r XXXX pg_catalog.pg_class {relname,relnamespace,reltype,reloftype,relowner,relam,relfilenode,reltablespace,relpages,reltuples,relallvisible,reltoastrelid,relhasindex,relisshared,relpersistence,relkind,relstorage,relnatts,relchecks,relhasoids,relhaspkey,relhasrules,relhastriggers,relhassubclass,relispopulated,relreplident,relfrozenxid,relminmxid,relacl,reloptions}}{f XXXX pg_catalog.count {}}{f XXXX pg_catalog.int8 {}}",<none>
 NOTICE:  AUDIT: SESSION,15,2,READ,SELECT,TABLE,pg_catalog.pg_class,"DECLARE ctest SCROLL CURSOR FOR
 SELECT count(*)
   FROM
@@ -678,7 +678,7 @@ SELECT count(*)
 	  FROM pg_class
 	 LIMIT 1
  ) subquery;
-NOTICE:  AUDIT: SESSION,20,1,AST_SEL,SELECT,,,"{QUERY...}{r XXXX pg_catalog.pg_class {relname,relnamespace,reltype,reloftype,relowner,relam,relfilenode,reltablespace,relpages,reltuples,relallvisible,reltoastrelid,relhasindex,relisshared,relpersistence,relkind,relstorage,relnatts,relchecks,relhasoids,relhaspkey,relhasrules,relhastriggers,relhassubclass,relispopulated,relreplident,relfrozenxid,relminmxid,relacl,reloptions}}{f XXXX pg_catalog.int8 {}}",<none>
+NOTICE:  AUDIT: SESSION,20,1,AST_SEL,SELECT,,,"{QUERY...}{r XXXX pg_catalog.pg_class {relname,relnamespace,reltype,reloftype,relowner,relam,relfilenode,reltablespace,relpages,reltuples,relallvisible,reltoastrelid,relhasindex,relisshared,relpersistence,relkind,relstorage,relnatts,relchecks,relhasoids,relhaspkey,relhasrules,relhastriggers,relhassubclass,relispopulated,relreplident,relfrozenxid,relminmxid,relacl,reloptions}}{f XXXX pg_catalog.count {}}{f XXXX pg_catalog.int8 {}}",<none>
  count 
 -------
      1
@@ -1296,23 +1296,42 @@ NOTICE:  AUDIT: SESSION,77,2,READ,SELECT,TABLE,public.t2,"SELECT * FROM t1, t2, 
 ----+-----+-----+------+--------+--------+--------+--------
 (0 rows)
 
+-- Aggregate function
+SELECT max(id) FROM t1;
+NOTICE:  AUDIT: SESSION,78,1,AST_SEL,SELECT,,,"{QUERY...}{r XXXX public.t1 {id,txt}}{f XXXX pg_catalog.max {}}",<none>
+NOTICE:  AUDIT: SESSION,78,1,AST_SEL,SELECT,TABLE,public.t1,"{QUERY...}{r XXXX public.t1 {id,txt}}{f XXXX pg_catalog.max {}}",<none>
+NOTICE:  AUDIT: SESSION,78,2,READ,SELECT,TABLE,public.t1,SELECT max(id) FROM t1;,<none>
+ max 
+-----
+    
+(1 row)
+
+-- Window function
+SELECT max(id) OVER(PARTITION BY txt) FROM t1;
+NOTICE:  AUDIT: SESSION,79,1,AST_SEL,SELECT,,,"{QUERY...}{r XXXX public.t1 {id,txt}}{f XXXX pg_catalog.max {}}",<none>
+NOTICE:  AUDIT: SESSION,79,1,AST_SEL,SELECT,TABLE,public.t1,"{QUERY...}{r XXXX public.t1 {id,txt}}{f XXXX pg_catalog.max {}}",<none>
+NOTICE:  AUDIT: SESSION,79,2,READ,SELECT,TABLE,public.t1,SELECT max(id) OVER(PARTITION BY txt) FROM t1;,<none>
+ max 
+-----
+(0 rows)
+
 -- Cleanup
 DROP FUNCTION get_t1_by_id(int);
-NOTICE:  AUDIT: SESSION,78,1,DDL,DROP FUNCTION,FUNCTION,public.get_t1_by_id(integer),DROP FUNCTION get_t1_by_id(int);,<none>
+NOTICE:  AUDIT: SESSION,80,1,DDL,DROP FUNCTION,FUNCTION,public.get_t1_by_id(integer),DROP FUNCTION get_t1_by_id(int);,<none>
 DROP FUNCTION get_tc();
-NOTICE:  AUDIT: SESSION,79,1,DDL,DROP FUNCTION,FUNCTION,public.get_tc(),DROP FUNCTION get_tc();,<none>
+NOTICE:  AUDIT: SESSION,81,1,DDL,DROP FUNCTION,FUNCTION,public.get_tc(),DROP FUNCTION get_tc();,<none>
 DROP FUNCTION get_records();
-NOTICE:  AUDIT: SESSION,80,1,DDL,DROP FUNCTION,FUNCTION,public.get_records(),DROP FUNCTION get_records();,<none>
+NOTICE:  AUDIT: SESSION,82,1,DDL,DROP FUNCTION,FUNCTION,public.get_records(),DROP FUNCTION get_records();,<none>
 DROP FUNCTION get_out_args(int);
-NOTICE:  AUDIT: SESSION,81,1,DDL,DROP FUNCTION,FUNCTION,public.get_out_args(integer),DROP FUNCTION get_out_args(int);,<none>
+NOTICE:  AUDIT: SESSION,83,1,DDL,DROP FUNCTION,FUNCTION,public.get_out_args(integer),DROP FUNCTION get_out_args(int);,<none>
 DROP FUNCTION get_table(int);
-NOTICE:  AUDIT: SESSION,82,1,DDL,DROP FUNCTION,FUNCTION,public.get_table(integer),DROP FUNCTION get_table(int);,<none>
+NOTICE:  AUDIT: SESSION,84,1,DDL,DROP FUNCTION,FUNCTION,public.get_table(integer),DROP FUNCTION get_table(int);,<none>
 DROP TABLE t1;
-NOTICE:  AUDIT: SESSION,83,1,DDL,DROP TABLE,TABLE,public.t1,DROP TABLE t1;,<none>
+NOTICE:  AUDIT: SESSION,85,1,DDL,DROP TABLE,TABLE,public.t1,DROP TABLE t1;,<none>
 DROP TABLE t2;
-NOTICE:  AUDIT: SESSION,84,1,DDL,DROP TABLE,TABLE,public.t2,DROP TABLE t2;,<none>
+NOTICE:  AUDIT: SESSION,86,1,DDL,DROP TABLE,TABLE,public.t2,DROP TABLE t2;,<none>
 DROP TYPE tc;
-NOTICE:  AUDIT: SESSION,85,1,DDL,DROP TYPE,COMPOSITE TYPE,public.tc,DROP TYPE tc;,<none>
+NOTICE:  AUDIT: SESSION,87,1,DDL,DROP TYPE,COMPOSITE TYPE,public.tc,DROP TYPE tc;,<none>
 --
 -- Delete all rows then delete 1 row
 SET pgaudit.log = 'write';
@@ -1326,37 +1345,37 @@ grant delete
    to auditor;
 insert into bar (col)
 		 values (1);
-NOTICE:  AUDIT: SESSION,86,1,WRITE,INSERT,TABLE,public.bar,"insert into bar (col)
+NOTICE:  AUDIT: SESSION,88,1,WRITE,INSERT,TABLE,public.bar,"insert into bar (col)
 		 values (1);",<none>
 delete from bar;
-NOTICE:  AUDIT: OBJECT,87,1,WRITE,DELETE,TABLE,public.bar,delete from bar;,<none>
-NOTICE:  AUDIT: SESSION,87,1,WRITE,DELETE,TABLE,public.bar,delete from bar;,<none>
+NOTICE:  AUDIT: OBJECT,89,1,WRITE,DELETE,TABLE,public.bar,delete from bar;,<none>
+NOTICE:  AUDIT: SESSION,89,1,WRITE,DELETE,TABLE,public.bar,delete from bar;,<none>
 insert into bar (col)
 		 values (1);
-NOTICE:  AUDIT: SESSION,88,1,WRITE,INSERT,TABLE,public.bar,"insert into bar (col)
+NOTICE:  AUDIT: SESSION,90,1,WRITE,INSERT,TABLE,public.bar,"insert into bar (col)
 		 values (1);",<none>
 delete from bar
  where col = 1;
-NOTICE:  AUDIT: OBJECT,89,1,WRITE,DELETE,TABLE,public.bar,"delete from bar
+NOTICE:  AUDIT: OBJECT,91,1,WRITE,DELETE,TABLE,public.bar,"delete from bar
  where col = 1;",<none>
-NOTICE:  AUDIT: SESSION,89,1,WRITE,DELETE,TABLE,public.bar,"delete from bar
+NOTICE:  AUDIT: SESSION,91,1,WRITE,DELETE,TABLE,public.bar,"delete from bar
  where col = 1;",<none>
 drop table bar;
 --
 -- Grant roles to each other
 SET pgaudit.log = 'role';
 GRANT user1 TO user2;
-NOTICE:  AUDIT: SESSION,90,1,ROLE,GRANT ROLE,,,GRANT user1 TO user2;,<none>
+NOTICE:  AUDIT: SESSION,92,1,ROLE,GRANT ROLE,,,GRANT user1 TO user2;,<none>
 REVOKE user1 FROM user2;
-NOTICE:  AUDIT: SESSION,91,1,ROLE,REVOKE ROLE,,,REVOKE user1 FROM user2;,<none>
+NOTICE:  AUDIT: SESSION,93,1,ROLE,REVOKE ROLE,,,REVOKE user1 FROM user2;,<none>
 --
 -- Test logging AST for CTAS
 SET pgaudit.log = 'ast_ctas';
 CREATE TABLE tmp (id int, data text) DISTRIBUTED BY (id);
 CREATE TABLE tmp2 AS (SELECT * FROM tmp) DISTRIBUTED BY (id);
-NOTICE:  AUDIT: SESSION,92,1,AST_CTAS,CREATE TABLE AS,TABLE,public.tmp2,"{QUERY...}{r XXXX public.tmp {id,data}}",<none>
+NOTICE:  AUDIT: SESSION,94,1,AST_CTAS,CREATE TABLE AS,TABLE,public.tmp2,"{QUERY...}{r XXXX public.tmp {id,data}}",<none>
 CREATE TEMP TABLE tmp3 AS (SELECT * FROM tmp) DISTRIBUTED BY (id);
-NOTICE:  AUDIT: SESSION,93,1,AST_CTAS,CREATE TABLE AS,TABLE,pg_temp_22.tmp3,"{QUERY...}{r XXXX public.tmp {id,data}}",<none>
+NOTICE:  AUDIT: SESSION,95,1,AST_CTAS,CREATE TABLE AS,TABLE,pg_temp_22.tmp3,"{QUERY...}{r XXXX public.tmp {id,data}}",<none>
 DROP TABLE tmp, tmp2, tmp3;
 --
 -- Test logging AST for SELECT
@@ -1367,7 +1386,7 @@ CREATE TABLE tmp (id int, data text) DISTRIBUTED BY (id);
 CREATE TABLE tmp2 AS (SELECT * FROM tmp) DISTRIBUTED BY (id);
 -- AST for independent select is logged
 SELECT id FROM tmp2;
-NOTICE:  AUDIT: SESSION,94,1,AST_SEL,SELECT,,,"{QUERY...}{r XXXX public.tmp2 {id,data}}",<none>
+NOTICE:  AUDIT: SESSION,96,1,AST_SEL,SELECT,,,"{QUERY...}{r XXXX public.tmp2 {id,data}}",<none>
  id 
 ----
 (0 rows)
@@ -1380,11 +1399,11 @@ SET pgaudit.log_relation = OFF;
 CREATE TABLE src (id int, txt text) DISTRIBUTED BY (id);
 CREATE TABLE dst (LIKE src) DISTRIBUTED BY (id);
 INSERT INTO dst SELECT * FROM src;
-NOTICE:  AUDIT: SESSION,95,1,AST_MOD,INSERT,,,"{QUERY...}{r XXXX public.dst {id,txt}}{r XXXX public.src {id,txt}}",<none>
+NOTICE:  AUDIT: SESSION,97,1,AST_MOD,INSERT,,,"{QUERY...}{r XXXX public.dst {id,txt}}{r XXXX public.src {id,txt}}",<none>
 UPDATE dst SET txt = src.txt FROM src WHERE dst.id = src.id;
-NOTICE:  AUDIT: SESSION,96,1,AST_MOD,UPDATE,,,"{QUERY...}{r XXXX public.dst {id,txt}}{r XXXX public.src {id,txt}}",<none>
+NOTICE:  AUDIT: SESSION,98,1,AST_MOD,UPDATE,,,"{QUERY...}{r XXXX public.dst {id,txt}}{r XXXX public.src {id,txt}}",<none>
 DELETE FROM dst USING src WHERE dst.id = src.id AND dst.txt = 'foo';
-NOTICE:  AUDIT: SESSION,97,1,AST_MOD,DELETE,,,"{QUERY...}{r XXXX public.dst {id,txt}}{r XXXX public.src {id,txt}}",<none>
+NOTICE:  AUDIT: SESSION,99,1,AST_MOD,DELETE,,,"{QUERY...}{r XXXX public.dst {id,txt}}{r XXXX public.src {id,txt}}",<none>
 DROP TABLE src, dst;
 -- Test create table as after extension as been dropped
 DROP EXTENSION pgaudit;
@@ -1411,9 +1430,9 @@ SET search_path = public, pg_catalog;
 -- If there was a vulnerability, these would fail with division by zero error
 CREATE TABLE wombat () DISTRIBUTED RANDOMLY;
 WARNING:  creating a table with no columns.
-NOTICE:  AUDIT: SESSION,98,1,DDL,CREATE TABLE,TABLE,public.wombat,CREATE TABLE wombat () DISTRIBUTED RANDOMLY;,<none>
+NOTICE:  AUDIT: SESSION,100,1,DDL,CREATE TABLE,TABLE,public.wombat,CREATE TABLE wombat () DISTRIBUTED RANDOMLY;,<none>
 DROP TABLE wombat;
-NOTICE:  AUDIT: SESSION,99,1,DDL,DROP TABLE,TABLE,public.wombat,DROP TABLE wombat;,<none>
+NOTICE:  AUDIT: SESSION,101,1,DDL,DROP TABLE,TABLE,public.wombat,DROP TABLE wombat;,<none>
 SET pgaudit.log = 'NONE';
 DROP EXTENSION pgaudit;
 DROP OPERATOR <> (text, text);

--- a/gpcontrib/pgaudit/expected/pgaudit.out
+++ b/gpcontrib/pgaudit/expected/pgaudit.out
@@ -1100,6 +1100,222 @@ NOTICE:  AUDIT: SESSION,60,8,AST_SEL,SELECT,,,{QUERY...},<none>
 (1 row)
 
 --
+-- Test function oid mapping with name
+-- Function returns SETOF <tablename>
+CREATE TABLE t1 (id int, txt text) DISTRIBUTED BY (id);
+NOTICE:  AUDIT: SESSION,62,1,DDL,CREATE TABLE,TABLE,public.t1,"CREATE TABLE t1 (id int, txt text) DISTRIBUTED BY (id);",<none>
+CREATE OR REPLACE FUNCTION get_t1_by_id(p_id int)
+RETURNS SETOF t1 AS $$
+DECLARE
+	r t1%rowtype;
+BEGIN
+	FOR r IN
+		SELECT * FROM t1 WHERE id < p_id
+	LOOP
+		RETURN NEXT r;
+	END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+NOTICE:  AUDIT: SESSION,63,1,DDL,CREATE FUNCTION,FUNCTION,public.get_t1_by_id(integer),"CREATE OR REPLACE FUNCTION get_t1_by_id(p_id int)
+RETURNS SETOF t1 AS $$
+DECLARE
+	r t1%rowtype;
+BEGIN
+	FOR r IN
+		SELECT * FROM t1 WHERE id < p_id
+	LOOP
+		RETURN NEXT r;
+	END LOOP;
+END;
+$$ LANGUAGE plpgsql;",<none>
+SELECT * FROM get_t1_by_id(10);
+NOTICE:  AUDIT: SESSION,64,1,AST_SEL,SELECT,,,"{QUERY...}{f XXXX public.get_t1_by_id {id,txt}}",<none>
+NOTICE:  AUDIT: SESSION,64,2,READ,SELECT,,,SELECT * FROM get_t1_by_id(10);,<none>
+NOTICE:  AUDIT: SESSION,64,3,FUNCTION,EXECUTE,FUNCTION,public.get_t1_by_id,SELECT * FROM get_t1_by_id(10);,<none>
+NOTICE:  AUDIT: SESSION,64,4,AST_SEL,SELECT,,,"{QUERY...}{r XXXX public.t1 {id,txt}}",<none>
+NOTICE:  AUDIT: SESSION,64,4,AST_SEL,SELECT,TABLE,public.t1,"{QUERY...}{r XXXX public.t1 {id,txt}}",<none>
+NOTICE:  AUDIT: SESSION,64,5,READ,SELECT,TABLE,public.t1,SELECT * FROM t1 WHERE id < p_id,"10,,,,"
+ id | txt 
+----+-----
+(0 rows)
+
+-- Function returns SETOF composite type
+CREATE TYPE tc AS (i int, d numeric(10,2));
+NOTICE:  AUDIT: SESSION,66,1,DDL,CREATE TYPE,TYPE,public.tc,"CREATE TYPE tc AS (i int, d numeric(10,2));",<none>
+CREATE OR REPLACE FUNCTION get_tc()
+RETURNS SETOF tc AS $$
+BEGIN
+	RETURN NEXT ROW(1, 1.1)::tc;
+	RETURN NEXT ROW(2, 2.2)::tc;
+END;
+$$ LANGUAGE plpgsql;
+NOTICE:  AUDIT: SESSION,67,1,DDL,CREATE FUNCTION,FUNCTION,public.get_tc(),"CREATE OR REPLACE FUNCTION get_tc()
+RETURNS SETOF tc AS $$
+BEGIN
+	RETURN NEXT ROW(1, 1.1)::tc;
+	RETURN NEXT ROW(2, 2.2)::tc;
+END;
+$$ LANGUAGE plpgsql;",<none>
+SELECT * FROM get_tc();
+NOTICE:  AUDIT: SESSION,68,1,AST_SEL,SELECT,,,"{QUERY...}{f XXXX public.get_tc {i,d}}",<none>
+NOTICE:  AUDIT: SESSION,68,2,READ,SELECT,,,SELECT * FROM get_tc();,<none>
+NOTICE:  AUDIT: SESSION,68,3,FUNCTION,EXECUTE,FUNCTION,public.get_tc,SELECT * FROM get_tc();,<none>
+NOTICE:  AUDIT: SESSION,68,4,AST_SEL,SELECT,,,{QUERY...}{f XXXX pg_catalog.numeric {}},<none>
+NOTICE:  AUDIT: SESSION,68,5,AST_SEL,SELECT,,,{QUERY...}{f XXXX pg_catalog.numeric {}},<none>
+ i |  d   
+---+------
+ 1 | 1.10
+ 2 | 2.20
+(2 rows)
+
+-- pgaudit logs a function name only, if the function returns SETOF record
+CREATE OR REPLACE FUNCTION get_records()
+RETURNS SETOF record AS $$
+DECLARE
+	r t1%rowtype;
+BEGIN
+	FOR r IN
+		SELECT * FROM t1
+	LOOP
+		RETURN NEXT (r.id, r.txt, 5::int)::record;
+	END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+NOTICE:  AUDIT: SESSION,69,1,DDL,CREATE FUNCTION,FUNCTION,public.get_records(),"CREATE OR REPLACE FUNCTION get_records()
+RETURNS SETOF record AS $$
+DECLARE
+	r t1%rowtype;
+BEGIN
+	FOR r IN
+		SELECT * FROM t1
+	LOOP
+		RETURN NEXT (r.id, r.txt, 5::int)::record;
+	END LOOP;
+END;
+$$ LANGUAGE plpgsql;",<none>
+SELECT * FROM get_records() a (id int, txt text, extra int);
+NOTICE:  AUDIT: SESSION,70,1,AST_SEL,SELECT,,,"{QUERY...}{f XXXX public.get_records {}}",<none>
+NOTICE:  AUDIT: SESSION,70,2,READ,SELECT,,,"SELECT * FROM get_records() a (id int, txt text, extra int);",<none>
+NOTICE:  AUDIT: SESSION,70,3,FUNCTION,EXECUTE,FUNCTION,public.get_records,"SELECT * FROM get_records() a (id int, txt text, extra int);",<none>
+NOTICE:  AUDIT: SESSION,70,4,AST_SEL,SELECT,,,"{QUERY...}{r XXXX public.t1 {id,txt}}",<none>
+NOTICE:  AUDIT: SESSION,70,4,AST_SEL,SELECT,TABLE,public.t1,"{QUERY...}{r XXXX public.t1 {id,txt}}",<none>
+NOTICE:  AUDIT: SESSION,70,5,READ,SELECT,TABLE,public.t1,SELECT * FROM t1,<none>
+ id | txt | extra 
+----+-----+-------
+(0 rows)
+
+-- Function returns SETOF record and has output arguments
+CREATE OR REPLACE FUNCTION get_out_args (x int, OUT col_o1 int, OUT col_o2 int)
+RETURNS SETOF record
+AS $$
+BEGIN
+	FOR i IN 1..x
+	LOOP
+		col_o1 := i * 2;
+		col_o2 := i * 2 + 1;
+		RETURN NEXT;
+	END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+NOTICE:  AUDIT: SESSION,71,1,DDL,CREATE FUNCTION,FUNCTION,public.get_out_args(integer),"CREATE OR REPLACE FUNCTION get_out_args (x int, OUT col_o1 int, OUT col_o2 int)
+RETURNS SETOF record
+AS $$
+BEGIN
+	FOR i IN 1..x
+	LOOP
+		col_o1 := i * 2;
+		col_o2 := i * 2 + 1;
+		RETURN NEXT;
+	END LOOP;
+END;
+$$ LANGUAGE plpgsql;",<none>
+SELECT * FROM get_out_args(3);
+NOTICE:  AUDIT: SESSION,72,1,AST_SEL,SELECT,,,"{QUERY...}{f XXXX public.get_out_args {col_o1,col_o2}}",<none>
+NOTICE:  AUDIT: SESSION,72,2,READ,SELECT,,,SELECT * FROM get_out_args(3);,<none>
+NOTICE:  AUDIT: SESSION,72,3,FUNCTION,EXECUTE,FUNCTION,public.get_out_args,SELECT * FROM get_out_args(3);,<none>
+NOTICE:  AUDIT: SESSION,72,4,AST_SEL,SELECT,,,{QUERY...},<none>
+NOTICE:  AUDIT: SESSION,72,5,READ,SELECT,,,SELECT 1,<none>
+NOTICE:  AUDIT: SESSION,72,6,AST_SEL,SELECT,,,{QUERY...},<none>
+NOTICE:  AUDIT: SESSION,72,7,AST_SEL,SELECT,,,{QUERY...},<none>
+NOTICE:  AUDIT: SESSION,72,8,AST_SEL,SELECT,,,{QUERY...},<none>
+ col_o1 | col_o2 
+--------+--------
+      2 |      3
+      4 |      5
+      6 |      7
+(3 rows)
+
+-- Function returns TABLE
+CREATE OR REPLACE FUNCTION get_table (x int)
+RETURNS TABLE(col_t1 int, col_t2 int)
+AS $$
+BEGIN
+	FOR i IN 1..x
+	LOOP
+		col_t1 := i * 2;
+		col_t2 := i * 2 + 1;
+		RETURN NEXT;
+	END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+NOTICE:  AUDIT: SESSION,73,1,DDL,CREATE FUNCTION,FUNCTION,public.get_table(integer),"CREATE OR REPLACE FUNCTION get_table (x int)
+RETURNS TABLE(col_t1 int, col_t2 int)
+AS $$
+BEGIN
+	FOR i IN 1..x
+	LOOP
+		col_t1 := i * 2;
+		col_t2 := i * 2 + 1;
+		RETURN NEXT;
+	END LOOP;
+END;
+$$ LANGUAGE plpgsql;",<none>
+SELECT * FROM get_table(2);
+NOTICE:  AUDIT: SESSION,74,1,AST_SEL,SELECT,,,"{QUERY...}{f XXXX public.get_table {col_t1,col_t2}}",<none>
+NOTICE:  AUDIT: SESSION,74,2,READ,SELECT,,,SELECT * FROM get_table(2);,<none>
+NOTICE:  AUDIT: SESSION,74,3,FUNCTION,EXECUTE,FUNCTION,public.get_table,SELECT * FROM get_table(2);,<none>
+NOTICE:  AUDIT: SESSION,74,4,AST_SEL,SELECT,,,{QUERY...},<none>
+NOTICE:  AUDIT: SESSION,74,5,READ,SELECT,,,SELECT 1,<none>
+NOTICE:  AUDIT: SESSION,74,6,AST_SEL,SELECT,,,{QUERY...},<none>
+NOTICE:  AUDIT: SESSION,74,7,AST_SEL,SELECT,,,{QUERY...},<none>
+NOTICE:  AUDIT: SESSION,74,8,AST_SEL,SELECT,,,{QUERY...},<none>
+ col_t1 | col_t2 
+--------+--------
+      2 |      3
+      4 |      5
+(2 rows)
+
+-- More than one table and function
+CREATE TABLE t2 (id2 int, txt2 text) DISTRIBUTED BY (id2);
+NOTICE:  AUDIT: SESSION,76,1,DDL,CREATE TABLE,TABLE,public.t2,"CREATE TABLE t2 (id2 int, txt2 text) DISTRIBUTED BY (id2);",<none>
+SELECT * FROM t1, t2, get_table(1), get_out_args(1);
+NOTICE:  AUDIT: SESSION,77,1,AST_SEL,SELECT,,,"{QUERY...}{r XXXX public.t2 {id2,txt2}}{f XXXX public.get_table {col_t1,col_t2}}{f XXXX public.get_out_args {col_o1,col_o2}}",<none>
+NOTICE:  AUDIT: SESSION,77,1,AST_SEL,SELECT,TABLE,public.t1,"{QUERY...}{r XXXX public.t2 {id2,txt2}}{f XXXX public.get_table {col_t1,col_t2}}{f XXXX public.get_out_args {col_o1,col_o2}}",<none>
+NOTICE:  AUDIT: SESSION,77,1,AST_SEL,SELECT,TABLE,public.t2,"{QUERY...}{r XXXX public.t2 {id2,txt2}}{f XXXX public.get_table {col_t1,col_t2}}{f XXXX public.get_out_args {col_o1,col_o2}}",<none>
+NOTICE:  AUDIT: SESSION,77,2,READ,SELECT,TABLE,public.t1,"SELECT * FROM t1, t2, get_table(1), get_out_args(1);",<none>
+NOTICE:  AUDIT: SESSION,77,2,READ,SELECT,TABLE,public.t2,"SELECT * FROM t1, t2, get_table(1), get_out_args(1);",<none>
+ id | txt | id2 | txt2 | col_t1 | col_t2 | col_o1 | col_o2 
+----+-----+-----+------+--------+--------+--------+--------
+(0 rows)
+
+-- Cleanup
+DROP FUNCTION get_t1_by_id(int);
+NOTICE:  AUDIT: SESSION,78,1,DDL,DROP FUNCTION,FUNCTION,public.get_t1_by_id(integer),DROP FUNCTION get_t1_by_id(int);,<none>
+DROP FUNCTION get_tc();
+NOTICE:  AUDIT: SESSION,79,1,DDL,DROP FUNCTION,FUNCTION,public.get_tc(),DROP FUNCTION get_tc();,<none>
+DROP FUNCTION get_records();
+NOTICE:  AUDIT: SESSION,80,1,DDL,DROP FUNCTION,FUNCTION,public.get_records(),DROP FUNCTION get_records();,<none>
+DROP FUNCTION get_out_args(int);
+NOTICE:  AUDIT: SESSION,81,1,DDL,DROP FUNCTION,FUNCTION,public.get_out_args(integer),DROP FUNCTION get_out_args(int);,<none>
+DROP FUNCTION get_table(int);
+NOTICE:  AUDIT: SESSION,82,1,DDL,DROP FUNCTION,FUNCTION,public.get_table(integer),DROP FUNCTION get_table(int);,<none>
+DROP TABLE t1;
+NOTICE:  AUDIT: SESSION,83,1,DDL,DROP TABLE,TABLE,public.t1,DROP TABLE t1;,<none>
+DROP TABLE t2;
+NOTICE:  AUDIT: SESSION,84,1,DDL,DROP TABLE,TABLE,public.t2,DROP TABLE t2;,<none>
+DROP TYPE tc;
+NOTICE:  AUDIT: SESSION,85,1,DDL,DROP TYPE,COMPOSITE TYPE,public.tc,DROP TYPE tc;,<none>
+--
 -- Delete all rows then delete 1 row
 SET pgaudit.log = 'write';
 SET pgaudit.role = 'auditor';
@@ -1112,37 +1328,37 @@ grant delete
    to auditor;
 insert into bar (col)
 		 values (1);
-NOTICE:  AUDIT: SESSION,61,1,WRITE,INSERT,TABLE,public.bar,"insert into bar (col)
+NOTICE:  AUDIT: SESSION,86,1,WRITE,INSERT,TABLE,public.bar,"insert into bar (col)
 		 values (1);",<none>
 delete from bar;
-NOTICE:  AUDIT: OBJECT,62,1,WRITE,DELETE,TABLE,public.bar,delete from bar;,<none>
-NOTICE:  AUDIT: SESSION,62,1,WRITE,DELETE,TABLE,public.bar,delete from bar;,<none>
+NOTICE:  AUDIT: OBJECT,87,1,WRITE,DELETE,TABLE,public.bar,delete from bar;,<none>
+NOTICE:  AUDIT: SESSION,87,1,WRITE,DELETE,TABLE,public.bar,delete from bar;,<none>
 insert into bar (col)
 		 values (1);
-NOTICE:  AUDIT: SESSION,63,1,WRITE,INSERT,TABLE,public.bar,"insert into bar (col)
+NOTICE:  AUDIT: SESSION,88,1,WRITE,INSERT,TABLE,public.bar,"insert into bar (col)
 		 values (1);",<none>
 delete from bar
  where col = 1;
-NOTICE:  AUDIT: OBJECT,64,1,WRITE,DELETE,TABLE,public.bar,"delete from bar
+NOTICE:  AUDIT: OBJECT,89,1,WRITE,DELETE,TABLE,public.bar,"delete from bar
  where col = 1;",<none>
-NOTICE:  AUDIT: SESSION,64,1,WRITE,DELETE,TABLE,public.bar,"delete from bar
+NOTICE:  AUDIT: SESSION,89,1,WRITE,DELETE,TABLE,public.bar,"delete from bar
  where col = 1;",<none>
 drop table bar;
 --
 -- Grant roles to each other
 SET pgaudit.log = 'role';
 GRANT user1 TO user2;
-NOTICE:  AUDIT: SESSION,65,1,ROLE,GRANT ROLE,,,GRANT user1 TO user2;,<none>
+NOTICE:  AUDIT: SESSION,90,1,ROLE,GRANT ROLE,,,GRANT user1 TO user2;,<none>
 REVOKE user1 FROM user2;
-NOTICE:  AUDIT: SESSION,66,1,ROLE,REVOKE ROLE,,,REVOKE user1 FROM user2;,<none>
+NOTICE:  AUDIT: SESSION,91,1,ROLE,REVOKE ROLE,,,REVOKE user1 FROM user2;,<none>
 --
 -- Test logging AST for CTAS
 SET pgaudit.log = 'ast_ctas';
 CREATE TABLE tmp (id int, data text) DISTRIBUTED BY (id);
 CREATE TABLE tmp2 AS (SELECT * FROM tmp) DISTRIBUTED BY (id);
-NOTICE:  AUDIT: SESSION,67,1,AST_CTAS,CREATE TABLE AS,TABLE,public.tmp2,"{QUERY...}{r XXXX public.tmp {id,data}}",<none>
+NOTICE:  AUDIT: SESSION,92,1,AST_CTAS,CREATE TABLE AS,TABLE,public.tmp2,"{QUERY...}{r XXXX public.tmp {id,data}}",<none>
 CREATE TEMP TABLE tmp3 AS (SELECT * FROM tmp) DISTRIBUTED BY (id);
-NOTICE:  AUDIT: SESSION,68,1,AST_CTAS,CREATE TABLE AS,TABLE,pg_temp_22.tmp3,"{QUERY...}{r XXXX public.tmp {id,data}}",<none>
+NOTICE:  AUDIT: SESSION,93,1,AST_CTAS,CREATE TABLE AS,TABLE,pg_temp_22.tmp3,"{QUERY...}{r XXXX public.tmp {id,data}}",<none>
 DROP TABLE tmp, tmp2, tmp3;
 --
 -- Test logging AST for SELECT
@@ -1153,7 +1369,7 @@ CREATE TABLE tmp (id int, data text) DISTRIBUTED BY (id);
 CREATE TABLE tmp2 AS (SELECT * FROM tmp) DISTRIBUTED BY (id);
 -- AST for independent select is logged
 SELECT id FROM tmp2;
-NOTICE:  AUDIT: SESSION,69,1,AST_SEL,SELECT,,,"{QUERY...}{r XXXX public.tmp2 {id,data}}",<none>
+NOTICE:  AUDIT: SESSION,94,1,AST_SEL,SELECT,,,"{QUERY...}{r XXXX public.tmp2 {id,data}}",<none>
  id 
 ----
 (0 rows)
@@ -1166,11 +1382,11 @@ SET pgaudit.log_relation = OFF;
 CREATE TABLE src (id int, txt text) DISTRIBUTED BY (id);
 CREATE TABLE dst (LIKE src) DISTRIBUTED BY (id);
 INSERT INTO dst SELECT * FROM src;
-NOTICE:  AUDIT: SESSION,70,1,AST_MOD,INSERT,,,"{QUERY...}{r XXXX public.src {id,txt}}",<none>
+NOTICE:  AUDIT: SESSION,95,1,AST_MOD,INSERT,,,"{QUERY...}{r XXXX public.src {id,txt}}",<none>
 UPDATE dst SET txt = src.txt FROM src WHERE dst.id = src.id;
-NOTICE:  AUDIT: SESSION,71,1,AST_MOD,UPDATE,,,"{QUERY...}{r XXXX public.src {id,txt}}",<none>
+NOTICE:  AUDIT: SESSION,96,1,AST_MOD,UPDATE,,,"{QUERY...}{r XXXX public.src {id,txt}}",<none>
 DELETE FROM dst USING src WHERE dst.id = src.id AND dst.txt = 'foo';
-NOTICE:  AUDIT: SESSION,72,1,AST_MOD,DELETE,,,"{QUERY...}{r XXXX public.src {id,txt}}",<none>
+NOTICE:  AUDIT: SESSION,97,1,AST_MOD,DELETE,,,"{QUERY...}{r XXXX public.src {id,txt}}",<none>
 DROP TABLE src, dst;
 -- Test create table as after extension as been dropped
 DROP EXTENSION pgaudit;
@@ -1197,9 +1413,9 @@ SET search_path = public, pg_catalog;
 -- If there was a vulnerability, these would fail with division by zero error
 CREATE TABLE wombat () DISTRIBUTED RANDOMLY;
 WARNING:  creating a table with no columns.
-NOTICE:  AUDIT: SESSION,73,1,DDL,CREATE TABLE,TABLE,public.wombat,CREATE TABLE wombat () DISTRIBUTED RANDOMLY;,<none>
+NOTICE:  AUDIT: SESSION,98,1,DDL,CREATE TABLE,TABLE,public.wombat,CREATE TABLE wombat () DISTRIBUTED RANDOMLY;,<none>
 DROP TABLE wombat;
-NOTICE:  AUDIT: SESSION,74,1,DDL,DROP TABLE,TABLE,public.wombat,DROP TABLE wombat;,<none>
+NOTICE:  AUDIT: SESSION,99,1,DDL,DROP TABLE,TABLE,public.wombat,DROP TABLE wombat;,<none>
 SET pgaudit.log = 'NONE';
 DROP EXTENSION pgaudit;
 DROP OPERATOR <> (text, text);

--- a/gpcontrib/pgaudit/expected/pgaudit.out
+++ b/gpcontrib/pgaudit/expected/pgaudit.out
@@ -21,7 +21,7 @@ CREATE TABLE tmp2 AS (SELECT * FROM tmp) DISTRIBUTED BY (id);
 NOTICE:  AUDIT: SESSION,5,1,DDL,CREATE TABLE AS,,,CREATE TABLE tmp2 AS (SELECT * FROM tmp) DISTRIBUTED BY (id);,<not logged>
 NOTICE:  AUDIT: SESSION,5,2,READ,SELECT,,,CREATE TABLE tmp2 AS (SELECT * FROM tmp) DISTRIBUTED BY (id);,<not logged>
 NOTICE:  AUDIT: SESSION,5,1,DDL,CREATE TABLE AS,TABLE,public.tmp2,CREATE TABLE tmp2 AS (SELECT * FROM tmp) DISTRIBUTED BY (id);,<not logged>
-NOTICE:  AUDIT: SESSION,5,1,AST_CTAS,CREATE TABLE AS,TABLE,public.tmp2,"{QUERY...}",<not logged>
+NOTICE:  AUDIT: SESSION,5,1,AST_CTAS,CREATE TABLE AS,TABLE,public.tmp2,"{QUERY...}{r XXXX public.tmp {id,data}}",<not logged>
 -- Reset log_client first to show that audits logs are not set to client
 RESET pgaudit.log_client;
 DROP TABLE tmp;
@@ -599,7 +599,7 @@ NOTICE:  AUDIT: SESSION,9,1,DDL,CREATE TABLE AS,TABLE,test.account_copy,"CREATE 
 SELECT *
   FROM account
 DISTRIBUTED BY (id);",<none>
-NOTICE:  AUDIT: SESSION,9,1,AST_CTAS,CREATE TABLE AS,TABLE,test.account_copy,"{QUERY...}",<none>
+NOTICE:  AUDIT: SESSION,9,1,AST_CTAS,CREATE TABLE AS,TABLE,test.account_copy,"{QUERY...}{r XXXX public.account {id,name,password,description}}",<none>
 --
 -- Copy from stdin to account copy
 COPY test.account_copy from stdin;
@@ -1140,9 +1140,9 @@ NOTICE:  AUDIT: SESSION,66,1,ROLE,REVOKE ROLE,,,REVOKE user1 FROM user2;,<none>
 SET pgaudit.log = 'ast_ctas';
 CREATE TABLE tmp (id int, data text) DISTRIBUTED BY (id);
 CREATE TABLE tmp2 AS (SELECT * FROM tmp) DISTRIBUTED BY (id);
-NOTICE:  AUDIT: SESSION,67,1,AST_CTAS,CREATE TABLE AS,TABLE,public.tmp2,"{QUERY...}",<none>
+NOTICE:  AUDIT: SESSION,67,1,AST_CTAS,CREATE TABLE AS,TABLE,public.tmp2,"{QUERY...}{r XXXX public.tmp {id,data}}",<none>
 CREATE TEMP TABLE tmp3 AS (SELECT * FROM tmp) DISTRIBUTED BY (id);
-NOTICE:  AUDIT: SESSION,68,1,AST_CTAS,CREATE TABLE AS,TABLE,pg_temp_22.tmp3,"{QUERY...}",<none>
+NOTICE:  AUDIT: SESSION,68,1,AST_CTAS,CREATE TABLE AS,TABLE,pg_temp_22.tmp3,"{QUERY...}{r XXXX public.tmp {id,data}}",<none>
 DROP TABLE tmp, tmp2, tmp3;
 --
 -- Test logging AST for SELECT

--- a/gpcontrib/pgaudit/expected/pgaudit.out
+++ b/gpcontrib/pgaudit/expected/pgaudit.out
@@ -1,16 +1,14 @@
 -- start_matchsubs
--- m/{QUERY .*}\{r /
--- s/{QUERY .*}\{r /{QUERY...}{r /
+-- m/{QUERY .* (false|true)}\{/
+-- s/{QUERY .* (false|true)}\{/{QUERY...}{/
 -- m/}\{r \d+ /
 -- s/}\{r \d+ /}{r XXXX /
--- m/{QUERY .*}\{f /
--- s/{QUERY .*}\{f /{QUERY...}{f /
 -- m/}\{f \d+ /
 -- s/}\{f \d+ /}{f XXXX /
--- m/{QUERY .*}",/
--- s/{QUERY .*}",/{QUERY...}",/
--- m/{QUERY .*},<none>/
--- s/{QUERY .*},<none>/{QUERY...},<none>/
+-- m/{QUERY .* (false|true)}",/
+-- s/{QUERY .* (false|true)}",/{QUERY...}",/
+-- m/{QUERY .* (false|true)},<none>/
+-- s/{QUERY .* (false|true)},<none>/{QUERY...},<none>/
 -- m/pg_temp_\d+/
 -- s/pg_temp_\d+/pg_temp_XX/
 -- end_matchsubs
@@ -641,7 +639,7 @@ SELECT count(*)
 	  FROM pg_class
 	 LIMIT 1
  ) subquery;
-NOTICE:  AUDIT: SESSION,15,1,AST_SEL,SELECT,,,"{QUERY...}{r XXXX pg_catalog.pg_class {relname,relnamespace,reltype,reloftype,relowner,relam,relfilenode,reltablespace,relpages,reltuples,relallvisible,reltoastrelid,relhasindex,relisshared,relpersistence,relkind,relstorage,relnatts,relchecks,relhasoids,relhaspkey,relhasrules,relhastriggers,relhassubclass,relispopulated,relreplident,relfrozenxid,relminmxid,relacl,reloptions}}",<none>
+NOTICE:  AUDIT: SESSION,15,1,AST_SEL,SELECT,,,"{QUERY...}{f XXXX pg_catalog.int8 {}}{r XXXX pg_catalog.pg_class {relname,relnamespace,reltype,reloftype,relowner,relam,relfilenode,reltablespace,relpages,reltuples,relallvisible,reltoastrelid,relhasindex,relisshared,relpersistence,relkind,relstorage,relnatts,relchecks,relhasoids,relhaspkey,relhasrules,relhastriggers,relhassubclass,relispopulated,relreplident,relfrozenxid,relminmxid,relacl,reloptions}}",<none>
 NOTICE:  AUDIT: SESSION,15,2,READ,SELECT,TABLE,pg_catalog.pg_class,"DECLARE ctest SCROLL CURSOR FOR
 SELECT count(*)
   FROM
@@ -680,7 +678,7 @@ SELECT count(*)
 	  FROM pg_class
 	 LIMIT 1
  ) subquery;
-NOTICE:  AUDIT: SESSION,20,1,AST_SEL,SELECT,,,"{QUERY...}{r XXXX pg_catalog.pg_class {relname,relnamespace,reltype,reloftype,relowner,relam,relfilenode,reltablespace,relpages,reltuples,relallvisible,reltoastrelid,relhasindex,relisshared,relpersistence,relkind,relstorage,relnatts,relchecks,relhasoids,relhaspkey,relhasrules,relhastriggers,relhassubclass,relispopulated,relreplident,relfrozenxid,relminmxid,relacl,reloptions}}",<none>
+NOTICE:  AUDIT: SESSION,20,1,AST_SEL,SELECT,,,"{QUERY...}{f XXXX pg_catalog.int8 {}}{r XXXX pg_catalog.pg_class {relname,relnamespace,reltype,reloftype,relowner,relam,relfilenode,reltablespace,relpages,reltuples,relallvisible,reltoastrelid,relhasindex,relisshared,relpersistence,relkind,relstorage,relnatts,relchecks,relhasoids,relhaspkey,relhasrules,relhastriggers,relhassubclass,relispopulated,relreplident,relfrozenxid,relminmxid,relacl,reloptions}}",<none>
  count 
 -------
      1
@@ -1289,9 +1287,9 @@ NOTICE:  AUDIT: SESSION,74,8,AST_SEL,SELECT,,,{QUERY...},<none>
 CREATE TABLE t2 (id2 int, txt2 text) DISTRIBUTED BY (id2);
 NOTICE:  AUDIT: SESSION,76,1,DDL,CREATE TABLE,TABLE,public.t2,"CREATE TABLE t2 (id2 int, txt2 text) DISTRIBUTED BY (id2);",<none>
 SELECT * FROM t1, t2, get_table(1), get_out_args(1);
-NOTICE:  AUDIT: SESSION,77,1,AST_SEL,SELECT,,,"{QUERY...}{r XXXX public.t2 {id2,txt2}}{f XXXX public.get_table {col_t1,col_t2}}{f XXXX public.get_out_args {col_o1,col_o2}}",<none>
-NOTICE:  AUDIT: SESSION,77,1,AST_SEL,SELECT,TABLE,public.t1,"{QUERY...}{r XXXX public.t2 {id2,txt2}}{f XXXX public.get_table {col_t1,col_t2}}{f XXXX public.get_out_args {col_o1,col_o2}}",<none>
-NOTICE:  AUDIT: SESSION,77,1,AST_SEL,SELECT,TABLE,public.t2,"{QUERY...}{r XXXX public.t2 {id2,txt2}}{f XXXX public.get_table {col_t1,col_t2}}{f XXXX public.get_out_args {col_o1,col_o2}}",<none>
+NOTICE:  AUDIT: SESSION,77,1,AST_SEL,SELECT,,,"{QUERY...}{r XXXX public.t1 {id,txt}}{r XXXX public.t2 {id2,txt2}}{f XXXX public.get_table {col_t1,col_t2}}{f XXXX public.get_out_args {col_o1,col_o2}}",<none>
+NOTICE:  AUDIT: SESSION,77,1,AST_SEL,SELECT,TABLE,public.t1,"{QUERY...}{r XXXX public.t1 {id,txt}}{r XXXX public.t2 {id2,txt2}}{f XXXX public.get_table {col_t1,col_t2}}{f XXXX public.get_out_args {col_o1,col_o2}}",<none>
+NOTICE:  AUDIT: SESSION,77,1,AST_SEL,SELECT,TABLE,public.t2,"{QUERY...}{r XXXX public.t1 {id,txt}}{r XXXX public.t2 {id2,txt2}}{f XXXX public.get_table {col_t1,col_t2}}{f XXXX public.get_out_args {col_o1,col_o2}}",<none>
 NOTICE:  AUDIT: SESSION,77,2,READ,SELECT,TABLE,public.t1,"SELECT * FROM t1, t2, get_table(1), get_out_args(1);",<none>
 NOTICE:  AUDIT: SESSION,77,2,READ,SELECT,TABLE,public.t2,"SELECT * FROM t1, t2, get_table(1), get_out_args(1);",<none>
  id | txt | id2 | txt2 | col_t1 | col_t2 | col_o1 | col_o2 
@@ -1382,11 +1380,11 @@ SET pgaudit.log_relation = OFF;
 CREATE TABLE src (id int, txt text) DISTRIBUTED BY (id);
 CREATE TABLE dst (LIKE src) DISTRIBUTED BY (id);
 INSERT INTO dst SELECT * FROM src;
-NOTICE:  AUDIT: SESSION,95,1,AST_MOD,INSERT,,,"{QUERY...}{r XXXX public.src {id,txt}}",<none>
+NOTICE:  AUDIT: SESSION,95,1,AST_MOD,INSERT,,,"{QUERY...}{r XXXX public.dst {id,txt}}{r XXXX public.src {id,txt}}",<none>
 UPDATE dst SET txt = src.txt FROM src WHERE dst.id = src.id;
-NOTICE:  AUDIT: SESSION,96,1,AST_MOD,UPDATE,,,"{QUERY...}{r XXXX public.src {id,txt}}",<none>
+NOTICE:  AUDIT: SESSION,96,1,AST_MOD,UPDATE,,,"{QUERY...}{r XXXX public.dst {id,txt}}{r XXXX public.src {id,txt}}",<none>
 DELETE FROM dst USING src WHERE dst.id = src.id AND dst.txt = 'foo';
-NOTICE:  AUDIT: SESSION,97,1,AST_MOD,DELETE,,,"{QUERY...}{r XXXX public.src {id,txt}}",<none>
+NOTICE:  AUDIT: SESSION,97,1,AST_MOD,DELETE,,,"{QUERY...}{r XXXX public.dst {id,txt}}{r XXXX public.src {id,txt}}",<none>
 DROP TABLE src, dst;
 -- Test create table as after extension as been dropped
 DROP EXTENSION pgaudit;

--- a/gpcontrib/pgaudit/expected/pgaudit.out
+++ b/gpcontrib/pgaudit/expected/pgaudit.out
@@ -639,7 +639,7 @@ SELECT count(*)
 	  FROM pg_class
 	 LIMIT 1
  ) subquery;
-NOTICE:  AUDIT: SESSION,15,1,AST_SEL,SELECT,,,"{QUERY...}{f XXXX pg_catalog.int8 {}}{r XXXX pg_catalog.pg_class {relname,relnamespace,reltype,reloftype,relowner,relam,relfilenode,reltablespace,relpages,reltuples,relallvisible,reltoastrelid,relhasindex,relisshared,relpersistence,relkind,relstorage,relnatts,relchecks,relhasoids,relhaspkey,relhasrules,relhastriggers,relhassubclass,relispopulated,relreplident,relfrozenxid,relminmxid,relacl,reloptions}}",<none>
+NOTICE:  AUDIT: SESSION,15,1,AST_SEL,SELECT,,,"{QUERY...}{r XXXX pg_catalog.pg_class {relname,relnamespace,reltype,reloftype,relowner,relam,relfilenode,reltablespace,relpages,reltuples,relallvisible,reltoastrelid,relhasindex,relisshared,relpersistence,relkind,relstorage,relnatts,relchecks,relhasoids,relhaspkey,relhasrules,relhastriggers,relhassubclass,relispopulated,relreplident,relfrozenxid,relminmxid,relacl,reloptions}}{f XXXX pg_catalog.int8 {}}",<none>
 NOTICE:  AUDIT: SESSION,15,2,READ,SELECT,TABLE,pg_catalog.pg_class,"DECLARE ctest SCROLL CURSOR FOR
 SELECT count(*)
   FROM
@@ -678,7 +678,7 @@ SELECT count(*)
 	  FROM pg_class
 	 LIMIT 1
  ) subquery;
-NOTICE:  AUDIT: SESSION,20,1,AST_SEL,SELECT,,,"{QUERY...}{f XXXX pg_catalog.int8 {}}{r XXXX pg_catalog.pg_class {relname,relnamespace,reltype,reloftype,relowner,relam,relfilenode,reltablespace,relpages,reltuples,relallvisible,reltoastrelid,relhasindex,relisshared,relpersistence,relkind,relstorage,relnatts,relchecks,relhasoids,relhaspkey,relhasrules,relhastriggers,relhassubclass,relispopulated,relreplident,relfrozenxid,relminmxid,relacl,reloptions}}",<none>
+NOTICE:  AUDIT: SESSION,20,1,AST_SEL,SELECT,,,"{QUERY...}{r XXXX pg_catalog.pg_class {relname,relnamespace,reltype,reloftype,relowner,relam,relfilenode,reltablespace,relpages,reltuples,relallvisible,reltoastrelid,relhasindex,relisshared,relpersistence,relkind,relstorage,relnatts,relchecks,relhasoids,relhaspkey,relhasrules,relhastriggers,relhassubclass,relispopulated,relreplident,relfrozenxid,relminmxid,relacl,reloptions}}{f XXXX pg_catalog.int8 {}}",<none>
  count 
 -------
      1

--- a/gpcontrib/pgaudit/expected/pgaudit.out
+++ b/gpcontrib/pgaudit/expected/pgaudit.out
@@ -1,4 +1,12 @@
 -- start_matchsubs
+-- m/{QUERY .*}\{r /
+-- s/{QUERY .*}\{r /{QUERY...}{r /
+-- m/}\{r \d+ /
+-- s/}\{r \d+ /}{r XXXX /
+-- m/{QUERY .*}\{f /
+-- s/{QUERY .*}\{f /{QUERY...}{f /
+-- m/}\{f \d+ /
+-- s/}\{f \d+ /}{f XXXX /
 -- m/{QUERY .*}",/
 -- s/{QUERY .*}",/{QUERY...}",/
 -- m/{QUERY .*},<none>/
@@ -607,8 +615,8 @@ SELECT *
   FROM account
  WHERE id = $1;",<none>
 EXECUTE pgclassstmt (1);
-NOTICE:  AUDIT: SESSION,12,1,AST_SEL,SELECT,,,"{QUERY...}",<none>
-NOTICE:  AUDIT: SESSION,12,1,AST_SEL,SELECT,TABLE,public.account,"{QUERY...}",<none>
+NOTICE:  AUDIT: SESSION,12,1,AST_SEL,SELECT,,,"{QUERY...}{r XXXX public.account {id,name,password,description}}",<none>
+NOTICE:  AUDIT: SESSION,12,1,AST_SEL,SELECT,TABLE,public.account,"{QUERY...}{r XXXX public.account {id,name,password,description}}",<none>
 NOTICE:  AUDIT: SESSION,12,2,READ,SELECT,TABLE,public.account,"PREPARE pgclassstmt (oid) AS
 SELECT *
   FROM account
@@ -633,7 +641,7 @@ SELECT count(*)
 	  FROM pg_class
 	 LIMIT 1
  ) subquery;
-NOTICE:  AUDIT: SESSION,15,1,AST_SEL,SELECT,,,"{QUERY...}",<none>
+NOTICE:  AUDIT: SESSION,15,1,AST_SEL,SELECT,,,"{QUERY...}{r XXXX pg_catalog.pg_class {relname,relnamespace,reltype,reloftype,relowner,relam,relfilenode,reltablespace,relpages,reltuples,relallvisible,reltoastrelid,relhasindex,relisshared,relpersistence,relkind,relstorage,relnatts,relchecks,relhasoids,relhaspkey,relhasrules,relhastriggers,relhassubclass,relispopulated,relreplident,relfrozenxid,relminmxid,relacl,reloptions}}",<none>
 NOTICE:  AUDIT: SESSION,15,2,READ,SELECT,TABLE,pg_catalog.pg_class,"DECLARE ctest SCROLL CURSOR FOR
 SELECT count(*)
   FROM
@@ -672,7 +680,7 @@ SELECT count(*)
 	  FROM pg_class
 	 LIMIT 1
  ) subquery;
-NOTICE:  AUDIT: SESSION,20,1,AST_SEL,SELECT,,,"{QUERY...}",<none>
+NOTICE:  AUDIT: SESSION,20,1,AST_SEL,SELECT,,,"{QUERY...}{r XXXX pg_catalog.pg_class {relname,relnamespace,reltype,reloftype,relowner,relam,relfilenode,reltablespace,relpages,reltuples,relallvisible,reltoastrelid,relhasindex,relisshared,relpersistence,relkind,relstorage,relnatts,relchecks,relhasoids,relhaspkey,relhasrules,relhastriggers,relhassubclass,relispopulated,relreplident,relfrozenxid,relminmxid,relacl,reloptions}}",<none>
  count 
 -------
      1
@@ -695,8 +703,8 @@ NOTICE:  AUDIT: SESSION,22,1,WRITE,PREPARE,,,"PREPARE pgclassstmt (oid) AS
 INSERT INTO test.test_insert (id)
 					  VALUES ($1);",<none>
 EXECUTE pgclassstmt (1);
-NOTICE:  AUDIT: SESSION,23,1,AST_MOD,INSERT,,,"{QUERY...}",<none>
-NOTICE:  AUDIT: SESSION,23,1,AST_MOD,INSERT,TABLE,test.test_insert,"{QUERY...}",<none>
+NOTICE:  AUDIT: SESSION,23,1,AST_MOD,INSERT,,,"{QUERY...}{r XXXX test.test_insert {id}}",<none>
+NOTICE:  AUDIT: SESSION,23,1,AST_MOD,INSERT,TABLE,test.test_insert,"{QUERY...}{r XXXX test.test_insert {id}}",<none>
 NOTICE:  AUDIT: SESSION,23,2,WRITE,INSERT,TABLE,test.test_insert,"PREPARE pgclassstmt (oid) AS
 INSERT INTO test.test_insert (id)
 					  VALUES ($1);",1
@@ -739,8 +747,8 @@ NOTICE:  AUDIT: SESSION,26,1,ROLE,GRANT,TABLE,,"GRANT SELECT
   TO PUBLIC;",<none>
 SELECT *
   FROM test;
-NOTICE:  AUDIT: SESSION,27,1,AST_SEL,SELECT,,,"{QUERY...}",<none>
-NOTICE:  AUDIT: SESSION,27,1,AST_SEL,SELECT,TABLE,public.test,"{QUERY...}",<none>
+NOTICE:  AUDIT: SESSION,27,1,AST_SEL,SELECT,,,"{QUERY...}{r XXXX public.test {id,name,description}}",<none>
+NOTICE:  AUDIT: SESSION,27,1,AST_SEL,SELECT,TABLE,public.test,"{QUERY...}{r XXXX public.test {id,name,description}}",<none>
 NOTICE:  AUDIT: SESSION,27,2,READ,SELECT,TABLE,public.test,"SELECT *
   FROM test;",<none>
  id | name | description 
@@ -750,8 +758,8 @@ NOTICE:  AUDIT: SESSION,27,2,READ,SELECT,TABLE,public.test,"SELECT *
 -- Check that statements without columns log
 SELECT
   FROM test;
-NOTICE:  AUDIT: SESSION,28,1,AST_SEL,SELECT,,,"{QUERY...}",<none>
-NOTICE:  AUDIT: SESSION,28,1,AST_SEL,SELECT,TABLE,public.test,"{QUERY...}",<none>
+NOTICE:  AUDIT: SESSION,28,1,AST_SEL,SELECT,,,"{QUERY...}{r XXXX public.test {id,name,description}}",<none>
+NOTICE:  AUDIT: SESSION,28,1,AST_SEL,SELECT,TABLE,public.test,"{QUERY...}{r XXXX public.test {id,name,description}}",<none>
 NOTICE:  AUDIT: SESSION,28,2,READ,SELECT,TABLE,public.test,"SELECT
   FROM test;",<none>
 --
@@ -759,7 +767,7 @@ NOTICE:  AUDIT: SESSION,28,2,READ,SELECT,TABLE,public.test,"SELECT
 
 SELECT 1,
 	   substring('Thomas' from 2 for 3);
-NOTICE:  AUDIT: SESSION,29,1,AST_SEL,SELECT,,,{QUERY...},<none>
+NOTICE:  AUDIT: SESSION,29,1,AST_SEL,SELECT,,,{QUERY...}{f XXXX pg_catalog.substring {}},<none>
 NOTICE:  AUDIT: SESSION,29,2,READ,SELECT,,,"SELECT 1,
 	   substring('Thomas' from 2 for 3);",<none>
  ?column? | substring 
@@ -798,20 +806,20 @@ NOTICE:  AUDIT: SESSION,31,3,MISC,EXPLAIN,,,explain select 1;,<none>
 -- Test that looks inside of do blocks log
 INSERT INTO TEST (id)
 		  VALUES (1);
-NOTICE:  AUDIT: SESSION,32,1,AST_MOD,INSERT,,,"{QUERY...}",<none>
-NOTICE:  AUDIT: SESSION,32,1,AST_MOD,INSERT,TABLE,public.test,"{QUERY...}",<none>
+NOTICE:  AUDIT: SESSION,32,1,AST_MOD,INSERT,,,"{QUERY...}{r XXXX public.test {id,name,description}}",<none>
+NOTICE:  AUDIT: SESSION,32,1,AST_MOD,INSERT,TABLE,public.test,"{QUERY...}{r XXXX public.test {id,name,description}}",<none>
 NOTICE:  AUDIT: SESSION,32,2,WRITE,INSERT,TABLE,public.test,"INSERT INTO TEST (id)
 		  VALUES (1);",<none>
 INSERT INTO TEST (id)
 		  VALUES (2);
-NOTICE:  AUDIT: SESSION,33,1,AST_MOD,INSERT,,,"{QUERY...}",<none>
-NOTICE:  AUDIT: SESSION,33,1,AST_MOD,INSERT,TABLE,public.test,"{QUERY...}",<none>
+NOTICE:  AUDIT: SESSION,33,1,AST_MOD,INSERT,,,"{QUERY...}{r XXXX public.test {id,name,description}}",<none>
+NOTICE:  AUDIT: SESSION,33,1,AST_MOD,INSERT,TABLE,public.test,"{QUERY...}{r XXXX public.test {id,name,description}}",<none>
 NOTICE:  AUDIT: SESSION,33,2,WRITE,INSERT,TABLE,public.test,"INSERT INTO TEST (id)
 		  VALUES (2);",<none>
 INSERT INTO TEST (id)
 		  VALUES (3);
-NOTICE:  AUDIT: SESSION,34,1,AST_MOD,INSERT,,,"{QUERY...}",<none>
-NOTICE:  AUDIT: SESSION,34,1,AST_MOD,INSERT,TABLE,public.test,"{QUERY...}",<none>
+NOTICE:  AUDIT: SESSION,34,1,AST_MOD,INSERT,,,"{QUERY...}{r XXXX public.test {id,name,description}}",<none>
+NOTICE:  AUDIT: SESSION,34,1,AST_MOD,INSERT,TABLE,public.test,"{QUERY...}{r XXXX public.test {id,name,description}}",<none>
 NOTICE:  AUDIT: SESSION,34,2,WRITE,INSERT,TABLE,public.test,"INSERT INTO TEST (id)
 		  VALUES (3);",<none>
 DO $$
@@ -840,21 +848,21 @@ BEGIN
 			 VALUES (result.id + 100);
 	END LOOP;
 END $$;",<none>
-NOTICE:  AUDIT: SESSION,35,2,AST_SEL,SELECT,,,"{QUERY...}",<none>
-NOTICE:  AUDIT: SESSION,35,2,AST_SEL,SELECT,TABLE,public.test,"{QUERY...}",<none>
+NOTICE:  AUDIT: SESSION,35,2,AST_SEL,SELECT,,,"{QUERY...}{r XXXX public.test {id,name,description}}",<none>
+NOTICE:  AUDIT: SESSION,35,2,AST_SEL,SELECT,TABLE,public.test,"{QUERY...}{r XXXX public.test {id,name,description}}",<none>
 NOTICE:  AUDIT: SESSION,35,3,READ,SELECT,TABLE,public.test,"SELECT id
 		  FROM test
 		ORDER BY id",<none>
-NOTICE:  AUDIT: SESSION,35,4,AST_MOD,INSERT,,,"{QUERY...}",<none>
-NOTICE:  AUDIT: SESSION,35,4,AST_MOD,INSERT,TABLE,public.test,"{QUERY...}",<none>
+NOTICE:  AUDIT: SESSION,35,4,AST_MOD,INSERT,,,"{QUERY...}{r XXXX public.test {id,name,description}}",<none>
+NOTICE:  AUDIT: SESSION,35,4,AST_MOD,INSERT,TABLE,public.test,"{QUERY...}{r XXXX public.test {id,name,description}}",<none>
 NOTICE:  AUDIT: SESSION,35,5,WRITE,INSERT,TABLE,public.test,"INSERT INTO test (id)
 			 VALUES (result.id + 100)",",,1"
-NOTICE:  AUDIT: SESSION,35,6,AST_MOD,INSERT,,,"{QUERY...}",<none>
-NOTICE:  AUDIT: SESSION,35,6,AST_MOD,INSERT,TABLE,public.test,"{QUERY...}",<none>
+NOTICE:  AUDIT: SESSION,35,6,AST_MOD,INSERT,,,"{QUERY...}{r XXXX public.test {id,name,description}}",<none>
+NOTICE:  AUDIT: SESSION,35,6,AST_MOD,INSERT,TABLE,public.test,"{QUERY...}{r XXXX public.test {id,name,description}}",<none>
 NOTICE:  AUDIT: SESSION,35,7,WRITE,INSERT,TABLE,public.test,"INSERT INTO test (id)
 			 VALUES (result.id + 100)",",,2"
-NOTICE:  AUDIT: SESSION,35,8,AST_MOD,INSERT,,,"{QUERY...}",<none>
-NOTICE:  AUDIT: SESSION,35,8,AST_MOD,INSERT,TABLE,public.test,"{QUERY...}",<none>
+NOTICE:  AUDIT: SESSION,35,8,AST_MOD,INSERT,,,"{QUERY...}{r XXXX public.test {id,name,description}}",<none>
+NOTICE:  AUDIT: SESSION,35,8,AST_MOD,INSERT,TABLE,public.test,"{QUERY...}{r XXXX public.test {id,name,description}}",<none>
 NOTICE:  AUDIT: SESSION,35,9,WRITE,INSERT,TABLE,public.test,"INSERT INTO test (id)
 			 VALUES (result.id + 100)",",,3"
 --
@@ -962,7 +970,7 @@ BEGIN
 	return a + b;
 END $$;",<none>
 SELECT int_add(1, 1);
-NOTICE:  AUDIT: SESSION,46,1,AST_SEL,SELECT,,,{QUERY...},<none>
+NOTICE:  AUDIT: SESSION,46,1,AST_SEL,SELECT,,,{QUERY...}{f XXXX public.int_add {}},<none>
 NOTICE:  AUDIT: SESSION,46,2,READ,SELECT,,,"SELECT int_add(1, 1);",<none>
 NOTICE:  AUDIT: SESSION,46,3,FUNCTION,EXECUTE,FUNCTION,public.int_add,"SELECT int_add(1, 1);",<none>
 NOTICE:  AUDIT: SESSION,46,4,AST_SEL,SELECT,,,{QUERY...},<none>
@@ -1077,13 +1085,13 @@ BEGIN
 END $$
 LANGUAGE plpgsql ;",<none>
 SELECT test();
-NOTICE:  AUDIT: SESSION,60,1,AST_SEL,SELECT,,,{QUERY...},<none>
+NOTICE:  AUDIT: SESSION,60,1,AST_SEL,SELECT,,,{QUERY...}{f XXXX public.test {}},<none>
 NOTICE:  AUDIT: SESSION,60,2,READ,SELECT,,,SELECT test();,<none>
 NOTICE:  AUDIT: SESSION,60,3,FUNCTION,EXECUTE,FUNCTION,public.test,SELECT test();,<none>
 NOTICE:  AUDIT: SESSION,60,4,AST_SEL,SELECT,,,{QUERY...},<none>
 NOTICE:  AUDIT: SESSION,60,5,READ,SELECT,,,SELECT 'cur1'::pg_catalog.refcursor,<none>
-NOTICE:  AUDIT: SESSION,60,6,AST_SEL,SELECT,,,"{QUERY...}",<none>
-NOTICE:  AUDIT: SESSION,60,6,AST_SEL,SELECT,TABLE,public.hoge,"{QUERY...}",<none>
+NOTICE:  AUDIT: SESSION,60,6,AST_SEL,SELECT,,,"{QUERY...}{r XXXX public.hoge {id}}",<none>
+NOTICE:  AUDIT: SESSION,60,6,AST_SEL,SELECT,TABLE,public.hoge,"{QUERY...}{r XXXX public.hoge {id}}",<none>
 NOTICE:  AUDIT: SESSION,60,7,READ,SELECT,TABLE,public.hoge,select * from hoge,<none>
 NOTICE:  AUDIT: SESSION,60,8,AST_SEL,SELECT,,,{QUERY...},<none>
  test 
@@ -1145,7 +1153,7 @@ CREATE TABLE tmp (id int, data text) DISTRIBUTED BY (id);
 CREATE TABLE tmp2 AS (SELECT * FROM tmp) DISTRIBUTED BY (id);
 -- AST for independent select is logged
 SELECT id FROM tmp2;
-NOTICE:  AUDIT: SESSION,69,1,AST_SEL,SELECT,,,"{QUERY...}",<none>
+NOTICE:  AUDIT: SESSION,69,1,AST_SEL,SELECT,,,"{QUERY...}{r XXXX public.tmp2 {id,data}}",<none>
  id 
 ----
 (0 rows)
@@ -1158,11 +1166,11 @@ SET pgaudit.log_relation = OFF;
 CREATE TABLE src (id int, txt text) DISTRIBUTED BY (id);
 CREATE TABLE dst (LIKE src) DISTRIBUTED BY (id);
 INSERT INTO dst SELECT * FROM src;
-NOTICE:  AUDIT: SESSION,70,1,AST_MOD,INSERT,,,"{QUERY...}",<none>
+NOTICE:  AUDIT: SESSION,70,1,AST_MOD,INSERT,,,"{QUERY...}{r XXXX public.src {id,txt}}",<none>
 UPDATE dst SET txt = src.txt FROM src WHERE dst.id = src.id;
-NOTICE:  AUDIT: SESSION,71,1,AST_MOD,UPDATE,,,"{QUERY...}",<none>
+NOTICE:  AUDIT: SESSION,71,1,AST_MOD,UPDATE,,,"{QUERY...}{r XXXX public.src {id,txt}}",<none>
 DELETE FROM dst USING src WHERE dst.id = src.id AND dst.txt = 'foo';
-NOTICE:  AUDIT: SESSION,72,1,AST_MOD,DELETE,,,"{QUERY...}",<none>
+NOTICE:  AUDIT: SESSION,72,1,AST_MOD,DELETE,,,"{QUERY...}{r XXXX public.src {id,txt}}",<none>
 DROP TABLE src, dst;
 -- Test create table as after extension as been dropped
 DROP EXTENSION pgaudit;

--- a/gpcontrib/pgaudit/pgaudit.c
+++ b/gpcontrib/pgaudit/pgaudit.c
@@ -23,6 +23,7 @@
 #include "commands/event_trigger.h"
 #include "executor/executor.h"
 #include "executor/spi.h"
+#include "funcapi.h"
 #include "miscadmin.h"
 #include "libpq/auth.h"
 #include "nodes/nodes.h"
@@ -1501,6 +1502,181 @@ pgaudit_object_access_hook(ObjectAccessType access,
         (*next_object_access_hook) (access, classId, objectId, subId, arg);
 }
 
+/* Fill in the list with oids of relations and functions used in the query */
+static bool
+walker_rel_and_func(Node *node, List **oids)
+{
+    if (node == NULL)
+        return false;
+
+    if (IsA(node, Query))
+        return query_tree_walker((Query *) node, walker_rel_and_func, oids,
+                                 QTW_EXAMINE_RTES);
+
+    if (IsA(node, RangeTblEntry))
+    {
+        RangeTblEntry *rte = (RangeTblEntry *) node;
+        if (rte->rtekind == RTE_RELATION)
+            *oids = list_append_unique_oid(*oids, rte->relid);
+        return false;
+    }
+
+    if (IsA(node, FuncExpr))
+        *oids = list_append_unique_oid(*oids, ((FuncExpr *) node)->funcid);
+
+    return expression_tree_walker(node, walker_rel_and_func, oids);
+}
+
+static void
+append_func_out_args(StringInfo str, HeapTuple htFunc)
+{
+    Form_pg_proc func = (Form_pg_proc) GETSTRUCT(htFunc);
+
+    if (func->prorettype == RECORDOID)
+    {
+        Oid *argtypes;
+        char **argnames;
+        char *argmodes;
+        int numargs = get_func_arg_info(htFunc, &argtypes,
+                                        &argnames, &argmodes);
+        pfree(argtypes);
+
+        if (argmodes != NULL && argnames != NULL)
+        {
+            bool printComma = false;
+            for (int i = 0; i < numargs; i++)
+                if (argmodes[i] == PROARGMODE_OUT ||
+                    argmodes[i] == PROARGMODE_TABLE)
+                {
+                    if (printComma)
+                        appendStringInfoChar(str, ',');
+
+                    if (argnames[i] != NULL)
+                        appendStringInfoString(str, argnames[i]);
+
+                    printComma = true;
+                }
+        }
+
+        if (argnames != NULL)
+            pfree(argnames);
+        if (argmodes != NULL)
+            pfree(argmodes);
+        return;
+    }
+
+    HeapTuple htType = SearchSysCache1(TYPEOID,
+                                       ObjectIdGetDatum(func->prorettype));
+    if (!HeapTupleIsValid(htType))
+        return;
+
+    Form_pg_type type = (Form_pg_type) GETSTRUCT(htType);
+    Oid typrelid = type->typrelid;
+    ReleaseSysCache(htType);
+
+    if (typrelid == 0)
+        return;
+
+    HeapTuple htRel = SearchSysCache1(RELOID, ObjectIdGetDatum(typrelid));
+    if (!HeapTupleIsValid(htRel))
+        return;
+
+    Form_pg_class rel = (Form_pg_class) GETSTRUCT(htRel);
+    for (AttrNumber n = 1; n <= rel->relnatts; n++)
+    {
+        char *att = get_attname(typrelid, n);
+        if (att == NULL)
+            break;
+
+        if (n > 1)
+            appendStringInfoChar(str, ',');
+
+        appendStringInfoString(str, att);
+        pfree(att);
+    }
+    ReleaseSysCache(htRel);
+}
+
+static void
+append_rel_attrs(StringInfo str, Oid relOid, int16 natts)
+{
+    for (AttrNumber n = 1; n <= natts; n++)
+    {
+        char *att = get_attname(relOid, n);
+        if (att == NULL)
+            break;
+
+        if (n > 1)
+            appendStringInfoChar(str, ',');
+
+        appendStringInfoString(str, att);
+        pfree(att);
+    }
+}
+
+static void
+append_name(StringInfo str, char type, Oid oid, Oid namespace, Name name)
+{
+    appendStringInfo(str, "{%c %u ", type, oid);
+    char *strNS = get_namespace_name(namespace);
+    if (strNS != NULL)
+    {
+        appendStringInfo(str, "%s.", strNS);
+        pfree(strNS);
+    }
+    appendStringInfo(str, "%s {", NameStr(*name));
+}
+
+static char *
+query_to_text(Query *parse)
+{
+    const ListCell *cell;
+    StringInfoData str;
+    List *oids = NIL;
+    char *parseStr = nodeToString(parse);
+
+    query_tree_walker(parse, walker_rel_and_func, &oids, QTW_EXAMINE_RTES);
+    if (oids == NIL)
+        return parseStr;
+
+    initStringInfo(&str);
+    appendStringInfoString(&str, parseStr);
+    pfree(parseStr);
+
+    foreach(cell, oids)
+    {
+        Oid oid = lfirst_oid(cell);
+        HeapTuple htFunc = SearchSysCache1(PROCOID, ObjectIdGetDatum(oid));
+
+        if (HeapTupleIsValid(htFunc))
+        {
+            Form_pg_proc func = (Form_pg_proc) GETSTRUCT(htFunc);
+            append_name(&str, 'f', oid, func->pronamespace, &func->proname);
+
+            if (func->proretset)
+                append_func_out_args(&str, htFunc);
+
+            appendStringInfoString(&str, "}}");
+            ReleaseSysCache(htFunc);
+        }
+        else
+        {
+            HeapTuple htRel = SearchSysCache1(RELOID, ObjectIdGetDatum(oid));
+            if (!HeapTupleIsValid(htRel))
+                continue;
+
+            Form_pg_class reltup = (Form_pg_class) GETSTRUCT(htRel);
+            append_name(&str, 'r', oid, reltup->relnamespace, &reltup->relname);
+            append_rel_attrs(&str, oid, reltup->relnatts);
+            appendStringInfoString(&str, "}}");
+            ReleaseSysCache(htRel);
+        }
+    }
+
+    list_free(oids);
+    return str.data;
+}
+
 static PlannedStmt *
 pgaudit_planner_hook(Query *parse, int cursorOptions, ParamListInfo boundParams)
 {
@@ -1516,7 +1692,7 @@ pgaudit_planner_hook(Query *parse, int cursorOptions, ParamListInfo boundParams)
              parse->commandType == CMD_DELETE))))
     {
         AuditEventStackItem *stackItem = stack_push_cmd(parse->commandType);
-        stackItem->auditEvent.commandText = nodeToString(parse);
+        stackItem->auditEvent.commandText = query_to_text(parse);
         log_audit_event(stackItem);
     }
 
@@ -1656,7 +1832,7 @@ pgaudit_ddl_command_end(PG_FUNCTION_ARGS)
                 }
 
                 auditEventStack->auditEvent.commandText =
-                    nodeToString(linitial(rewritten));
+                    query_to_text(linitial(rewritten));
                 auditEventStack->auditEvent.logged = false;
                 log_audit_event(auditEventStack);
             }

--- a/gpcontrib/pgaudit/pgaudit.c
+++ b/gpcontrib/pgaudit/pgaudit.c
@@ -1527,8 +1527,17 @@ walker_rel_and_func(Node *node, QueryOids *oids)
         return false;
     }
 
+    if (IsA(node, Aggref))
+        oids->func_oids = list_append_unique_oid(oids->func_oids,
+                                                 ((Aggref *) node)->aggfnoid);
+
+    if (IsA(node, WindowFunc))
+        oids->func_oids = list_append_unique_oid(oids->func_oids,
+                                               ((WindowFunc *) node)->winfnoid);
+
     if (IsA(node, FuncExpr))
-        oids->func_oids = list_append_unique_oid(oids->func_oids, ((FuncExpr *) node)->funcid);
+        oids->func_oids = list_append_unique_oid(oids->func_oids,
+                                                 ((FuncExpr *) node)->funcid);
 
     return expression_tree_walker(node, walker_rel_and_func, oids);
 }

--- a/gpcontrib/pgaudit/pgaudit.c
+++ b/gpcontrib/pgaudit/pgaudit.c
@@ -229,6 +229,12 @@ char *auditRole = NULL;
 #define TOKEN_PASSWORD             "password"
 #define TOKEN_REDACTED             "<REDACTED>"
 
+typedef struct
+{
+    List *rel_oids;
+    List *func_oids;
+} QueryOids;
+
 /*
  * An AuditEvent represents an operation that potentially affects a single
  * object.  If a statement affects multiple objects then multiple AuditEvents
@@ -1504,7 +1510,7 @@ pgaudit_object_access_hook(ObjectAccessType access,
 
 /* Fill in the list with oids of relations and functions used in the query */
 static bool
-walker_rel_and_func(Node *node, List **oids)
+walker_rel_and_func(Node *node, QueryOids *oids)
 {
     if (node == NULL)
         return false;
@@ -1517,12 +1523,12 @@ walker_rel_and_func(Node *node, List **oids)
     {
         RangeTblEntry *rte = (RangeTblEntry *) node;
         if (rte->rtekind == RTE_RELATION)
-            *oids = list_append_unique_oid(*oids, rte->relid);
+            oids->rel_oids = list_append_unique_oid(oids->rel_oids, rte->relid);
         return false;
     }
 
     if (IsA(node, FuncExpr))
-        *oids = list_append_unique_oid(*oids, ((FuncExpr *) node)->funcid);
+        oids->func_oids = list_append_unique_oid(oids->func_oids, ((FuncExpr *) node)->funcid);
 
     return expression_tree_walker(node, walker_rel_and_func, oids);
 }
@@ -1637,18 +1643,33 @@ query_to_text(Query *parse)
 {
     const ListCell *cell;
     StringInfoData str;
-    List *oids = NIL;
+    QueryOids oids = {NIL, NIL};
     char *parseStr = nodeToString(parse);
 
     query_tree_walker(parse, walker_rel_and_func, &oids, QTW_EXAMINE_RTES);
-    if (oids == NIL)
+    if (oids.rel_oids == NIL && oids.func_oids == NIL)
         return parseStr;
 
     initStringInfo(&str);
     appendStringInfoString(&str, parseStr);
     pfree(parseStr);
 
-    foreach(cell, oids)
+    foreach(cell, oids.rel_oids)
+    {
+        Oid oid = lfirst_oid(cell);
+        HeapTuple htRel = SearchSysCache1(RELOID, ObjectIdGetDatum(oid));
+
+        if (HeapTupleIsValid(htRel))
+        {
+            Form_pg_class reltup = (Form_pg_class) GETSTRUCT(htRel);
+            append_name(&str, 'r', oid, reltup->relnamespace, &reltup->relname);
+            append_rel_attrs(&str, oid, reltup->relnatts);
+            appendStringInfoString(&str, "}}");
+            ReleaseSysCache(htRel);
+        }
+    }
+
+    foreach(cell, oids.func_oids)
     {
         Oid oid = lfirst_oid(cell);
         HeapTuple htFunc = SearchSysCache1(PROCOID, ObjectIdGetDatum(oid));
@@ -1664,21 +1685,10 @@ query_to_text(Query *parse)
             appendStringInfoString(&str, "}}");
             ReleaseSysCache(htFunc);
         }
-        else
-        {
-            HeapTuple htRel = SearchSysCache1(RELOID, ObjectIdGetDatum(oid));
-            if (!HeapTupleIsValid(htRel))
-                continue;
-
-            Form_pg_class reltup = (Form_pg_class) GETSTRUCT(htRel);
-            append_name(&str, 'r', oid, reltup->relnamespace, &reltup->relname);
-            append_rel_attrs(&str, oid, reltup->relnatts);
-            appendStringInfoString(&str, "}}");
-            ReleaseSysCache(htRel);
-        }
     }
 
-    list_free(oids);
+    list_free(oids.rel_oids);
+    list_free(oids.func_oids);
     return str.data;
 }
 

--- a/gpcontrib/pgaudit/pgaudit.c
+++ b/gpcontrib/pgaudit/pgaudit.c
@@ -1559,7 +1559,12 @@ append_func_out_args(StringInfo str, HeapTuple htFunc)
         }
 
         if (argnames != NULL)
+        {
+            for (int i = 0; i < numargs; i++)
+                pfree(argnames[i]);
             pfree(argnames);
+        }
+
         if (argmodes != NULL)
             pfree(argmodes);
         return;

--- a/gpcontrib/pgaudit/sql/pgaudit.sql
+++ b/gpcontrib/pgaudit/sql/pgaudit.sql
@@ -719,6 +719,114 @@ LANGUAGE plpgsql ;
 SELECT test();
 
 --
+-- Test function oid mapping with name
+
+-- Function returns SETOF <tablename>
+-- start_ignore
+DROP TABLE IF EXISTS t1;
+-- end_ignore
+CREATE TABLE t1 (id int, txt text) DISTRIBUTED BY (id);
+
+CREATE OR REPLACE FUNCTION get_t1_by_id(p_id int)
+RETURNS SETOF t1 AS $$
+DECLARE
+	r t1%rowtype;
+BEGIN
+	FOR r IN
+		SELECT * FROM t1 WHERE id < p_id
+	LOOP
+		RETURN NEXT r;
+	END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT * FROM get_t1_by_id(10);
+
+-- Function returns SETOF composite type
+-- start_ignore
+DROP TYPE IF EXISTS tc;
+-- end_ignore
+
+CREATE TYPE tc AS (i int, d numeric(10,2));
+
+CREATE OR REPLACE FUNCTION get_tc()
+RETURNS SETOF tc AS $$
+BEGIN
+	RETURN NEXT ROW(1, 1.1)::tc;
+	RETURN NEXT ROW(2, 2.2)::tc;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT * FROM get_tc();
+
+-- pgaudit logs a function name only, if the function returns SETOF record
+CREATE OR REPLACE FUNCTION get_records()
+RETURNS SETOF record AS $$
+DECLARE
+	r t1%rowtype;
+BEGIN
+	FOR r IN
+		SELECT * FROM t1
+	LOOP
+		RETURN NEXT (r.id, r.txt, 5::int)::record;
+	END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT * FROM get_records() a (id int, txt text, extra int);
+
+-- Function returns SETOF record and has output arguments
+CREATE OR REPLACE FUNCTION get_out_args (x int, OUT col_o1 int, OUT col_o2 int)
+RETURNS SETOF record
+AS $$
+BEGIN
+	FOR i IN 1..x
+	LOOP
+		col_o1 := i * 2;
+		col_o2 := i * 2 + 1;
+		RETURN NEXT;
+	END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT * FROM get_out_args(3);
+
+-- Function returns TABLE
+CREATE OR REPLACE FUNCTION get_table (x int)
+RETURNS TABLE(col_t1 int, col_t2 int)
+AS $$
+BEGIN
+	FOR i IN 1..x
+	LOOP
+		col_t1 := i * 2;
+		col_t2 := i * 2 + 1;
+		RETURN NEXT;
+	END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT * FROM get_table(2);
+
+-- More than one table and function
+-- start_ignore
+DROP TABLE IF EXISTS t2;
+-- end_ignore
+CREATE TABLE t2 (id2 int, txt2 text) DISTRIBUTED BY (id2);
+
+SELECT * FROM t1, t2, get_table(1), get_out_args(1);
+
+-- Cleanup
+DROP FUNCTION get_t1_by_id(int);
+DROP FUNCTION get_tc();
+DROP FUNCTION get_records();
+DROP FUNCTION get_out_args(int);
+DROP FUNCTION get_table(int);
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TYPE tc;
+
+
+--
 -- Delete all rows then delete 1 row
 SET pgaudit.log = 'write';
 SET pgaudit.role = 'auditor';

--- a/gpcontrib/pgaudit/sql/pgaudit.sql
+++ b/gpcontrib/pgaudit/sql/pgaudit.sql
@@ -1,16 +1,14 @@
 -- start_matchsubs
--- m/{QUERY .*}\{r /
--- s/{QUERY .*}\{r /{QUERY...}{r /
+-- m/{QUERY .* (false|true)}\{/
+-- s/{QUERY .* (false|true)}\{/{QUERY...}{/
 -- m/}\{r \d+ /
 -- s/}\{r \d+ /}{r XXXX /
--- m/{QUERY .*}\{f /
--- s/{QUERY .*}\{f /{QUERY...}{f /
 -- m/}\{f \d+ /
 -- s/}\{f \d+ /}{f XXXX /
--- m/{QUERY .*}",/
--- s/{QUERY .*}",/{QUERY...}",/
--- m/{QUERY .*},<none>/
--- s/{QUERY .*},<none>/{QUERY...},<none>/
+-- m/{QUERY .* (false|true)}",/
+-- s/{QUERY .* (false|true)}",/{QUERY...}",/
+-- m/{QUERY .* (false|true)},<none>/
+-- s/{QUERY .* (false|true)},<none>/{QUERY...},<none>/
 -- m/pg_temp_\d+/
 -- s/pg_temp_\d+/pg_temp_XX/
 -- end_matchsubs

--- a/gpcontrib/pgaudit/sql/pgaudit.sql
+++ b/gpcontrib/pgaudit/sql/pgaudit.sql
@@ -1,4 +1,12 @@
 -- start_matchsubs
+-- m/{QUERY .*}\{r /
+-- s/{QUERY .*}\{r /{QUERY...}{r /
+-- m/}\{r \d+ /
+-- s/}\{r \d+ /}{r XXXX /
+-- m/{QUERY .*}\{f /
+-- s/{QUERY .*}\{f /{QUERY...}{f /
+-- m/}\{f \d+ /
+-- s/}\{f \d+ /}{f XXXX /
 -- m/{QUERY .*}",/
 -- s/{QUERY .*}",/{QUERY...}",/
 -- m/{QUERY .*},<none>/

--- a/gpcontrib/pgaudit/sql/pgaudit.sql
+++ b/gpcontrib/pgaudit/sql/pgaudit.sql
@@ -813,6 +813,12 @@ CREATE TABLE t2 (id2 int, txt2 text) DISTRIBUTED BY (id2);
 
 SELECT * FROM t1, t2, get_table(1), get_out_args(1);
 
+-- Aggregate function
+SELECT max(id) FROM t1;
+
+-- Window function
+SELECT max(id) OVER(PARTITION BY txt) FROM t1;
+
 -- Cleanup
 DROP FUNCTION get_t1_by_id(int);
 DROP FUNCTION get_tc();


### PR DESCRIPTION
It is necessary to know names of tables and functions used in a query, but AST
contains oids only. We cannot use the system catalog tables to find out
the names, because tables and functions may have been dropped before the logs
are analysed.

Append oids mappings with names of relations and functions to AST. These
mappings also contain list of columns to get column name by its index.

The nodeToString function is replaced with query_to_text. This new function
finds out relations and functions oids in the Query structure. If they exist,
the function appends records about them to the output of nodeToString.
Otherwise, query_to_text return value is the same as that of nodeToString.