### PR TITLE
Fix: widen MotionLayerState stat counters from uint32 to uint64

### DIFF
--- a/src/backend/cdb/motion/cdbmotion.c
+++ b/src/backend/cdb/motion/cdbmotion.c
@@ -129,8 +129,8 @@ RemoveMotionLayer(MotionLayerState *mlStates)
 	/* Emit statistics to log */
 	if (gp_log_interconnect >= GPVARS_VERBOSITY_VERBOSE)
 		elog(LOG, "RemoveMotionLayer(): dumping stats\n"
-			 "      Sent: %9u chunks %9u total bytes %9u tuple bytes\n"
-			 "  Received: %9u chunks %9u total bytes %9u tuple bytes; "
+			 "      Sent: %9lu chunks %9lu total bytes %9lu tuple bytes\n"
+			 "  Received: %9lu chunks %9lu total bytes %9lu tuple bytes; "
 			 "%9u chunkproc calls\n",
 			 mlStates->stat_total_chunks_sent,
 			 mlStates->stat_total_bytes_sent,

--- a/src/include/cdb/cdbinterconnect.h
+++ b/src/include/cdb/cdbinterconnect.h
@@ -537,13 +537,13 @@ typedef struct MotionLayerState
 	/*
 	 * GLOBAL MOTION-LAYER STATISTICS
 	 */
-	uint32		stat_total_chunks_sent; /* Tuple-chunks sent. */
-	uint32		stat_total_bytes_sent;	/* Bytes sent, including headers. */
-	uint32		stat_tuple_bytes_sent;	/* Bytes of pure tuple-data sent. */
+	uint64		stat_total_chunks_sent; /* Tuple-chunks sent. */
+	uint64		stat_total_bytes_sent;	/* Bytes sent, including headers. */
+	uint64		stat_tuple_bytes_sent;	/* Bytes of pure tuple-data sent. */
 
-	uint32		stat_total_chunks_recvd;/* Tuple-chunks received. */
-	uint32		stat_total_bytes_recvd; /* Bytes received, including headers. */
-	uint32		stat_tuple_bytes_recvd; /* Bytes of pure tuple-data received. */
+	uint64		stat_total_chunks_recvd;/* Tuple-chunks received. */
+	uint64		stat_total_bytes_recvd; /* Bytes received, including headers. */
+	uint64		stat_tuple_bytes_recvd; /* Bytes of pure tuple-data received. */
 
 	uint32		stat_total_chunkproc_calls;		/* Calls to processIncomingChunks() */
 


### PR DESCRIPTION
MotionLayerState accumulates stats across all MotionNodeEntry instances.
Per-node entries already use uint64 [0]. The global sum ≥ any individual node,
so it overflows first — at 4GB. Fix by widening to uint64.

Also fix the debug elog() format specifiers to match.

[0] https://github.com/open-gpdb/gpdb/blob/e0db8c33c80117241f88cecca225c9fcd39dd28f/src/include/cdb/cdbinterconnect.h#L498