### PR TITLE
[yagp_hooks_collector] Widen proto motion stats

### DIFF
--- a/gpcontrib/yagp_hooks_collector/protos/yagpcc_metrics.proto
+++ b/gpcontrib/yagp_hooks_collector/protos/yagpcc_metrics.proto
@@ -97,9 +97,9 @@ message SystemStat {
 }
 
 message NetworkStat {
-    uint32 total_bytes  = 1;
-    uint32 tuple_bytes = 2;
-    uint32 chunks = 3;
+    uint64 total_bytes  = 1;
+    uint64 tuple_bytes = 2;
+    uint64 chunks = 3;
 }
 
 message InterconnectStat {


### PR DESCRIPTION
Correct proto definition of motion
counters since they are uint64 [0].

[0] https://github.com/open-gpdb/gpdb/commit/4e129eb06097fdc918b035bf2387e5c35578e6ac
