### PR TITLE
[yagp_hooks_collector] Port fixes from Cloudberry

### DIFF
--- a/gpcontrib/yagp_hooks_collector/src/EventSender.cpp
+++ b/gpcontrib/yagp_hooks_collector/src/EventSender.cpp
@@ -41,6 +41,10 @@ bool EventSender::verify_query(QueryDesc *query_desc, QueryState state,
     // not executed yet, causing DONE to be skipped/added.
     config.sync();
 
+    if (!config.enable_collector()) {
+      return false;
+    }
+
     if (utility && !config.enable_utility()) {
       return false;
     }
@@ -123,7 +127,7 @@ void EventSender::query_metrics_collect(QueryMetricsStatus status, void *arg,
     collect_query_done(query_desc, utility, status, edata);
     break;
   default:
-    ereport(FATAL, (errmsg("Unknown query status: %d", status)));
+    ereport(ERROR, (errmsg("Unknown query status: %d", status)));
   }
 }
 
@@ -253,7 +257,7 @@ void EventSender::report_query_done(QueryDesc *query_desc, QueryItem &query,
     msg = "cancelled";
     break;
   default:
-    ereport(FATAL,
+    ereport(ERROR,
             (errmsg("Unexpected query status in query_done hook: %d", status)));
   }
   auto prev_state = query.state;
@@ -382,13 +386,11 @@ EventSender::EventSender() {
   // Perform initial sync to get default GUC values
   config.sync();
 
-  if (config.enable_collector()) {
-    try {
-      GOOGLE_PROTOBUF_VERIFY_VERSION;
-      proto_verified = true;
-    } catch (const std::exception &e) {
-      ereport(INFO, (errmsg("Unable to start query tracing %s", e.what())));
-    }
+  try {
+    GOOGLE_PROTOBUF_VERIFY_VERSION;
+    proto_verified = true;
+  } catch (const std::exception &e) {
+    ereport(INFO, (errmsg("Unable to start query tracing %s", e.what())));
   }
 #ifdef IC_TEARDOWN_HOOK
   memset(&ic_statistics, 0, sizeof(ICStatistics));

--- a/gpcontrib/yagp_hooks_collector/src/hook_wrappers.cpp
+++ b/gpcontrib/yagp_hooks_collector/src/hook_wrappers.cpp
@@ -64,7 +64,7 @@ R cpp_call(T *obj, R (T::*func)(Args...), Args... args) {
   try {
     return (obj->*func)(args...);
   } catch (const std::exception &e) {
-    ereport(FATAL, (errmsg("Unexpected exception in yagpcc %s", e.what())));
+    ereport(ERROR, (errmsg("Unexpected exception in yagpcc %s", e.what())));
   }
 }
 

--- a/src/backend/commands/portalcmds.c
+++ b/src/backend/commands/portalcmds.c
@@ -386,11 +386,23 @@ PortalCleanup(Portal portal)
 			}
 			PG_END_TRY();
 			CurrentResourceOwner = saveResourceOwner;
-		} else {
-			/* GPDB hook for collecting query info */
-			if (queryDesc->yagp_query_key && query_info_collect_hook)
-				(*query_info_collect_hook)(METRICS_QUERY_ERROR, queryDesc);
 		}
+		else
+  		{
+        	/* GPDB hook for collecting query info */
+        	if (queryDesc->yagp_query_key && query_info_collect_hook)
+        	{
+        	    PG_TRY();
+        	    {
+					(*query_info_collect_hook)(METRICS_QUERY_ERROR, queryDesc);
+        	    }
+        	    PG_CATCH();
+        	    {
+					FlushErrorState();
+        	    }
+        	    PG_END_TRY();
+        	}
+  		}
 	}
 
 	if (PortalIsParallelRetrieveCursor(portal) && pg_atomic_read_u32((pg_atomic_uint32 *) parallelCursorCount) > 0)


### PR DESCRIPTION
- Do not terminate backend when extension fails: Change ereport(FATAL) to ereport(ERROR).
- Add PG_TRY/PG_CATCH around query_info_collect_hook in PortalCleanup() error path to prevent exceptions from propagating during cleanup.
- Add missing check in verify_query() to ensure the extension does not execute main code while disabled. Always verify protobuf version once the shared library is preloaded.
