### PR TITLE
Fix cross-slice Shared Scan failure for CTE with replicated table in scalar subquery

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -2494,16 +2494,12 @@ shareinput_mutator_xslice_2(Node *node, PlannerInfo *root, bool fPop)
 			if (shareSliceId != motId)
 			{
 				/*
-				 * Check for cross-slice SharedScan with a replicated
-				 * table inside a SubPlan.  When the producer runs on
-				 * fewer segments than the consumer, the temp file does
-				 * not exist on all consumer segments.
-				 *
-				 * Fix: give this consumer its own copy of the
-				 * producer's underlying plan (Materialize + Scan) and
-				 * convert it to an intra-slice SHARE_MATERIAL with a
-				 * new share_id.  The consumer then materializes data
-				 * locally instead of reading cross-slice temp files.
+				 * Cross-slice SharedScan over a replicated table inside
+				 * a SubPlan: the cross-slice temp file protocol does not
+				 * work in this topology.  Give this Consumer a local copy
+				 * of the Producer's subtree with a fresh share_id /
+				 * SHARE_MATERIAL -- replicated data is identical on every
+				 * segment, so a local copy is equivalent.
 				 */
 				bool		inlined = false;
 
@@ -2513,12 +2509,7 @@ shareinput_mutator_xslice_2(Node *node, PlannerInfo *root, bool fPop)
 					int			existingNewId = -1;
 					int			k;
 
-					/*
-					 * Check if we already inlined a consumer for this
-					 * same original share_id in this same slice.  If so,
-					 * make this consumer a reader of the existing inlined
-					 * producer instead of creating another copy.
-					 */
+					/* Already inlined in this slice: reuse it as an intra-slice reader. */
 					for (k = 0; k < ctxt->inlined_count; k++)
 					{
 						if (ctxt->inlined_orig_ids[k] == origShareId &&
@@ -2531,12 +2522,7 @@ shareinput_mutator_xslice_2(Node *node, PlannerInfo *root, bool fPop)
 
 					if (existingNewId >= 0)
 					{
-						/*
-						 * Reuse the already-inlined producer: make this
-						 * consumer a reader with the same share_id.
-						 * This is intra-slice sharing, so no need to
-						 * increment nsharer_xslice.
-						 */
+						/* Intra-slice sharing -- do not bump nsharer_xslice. */
 						if (origShareId < ctxt->orig_producer_count)
 							ctxt->consumer_counts[origShareId]--;
 
@@ -2555,12 +2541,7 @@ shareinput_mutator_xslice_2(Node *node, PlannerInfo *root, bool fPop)
 						while (leaf && leaf->lefttree)
 							leaf = leaf->lefttree;
 
-						/*
-						 * Any scan over a base relation shares the Scan
-						 * struct layout (scanrelid at a fixed offset):
-						 * SeqScan, IndexScan, IndexOnlyScan, BitmapHeapScan,
-						 * TidScan, SampleScan, and the Dynamic* variants.
-						 */
+						/* Base scan over a replicated table -- safe to inline locally. */
 						if (leaf &&
 							(IsA(leaf, SeqScan) ||
 							 IsA(leaf, IndexScan) ||
@@ -2592,11 +2573,7 @@ shareinput_mutator_xslice_2(Node *node, PlannerInfo *root, bool fPop)
 
 										pfree(policy);
 
-										/*
-										 * Deep copy the producer's subtree and
-										 * assign a fresh share_id so there is no
-										 * conflict with the original producer.
-										 */
+										/* Deep-copy with a fresh share_id. */
 										if (origShareId < ctxt->orig_producer_count)
 											ctxt->consumer_counts[origShareId]--;
 
@@ -2610,10 +2587,7 @@ shareinput_mutator_xslice_2(Node *node, PlannerInfo *root, bool fPop)
 										sisc->driver_slice = motId;
 										plan->lefttree = newChild;
 
-										/*
-										 * Register the new producer so later
-										 * passes can find it.
-										 */
+										/* Register the new producer for later passes. */
 										ctxt->producers = repalloc(ctxt->producers,
 											ctxt->producer_count * sizeof(ShareInputScan *));
 										ctxt->producers[newShareId] = sisc;
@@ -2621,11 +2595,7 @@ shareinput_mutator_xslice_2(Node *node, PlannerInfo *root, bool fPop)
 											ctxt->producer_count * sizeof(int));
 										ctxt->sliceMarks[newShareId] = motId;
 
-										/*
-										 * Record the mapping so subsequent consumers
-										 * of the same CTE in this slice can reuse
-										 * this inlined producer.
-										 */
+										/* Let later Consumers of the same CTE in this slice reuse it. */
 										ctxt->inlined_count++;
 										ctxt->inlined_orig_ids = repalloc(ctxt->inlined_orig_ids,
 											ctxt->inlined_count * sizeof(int));
@@ -2775,10 +2745,9 @@ shareinput_mutator_xslice_4(Node *node, PlannerInfo *root, bool fPop)
 }
 
 /*
- * record_subplan_motid_walker
- *   Walk expressions looking for SubPlan references.  For each SubPlan found,
- *   record the current motId from the motion stack.  This tells us what slice
- *   the SubPlan actually executes in (which is the caller's slice).
+ * For each SubPlan expression, record the motId of the slice that calls
+ * it; later we use this to tell whether a Consumer lives inside a SubPlan
+ * slice.
  */
 static bool
 record_subplan_motid_walker(Node *node, ApplyShareInputContext *ctxt)

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -2437,6 +2437,12 @@ shareinput_mutator_xslice_1(Node *node, PlannerInfo *root, bool fPop)
 			ctxt->producers[sisc->share_id] = sisc;
 			ctxt->sliceMarks[sisc->share_id] = motId;
 		}
+		else
+		{
+			/* Consumer: count references to original producers */
+			if (sisc->share_id < ctxt->orig_producer_count)
+				ctxt->consumer_counts[sisc->share_id]++;
+		}
 	}
 
 	return true;
@@ -2487,13 +2493,170 @@ shareinput_mutator_xslice_2(Node *node, PlannerInfo *root, bool fPop)
 
 			if (shareSliceId != motId)
 			{
-				ShareType	stype = get_plan_share_type(plan_slicemark.plan);
+				/*
+				 * Check for cross-slice SharedScan with a replicated
+				 * table inside a SubPlan.  When the producer runs on
+				 * fewer segments than the consumer, the temp file does
+				 * not exist on all consumer segments.
+				 *
+				 * Fix: give this consumer its own copy of the
+				 * producer's underlying plan (Materialize + Scan) and
+				 * convert it to an intra-slice SHARE_MATERIAL with a
+				 * new share_id.  The consumer then materializes data
+				 * locally instead of reading cross-slice temp files.
+				 */
+				bool		inlined = false;
 
-				if (stype == SHARE_MATERIAL || stype == SHARE_SORT)
-					set_plan_share_type_xslice(plan_slicemark.plan);
+				if (ctxt->walking_subplan)
+				{
+					int			origShareId = sisc->share_id;
+					int			existingNewId = -1;
+					int			k;
 
-				incr_plan_nsharer_xslice(plan_slicemark.plan);
-				sisc->driver_slice = motId;
+					/*
+					 * Check if we already inlined a consumer for this
+					 * same original share_id in this same slice.  If so,
+					 * make this consumer a reader of the existing inlined
+					 * producer instead of creating another copy.
+					 */
+					for (k = 0; k < ctxt->inlined_count; k++)
+					{
+						if (ctxt->inlined_orig_ids[k] == origShareId &&
+							ctxt->inlined_mot_ids[k] == motId)
+						{
+							existingNewId = ctxt->inlined_new_ids[k];
+							break;
+						}
+					}
+
+					if (existingNewId >= 0)
+					{
+						/*
+						 * Reuse the already-inlined producer: make this
+						 * consumer a reader with the same share_id.
+						 * This is intra-slice sharing, so no need to
+						 * increment nsharer_xslice.
+						 */
+						if (origShareId < ctxt->orig_producer_count)
+							ctxt->consumer_counts[origShareId]--;
+
+						sisc->share_id = existingNewId;
+						sisc->share_type = SHARE_MATERIAL;
+						sisc->driver_slice = motId;
+
+						inlined = true;
+					}
+					else
+					{
+						ShareInputScan *producer = ctxt->producers[origShareId];
+						Plan	   *producerChild = producer->scan.plan.lefttree;
+						Plan	   *leaf = producerChild;
+
+						while (leaf && leaf->lefttree)
+							leaf = leaf->lefttree;
+
+						/*
+						 * Any scan over a base relation shares the Scan
+						 * struct layout (scanrelid at a fixed offset):
+						 * SeqScan, IndexScan, IndexOnlyScan, BitmapHeapScan,
+						 * TidScan, SampleScan, and the Dynamic* variants.
+						 */
+						if (leaf &&
+							(IsA(leaf, SeqScan) ||
+							 IsA(leaf, IndexScan) ||
+							 IsA(leaf, IndexOnlyScan) ||
+							 IsA(leaf, BitmapHeapScan) ||
+							 IsA(leaf, TidScan) ||
+							 IsA(leaf, DynamicSeqScan) ||
+							 IsA(leaf, DynamicIndexScan) ||
+							 IsA(leaf, DynamicBitmapHeapScan)))
+						{
+							Index		scanrelid = ((Scan *) leaf)->scanrelid;
+							List	   *rtable = glob->finalrtable;
+
+							if (scanrelid > 0 &&
+								scanrelid <= (Index) list_length(rtable))
+							{
+								RangeTblEntry *rte = rt_fetch(scanrelid, rtable);
+
+								if (rte->rtekind == RTE_RELATION)
+								{
+									GpPolicy *policy = GpPolicyFetch(rte->relid);
+
+									if (policy &&
+										policy->ptype == POLICYTYPE_REPLICATED &&
+										producerChild)
+									{
+										Plan	   *newChild;
+										int			newShareId;
+
+										pfree(policy);
+
+										/*
+										 * Deep copy the producer's subtree and
+										 * assign a fresh share_id so there is no
+										 * conflict with the original producer.
+										 */
+										if (origShareId < ctxt->orig_producer_count)
+											ctxt->consumer_counts[origShareId]--;
+
+										newChild = (Plan *) copyObject(producerChild);
+										newShareId = ctxt->producer_count;
+										ctxt->producer_count++;
+
+										set_plan_share_id(newChild, newShareId);
+										sisc->share_id = newShareId;
+										sisc->share_type = SHARE_MATERIAL;
+										sisc->driver_slice = motId;
+										plan->lefttree = newChild;
+
+										/*
+										 * Register the new producer so later
+										 * passes can find it.
+										 */
+										ctxt->producers = repalloc(ctxt->producers,
+											ctxt->producer_count * sizeof(ShareInputScan *));
+										ctxt->producers[newShareId] = sisc;
+										ctxt->sliceMarks = repalloc(ctxt->sliceMarks,
+											ctxt->producer_count * sizeof(int));
+										ctxt->sliceMarks[newShareId] = motId;
+
+										/*
+										 * Record the mapping so subsequent consumers
+										 * of the same CTE in this slice can reuse
+										 * this inlined producer.
+										 */
+										ctxt->inlined_count++;
+										ctxt->inlined_orig_ids = repalloc(ctxt->inlined_orig_ids,
+											ctxt->inlined_count * sizeof(int));
+										ctxt->inlined_mot_ids = repalloc(ctxt->inlined_mot_ids,
+											ctxt->inlined_count * sizeof(int));
+										ctxt->inlined_new_ids = repalloc(ctxt->inlined_new_ids,
+											ctxt->inlined_count * sizeof(int));
+										ctxt->inlined_orig_ids[ctxt->inlined_count - 1] = origShareId;
+										ctxt->inlined_mot_ids[ctxt->inlined_count - 1] = motId;
+										ctxt->inlined_new_ids[ctxt->inlined_count - 1] = newShareId;
+
+										inlined = true;
+									}
+									else if (policy)
+										pfree(policy);
+								}
+							}
+						}
+					}
+				}
+
+				if (!inlined)
+				{
+					ShareType	stype = get_plan_share_type(plan_slicemark.plan);
+
+					if (stype == SHARE_MATERIAL || stype == SHARE_SORT)
+						set_plan_share_type_xslice(plan_slicemark.plan);
+
+					incr_plan_nsharer_xslice(plan_slicemark.plan);
+					sisc->driver_slice = motId;
+				}
 			}
 		}
 	}
@@ -2611,21 +2774,319 @@ shareinput_mutator_xslice_4(Node *node, PlannerInfo *root, bool fPop)
 	return true;
 }
 
+/*
+ * record_subplan_motid_walker
+ *   Walk expressions looking for SubPlan references.  For each SubPlan found,
+ *   record the current motId from the motion stack.  This tells us what slice
+ *   the SubPlan actually executes in (which is the caller's slice).
+ */
+static bool
+record_subplan_motid_walker(Node *node, ApplyShareInputContext *ctxt)
+{
+	if (node == NULL)
+		return false;
+
+	if (IsA(node, SubPlan))
+	{
+		SubPlan *sp = (SubPlan *) node;
+		int		 motId = shareinput_peekmot(ctxt);
+
+		if (sp->plan_id >= 1 && sp->plan_id <= ctxt->num_subplans)
+			ctxt->subplan_motids[sp->plan_id - 1] = motId;
+
+		/* don't recurse into SubPlan's testexpr/args */
+		return false;
+	}
+
+	return expression_tree_walker(node, record_subplan_motid_walker, ctxt);
+}
+
+/*
+ * shareinput_mutator_build_subplan_motids
+ *   Pre-pass over the main plan tree to build a mapping from SubPlan plan_id
+ *   to the motId (slice) where the SubPlan is referenced.
+ *
+ *   SubPlan plan trees are walked separately by apply_shareinput_xslice, but
+ *   without motion context from the main plan.  This causes the xslice passes
+ *   to incorrectly treat SharedScan consumers in SubPlans as being in slice 0
+ *   instead of their actual execution slice.  By recording the correct motId
+ *   here, we can push it before walking each subplan.
+ */
+ static bool
+ shareinput_mutator_build_subplan_motids(Node *node, PlannerInfo *root, bool fPop)
+ {
+	 PlannerGlobal *glob = root->glob;
+	 ApplyShareInputContext *ctxt = &glob->share;
+	 Plan	   *plan = (Plan *) node;
+ 
+	 if (fPop)
+	 {
+		 if (IsA(plan, Motion))
+			 shareinput_popmot(ctxt);
+		 return false;
+	 }
+ 
+	 if (IsA(plan, Motion))
+	 {
+		 Motion	   *motion = (Motion *) plan;
+ 
+		 shareinput_pushmot(ctxt, motion->motionID);
+		 return true;
+	 }
+ 
+	 /* Scan common expression fields for SubPlan references */
+	 record_subplan_motid_walker((Node *) plan->targetlist, ctxt);
+	 record_subplan_motid_walker((Node *) plan->qual, ctxt);
+ 
+	 /*
+	  * Check additional node-type-specific expression fields where SubPlan
+	  * references may appear.  Modeled after finalize_plan() in subselect.c.
+	  */
+	 switch (nodeTag(plan))
+	 {
+		 case T_Result:
+			 record_subplan_motid_walker(((Result *) plan)->resconstantqual, ctxt);
+			 break;
+		 case T_IndexScan:
+			 record_subplan_motid_walker((Node *) ((IndexScan *) plan)->indexqual, ctxt);
+			 record_subplan_motid_walker((Node *) ((IndexScan *) plan)->indexorderby, ctxt);
+			 break;
+		 case T_IndexOnlyScan:
+			 record_subplan_motid_walker((Node *) ((IndexOnlyScan *) plan)->indexqual, ctxt);
+			 record_subplan_motid_walker((Node *) ((IndexOnlyScan *) plan)->indexorderby, ctxt);
+			 break;
+		 case T_BitmapIndexScan:
+			 record_subplan_motid_walker((Node *) ((BitmapIndexScan *) plan)->indexqual, ctxt);
+			 break;
+		 case T_BitmapHeapScan:
+			 record_subplan_motid_walker((Node *) ((BitmapHeapScan *) plan)->bitmapqualorig, ctxt);
+			 break;
+		 case T_TidScan:
+			 record_subplan_motid_walker((Node *) ((TidScan *) plan)->tidquals, ctxt);
+			 break;
+		 case T_ForeignScan:
+			 record_subplan_motid_walker((Node *) ((ForeignScan *) plan)->fdw_exprs, ctxt);
+			 break;
+		 case T_NestLoop:
+			 record_subplan_motid_walker((Node *) ((Join *) plan)->joinqual, ctxt);
+			 break;
+		 case T_MergeJoin:
+			 record_subplan_motid_walker((Node *) ((Join *) plan)->joinqual, ctxt);
+			 record_subplan_motid_walker((Node *) ((MergeJoin *) plan)->mergeclauses, ctxt);
+			 break;
+		 case T_HashJoin:
+			 record_subplan_motid_walker((Node *) ((Join *) plan)->joinqual, ctxt);
+			 record_subplan_motid_walker((Node *) ((HashJoin *) plan)->hashclauses, ctxt);
+			 record_subplan_motid_walker((Node *) ((HashJoin *) plan)->hashqualclauses, ctxt);
+			 break;
+		 case T_Limit:
+			 record_subplan_motid_walker(((Limit *) plan)->limitOffset, ctxt);
+			 record_subplan_motid_walker(((Limit *) plan)->limitCount, ctxt);
+			 break;
+		 case T_Motion:
+			 record_subplan_motid_walker((Node *) ((Motion *) plan)->hashExprs, ctxt);
+			 break;
+		 case T_ModifyTable:
+			 record_subplan_motid_walker((Node *) ((ModifyTable *) plan)->returningLists, ctxt);
+			 break;
+		 case T_ValuesScan:
+			 record_subplan_motid_walker((Node *) ((ValuesScan *) plan)->values_lists, ctxt);
+			 break;
+		 case T_WindowAgg:
+			 record_subplan_motid_walker(((WindowAgg *) plan)->startOffset, ctxt);
+			 record_subplan_motid_walker(((WindowAgg *) plan)->endOffset, ctxt);
+			 break;
+		 case T_PartitionSelector:
+			 record_subplan_motid_walker((Node *) ((PartitionSelector *) plan)->levelEqExpressions, ctxt);
+			 record_subplan_motid_walker((Node *) ((PartitionSelector *) plan)->levelExpressions, ctxt);
+			 record_subplan_motid_walker(((PartitionSelector *) plan)->residualPredicate, ctxt);
+			 record_subplan_motid_walker(((PartitionSelector *) plan)->propagationExpression, ctxt);
+			 record_subplan_motid_walker(((PartitionSelector *) plan)->printablePredicate, ctxt);
+			 record_subplan_motid_walker((Node *) ((PartitionSelector *) plan)->partTabTargetlist, ctxt);
+			 break;
+		 default:
+			 break;
+	 }
+ 
+	 return true;
+ }
+
+/*
+ * shareinput_walk_subplans
+ *   Walk all subplans using the given mutator function, pushing the correct
+ *   motId for each subplan based on where it is referenced in the main plan.
+ */
+static void
+shareinput_walk_subplans(SHAREINPUT_MUTATOR f, PlannerGlobal *glob)
+{
+	ApplyShareInputContext *ctxt = &glob->share;
+	ListCell   *lp, *lr;
+	int			i = 0;
+
+	forboth(lp, glob->subplans, lr, glob->subroots)
+	{
+		Plan	   *subplan = (Plan *) lfirst(lp);
+		PlannerInfo *subroot = (PlannerInfo *) lfirst(lr);
+
+		if (ctxt->subplan_motids != NULL && i < ctxt->num_subplans)
+			shareinput_pushmot(ctxt, ctxt->subplan_motids[i]);
+
+		ctxt->walking_subplan = true;
+		shareinput_walker(f, (Node *) subplan, subroot);
+		ctxt->walking_subplan = false;
+
+		if (ctxt->subplan_motids != NULL && i < ctxt->num_subplans)
+			shareinput_popmot(ctxt);
+
+		i++;
+	}
+}
+
+/*
+ * cleanup_orphaned_producers
+ *   After inlining, some original producers may have zero remaining
+ *   consumers.  Remove them from Sequence nodes to eliminate unnecessary
+ *   SeqScans.  Collapse Sequence nodes that end up with a single child.
+ */
+static Plan *
+cleanup_orphaned_producers(Plan *plan, ApplyShareInputContext *ctxt)
+{
+	if (plan == NULL)
+		return NULL;
+
+	if (IsA(plan, Sequence))
+	{
+		Sequence   *seq = (Sequence *) plan;
+		List	   *newplans = NIL;
+		ListCell   *lc;
+
+		foreach(lc, seq->subplans)
+		{
+			Plan	   *child = (Plan *) lfirst(lc);
+
+			child = cleanup_orphaned_producers(child, ctxt);
+
+			/* Skip orphaned SharedScan producers (those with lefttree) */
+			if (IsA(child, ShareInputScan) && child->lefttree != NULL)
+			{
+				ShareInputScan *sisc = (ShareInputScan *) child;
+
+				if (sisc->share_id < ctxt->orig_producer_count &&
+					ctxt->consumer_counts[sisc->share_id] == 0)
+					continue;
+			}
+
+			/*
+			 * Flatten nested Sequences: if a child is itself a
+			 * Sequence, splice its children into this level.
+			 */
+			if (IsA(child, Sequence))
+			{
+				Sequence   *inner = (Sequence *) child;
+				ListCell   *lc2;
+
+				foreach(lc2, inner->subplans)
+					newplans = lappend(newplans, lfirst(lc2));
+			}
+			else
+				newplans = lappend(newplans, child);
+		}
+
+		seq->subplans = newplans;
+		return plan;
+	}
+
+	if (IsA(plan, Append))
+	{
+		ListCell   *lc;
+
+		foreach(lc, ((Append *) plan)->appendplans)
+			lfirst(lc) = cleanup_orphaned_producers((Plan *) lfirst(lc), ctxt);
+	}
+	else if (IsA(plan, MergeAppend))
+	{
+		ListCell   *lc;
+
+		foreach(lc, ((MergeAppend *) plan)->mergeplans)
+			lfirst(lc) = cleanup_orphaned_producers((Plan *) lfirst(lc), ctxt);
+	}
+	else if (IsA(plan, ModifyTable))
+	{
+		ListCell   *lc;
+
+		foreach(lc, ((ModifyTable *) plan)->plans)
+			lfirst(lc) = cleanup_orphaned_producers((Plan *) lfirst(lc), ctxt);
+	}
+	else if (IsA(plan, BitmapAnd))
+	{
+		ListCell   *lc;
+
+		foreach(lc, ((BitmapAnd *) plan)->bitmapplans)
+			lfirst(lc) = cleanup_orphaned_producers((Plan *) lfirst(lc), ctxt);
+	}
+	else if (IsA(plan, BitmapOr))
+	{
+		ListCell   *lc;
+
+		foreach(lc, ((BitmapOr *) plan)->bitmapplans)
+			lfirst(lc) = cleanup_orphaned_producers((Plan *) lfirst(lc), ctxt);
+	}
+	else if (IsA(plan, SubqueryScan))
+	{
+		SubqueryScan *sub = (SubqueryScan *) plan;
+
+		sub->subplan = cleanup_orphaned_producers(sub->subplan, ctxt);
+	}
+	else
+	{
+		plan->lefttree = cleanup_orphaned_producers(plan->lefttree, ctxt);
+		plan->righttree = cleanup_orphaned_producers(plan->righttree, ctxt);
+	}
+
+	return plan;
+}
+
 Plan *
 apply_shareinput_xslice(Plan *plan, PlannerInfo *root)
 {
 	PlannerGlobal *glob = root->glob;
 	ApplyShareInputContext *ctxt = &glob->share;
-	ListCell   *lp, *lr;
 
 	ctxt->motStack = NULL;
 	ctxt->qdShares = NULL;
 	ctxt->qdSlices = NULL;
 	ctxt->nextPlanId = 0;
+	ctxt->walking_subplan = false;
+
+	ctxt->inlined_orig_ids = palloc0(sizeof(int));
+	ctxt->inlined_mot_ids = palloc0(sizeof(int));
+	ctxt->inlined_new_ids = palloc0(sizeof(int));
+	ctxt->inlined_count = 0;
+
+	ctxt->orig_producer_count = ctxt->producer_count;
+	ctxt->consumer_counts = palloc0(ctxt->producer_count * sizeof(int));
 
 	ctxt->sliceMarks = palloc0(ctxt->producer_count * sizeof(int));
 
 	shareinput_pushmot(ctxt, 0);
+
+	/*
+	 * Pre-pass: build a mapping from SubPlan plan_id to the motId (slice)
+	 * where the SubPlan is referenced in the main plan.  This is needed
+	 * because the xslice passes walk subplan trees separately, and without
+	 * this mapping they would use motId=0 for all subplan nodes.
+	 */
+	ctxt->num_subplans = list_length(glob->subplans);
+	if (ctxt->num_subplans > 0)
+	{
+		ctxt->subplan_motids = palloc0(ctxt->num_subplans * sizeof(int));
+		shareinput_walker(shareinput_mutator_build_subplan_motids,
+						  (Node *) plan, root);
+	}
+	else
+	{
+		ctxt->subplan_motids = NULL;
+	}
 
 	/*
 	 * Walk the tree.  See comment for each pass for what each pass will do.
@@ -2639,42 +3100,26 @@ apply_shareinput_xslice(Plan *plan, PlannerInfo *root)
 	 * walk through all plans and collect all producer subplans into the
 	 * context, before processing the consumers.
 	 */
-	forboth(lp, glob->subplans, lr, glob->subroots)
-	{
-		Plan	   *subplan = (Plan *) lfirst(lp);
-		PlannerInfo *subroot =  (PlannerInfo *) lfirst(lr);
-
-		shareinput_walker(shareinput_mutator_xslice_1, (Node *) subplan, subroot);
-	}
+	shareinput_walk_subplans(shareinput_mutator_xslice_1, glob);
 	shareinput_walker(shareinput_mutator_xslice_1, (Node *) plan, root);
 
 	/* Now walk the tree again, and process all the consumers. */
-	forboth(lp, glob->subplans, lr, glob->subroots)
-	{
-		Plan	   *subplan = (Plan *) lfirst(lp);
-		PlannerInfo *subroot =  (PlannerInfo *) lfirst(lr);
-
-		shareinput_walker(shareinput_mutator_xslice_2, (Node *) subplan, subroot);
-	}
+	shareinput_walk_subplans(shareinput_mutator_xslice_2, glob);
 	shareinput_walker(shareinput_mutator_xslice_2, (Node *) plan, root);
 
-	forboth(lp, glob->subplans, lr, glob->subroots)
-	{
-		Plan	   *subplan = (Plan *) lfirst(lp);
-		PlannerInfo *subroot =  (PlannerInfo *) lfirst(lr);
-
-		shareinput_walker(shareinput_mutator_xslice_3, (Node *) subplan, subroot);
-	}
+	shareinput_walk_subplans(shareinput_mutator_xslice_3, glob);
 	shareinput_walker(shareinput_mutator_xslice_3, (Node *) plan, root);
 
-	forboth(lp, glob->subplans, lr, glob->subroots)
-	{
-		Plan	   *subplan = (Plan *) lfirst(lp);
-		PlannerInfo *subroot =  (PlannerInfo *) lfirst(lr);
-
-		shareinput_walker(shareinput_mutator_xslice_4, (Node *) subplan, subroot);
-	}
+	shareinput_walk_subplans(shareinput_mutator_xslice_4, glob);
 	shareinput_walker(shareinput_mutator_xslice_4, (Node *) plan, root);
+
+	/*
+	 * Cleanup: remove orphaned SharedScan producers from Sequence nodes.
+	 * After inlining, some original producers may have lost all consumers.
+	 * Keeping them would cause unnecessary SeqScans at execution time.
+	 */
+	if (ctxt->inlined_count > 0)
+		plan = cleanup_orphaned_producers(plan, ctxt);
 
 	return plan;
 }

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h
@@ -1024,6 +1024,18 @@ public:
 
 	static BOOL FScalarConstOrBinaryCoercible(CExpression *pexpr);
 
+	// hash set from CTE ids
+	typedef CHashSet<ULONG, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+					 CleanupDelete<ULONG> >
+		UlongCteIdHashSet;
+
+	static void CollectConsumersAndProducers(CMemoryPool *mp,
+											 CExpression *pexpr,
+											 ULongPtrArray *cteConsumers,
+											 UlongCteIdHashSet *cteProducerSet);
+
+	static BOOL hasUnpairedCTEConsumer(CMemoryPool *mp, CExpression *pexpr);
+
 	static CExpression *ReplaceColrefWithProjectExpr(CMemoryPool *mp,
 													 CExpression *pexpr,
 													 CColRef *pcolref,

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -901,6 +901,62 @@ CUtils::FHasCTEAnchor(CExpression *pexpr)
 	return false;
 }
 
+// return CTEConsumers' and a set of CTEProducers' CTE ids in the given subtree
+void
+CUtils::CollectConsumersAndProducers(CMemoryPool *mp, CExpression *pexpr,
+									 ULongPtrArray *cteConsumers,
+									 UlongCteIdHashSet *cteProducerSet)
+{
+	COperator *pop = pexpr->Pop();
+
+	if (COperator::EopPhysicalCTEConsumer == pop->Eopid())
+	{
+		cteConsumers->Append(GPOS_NEW(mp) ULONG(
+			CPhysicalCTEConsumer::PopConvert(pop)->UlCTEId()));
+	}
+	else if (COperator::EopPhysicalCTEProducer == pop->Eopid())
+	{
+		cteProducerSet->Insert(GPOS_NEW(mp) ULONG(
+			CPhysicalCTEProducer::PopConvert(pop)->UlCTEId()));
+	}
+
+	for (ULONG ul = 0; ul < pexpr->Arity(); ul++)
+	{
+		CExpression *pexprChild = (*pexpr)[ul];
+
+		if (!pexprChild->Pop()->FScalar())
+		{
+			CollectConsumersAndProducers(mp, pexprChild, cteConsumers,
+										 cteProducerSet);
+		}
+	}
+}
+
+BOOL
+CUtils::hasUnpairedCTEConsumer(CMemoryPool *mp, CExpression *pexpr)
+{
+	BOOL hasUnpairedConsumer = false;
+
+	ULongPtrArray *cteConsumers = GPOS_NEW(mp) ULongPtrArray(mp);
+	UlongCteIdHashSet *cteProducerSet = GPOS_NEW(mp) UlongCteIdHashSet(mp);
+
+	CollectConsumersAndProducers(mp, pexpr, cteConsumers, cteProducerSet);
+
+	// check if every consumer's producer is in ProducerSet
+	for (ULONG ul = 0; ul < cteConsumers->Size(); ul++)
+	{
+		if (!cteProducerSet->Contains((*cteConsumers)[ul]))
+		{
+			hasUnpairedConsumer = true;
+			break;
+		}
+	}
+	cteConsumers->Release();
+	cteProducerSet->Release();
+
+	return hasUnpairedConsumer;
+}
+
 //---------------------------------------------------------------------------
 //	@class:
 //		CUtils::FHasSubqueryOrApply

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -8257,6 +8257,19 @@ CTranslatorExprToDXL::GetInputSegIdsArray(CExpression *pexprMotion)
 		// motion (which cannot be a result hash filter node) will read the
 		// input from one segment in order to ensure that data is consistent
 		// after bring read from operator delivering tainted replication.
+
+		// If any CTE Consumer beneath this motion has no matching Producer
+		// in this subtree, reducing to one segment would break Producer-
+		// Consumer locality; fall back to the Postgres optimizer.
+		// Related to: https://github.com/greenplum-db/gpdb/issues/13039
+		if (CUtils::hasUnpairedCTEConsumer(m_mp, pexprMotion))
+		{
+			GPOS_RAISE(
+				gpdxl::ExmaDXL, gpdxl::ExmiExpr2DXLUnsupportedFeature,
+				GPOS_WSZ_LIT(
+					"CTE Consumer without the appropriate CTE Producer under a duplicate-hazard motion or a tainted replicated node"));
+		}
+
 		IntPtrArray *pdrgpi = GPOS_NEW(m_mp) IntPtrArray(m_mp);
 		INT iSegmentId = *((*m_pdrgpiSegments)[0]);
 		pdrgpi->Append(GPOS_NEW(m_mp) INT(iSegmentId));

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -96,6 +96,30 @@ typedef struct ApplyShareInputContext
 	int		   *sliceMarks;			/* one for each producer */
 	int			producer_count;
 
+	int		   *subplan_motids;		/* motId for each subplan, indexed by plan_id-1 */
+	int			num_subplans;
+
+	bool		walking_subplan;	/* true when walking a SubPlan tree */
+
+	/*
+	 * Track already-inlined cross-slice producers so that a second consumer
+	 * of the same CTE in the same slice can share the inlined copy instead
+	 * of creating yet another independent scan.
+	 *
+	 * Each entry maps (orig_share_id, motId) → new_share_id.
+	 */
+	int		   *inlined_orig_ids;	/* original share_id */
+	int		   *inlined_mot_ids;	/* slice (motId) where it was inlined */
+	int		   *inlined_new_ids;	/* new share_id of the inlined producer */
+	int			inlined_count;
+
+	/*
+	 * Consumer reference counts for original producers, used to detect
+	 * orphaned producers after inlining (those with zero remaining consumers).
+	 */
+	int		   *consumer_counts;	/* consumer count per producer */
+	int			orig_producer_count;	/* producer_count before inlining */
+
 } ApplyShareInputContext;
 
 

--- a/src/test/regress/expected/qp_orca_fallback.out
+++ b/src/test/regress/expected/qp_orca_fallback.out
@@ -330,3 +330,51 @@ SELECT * FROM jsonb_array_elements('["b", "a"]'::jsonb) WITH ORDINALITY;
  "a"   |          2
 (2 rows)
 
+
+-- ORCA should fallback in case there are any CTE Consumers beneath a duplicate-hazard motion
+-- Should be removed after issue#13039 is fixed
+-- start_ignore
+DROP TABLE IF EXISTS tbl1, tbl2;
+CREATE TABLE tbl2 (
+	id numeric NULL,
+	refrcode varchar(255) NULL,
+	referenceid numeric NULL
+)
+DISTRIBUTED REPLICATED;
+
+CREATE TABLE tbl1 (
+	id bigserial NOT NULL,
+	iscalctrg varchar(15) NOT NULL,
+	iscalcdetail varchar(15) NULL
+)
+DISTRIBUTED REPLICATED;
+-- end_ignore
+EXPLAIN WITH
+t1 AS (SELECT * FROM tbl1),
+t2 AS (SELECT id, refrcode FROM tbl2 WHERE REFERENCEID = 101991)
+ SELECT p.*FROM t1 p
+  JOIN t2 r
+   ON p.isCalcTRG = r.RefrCode
+  JOIN t2 r1
+   ON p.isCalcDetail = r1.RefrCode
+ LIMIT 1;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Limit  (cost=0.34..83.24 rows=1 width=104)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.34..581.83 rows=8 width=104)
+         ->  Hash Join  (cost=0.34..581.69 rows=8 width=104)
+               Hash Cond: ((tbl1.iscalcdetail)::text = (r1.refrcode)::text)
+               ->  Hash Join  (cost=0.17..580.97 rows=130 width=104)
+                     Hash Cond: ((tbl1.iscalctrg)::text = (r.refrcode)::text)
+                     ->  Seq Scan on tbl1  (cost=0.00..344.00 rows=24400 width=104)
+                     ->  Hash  (cost=166.30..166.30 rows=2 width=548)
+                           ->  Subquery Scan on r  (cost=0.00..166.30 rows=6 width=548)
+                                 ->  Seq Scan on tbl2  (cost=0.00..166.25 rows=6 width=548)
+                                       Filter: (referenceid = 101991::numeric)
+               ->  Hash  (cost=166.30..166.30 rows=2 width=548)
+                     ->  Subquery Scan on r1  (cost=0.00..166.30 rows=6 width=548)
+                           ->  Seq Scan on tbl2 tbl2_1  (cost=0.00..166.25 rows=6 width=548)
+                                 Filter: (referenceid = 101991::numeric)
+ Optimizer: Postgres query optimizer
+(16 rows)
+

--- a/src/test/regress/expected/qp_orca_fallback_optimizer.out
+++ b/src/test/regress/expected/qp_orca_fallback_optimizer.out
@@ -384,3 +384,53 @@ DETAIL:  Feature not supported: WITH ORDINALITY
  "a"   |          2
 (2 rows)
 
+
+-- ORCA should fallback in case there are any CTE Consumers beneath a duplicate-hazard motion
+-- Should be removed after issue#13039 is fixed
+-- start_ignore
+DROP TABLE IF EXISTS tbl1, tbl2;
+CREATE TABLE tbl2 (
+	id numeric NULL,
+	refrcode varchar(255) NULL,
+	referenceid numeric NULL
+)
+DISTRIBUTED REPLICATED;
+
+CREATE TABLE tbl1 (
+	id bigserial NOT NULL,
+	iscalctrg varchar(15) NOT NULL,
+	iscalcdetail varchar(15) NULL
+)
+DISTRIBUTED REPLICATED;
+-- end_ignore
+EXPLAIN WITH
+t1 AS (SELECT * FROM tbl1),
+t2 AS (SELECT id, refrcode FROM tbl2 WHERE REFERENCEID = 101991)
+ SELECT p.*FROM t1 p
+  JOIN t2 r
+   ON p.isCalcTRG = r.RefrCode
+  JOIN t2 r1
+   ON p.isCalcDetail = r1.RefrCode
+ LIMIT 1;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: CTE Consumer without the appropriate CTE Producer under a duplicate-hazard motion or a tainted replicated node
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Limit  (cost=0.34..83.24 rows=1 width=104)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.34..581.83 rows=8 width=104)
+         ->  Hash Join  (cost=0.34..581.69 rows=8 width=104)
+               Hash Cond: ((tbl1.iscalcdetail)::text = (r1.refrcode)::text)
+               ->  Hash Join  (cost=0.17..580.97 rows=130 width=104)
+                     Hash Cond: ((tbl1.iscalctrg)::text = (r.refrcode)::text)
+                     ->  Seq Scan on tbl1  (cost=0.00..344.00 rows=24400 width=104)
+                     ->  Hash  (cost=166.30..166.30 rows=2 width=548)
+                           ->  Subquery Scan on r  (cost=0.00..166.30 rows=6 width=548)
+                                 ->  Seq Scan on tbl2  (cost=0.00..166.25 rows=6 width=548)
+                                       Filter: (referenceid = 101991::numeric)
+               ->  Hash  (cost=166.30..166.30 rows=2 width=548)
+                     ->  Subquery Scan on r1  (cost=0.00..166.30 rows=6 width=548)
+                           ->  Seq Scan on tbl2 tbl2_1  (cost=0.00..166.25 rows=6 width=548)
+                                 Filter: (referenceid = 101991::numeric)
+ Optimizer: Postgres query optimizer
+(16 rows)
+

--- a/src/test/regress/expected/shared_scan.out
+++ b/src/test/regress/expected/shared_scan.out
@@ -284,3 +284,32 @@ select gp_inject_fault('inject_many_fds_for_shareinputscan', 'reset', dbid) from
 (1 row)
 
 \! rm -rf /tmp/_gpdb_fault_inject_tmp_dir/
+-- A CTE over a replicated table referenced from multiple scalar
+-- subqueries used to hang because ORCA placed the SharedScan consumer
+-- on a different slice than the producer. Fixed by inlining the
+-- producer locally in apply_shareinput_xslice.
+-- ss_t1 needs enough rows (40000) to push ORCA to the cross-slice
+-- plan; with fewer rows the bug does not manifest and the test would
+-- silently pass even without the fix.
+CREATE TABLE ss_t1 AS
+  SELECT generate_series(1, 40000) id
+  DISTRIBUTED BY (id);
+CREATE TABLE ss_t2 AS
+  SELECT * FROM (VALUES (1, 10), (2, 20)) AS v(id, v)
+  DISTRIBUTED REPLICATED;
+ANALYZE ss_t1;
+ANALYZE ss_t2;
+SET statement_timeout = '15s';
+WITH
+    cte1 AS (SELECT v FROM ss_t2 WHERE id = 1),
+    cte2 AS (SELECT v FROM ss_t2 WHERE id = 2)
+  SELECT (SELECT v FROM cte1) + (SELECT v FROM cte2) +
+         (SELECT v FROM cte1) + (SELECT v FROM cte2) AS result
+  FROM ss_t1
+  LIMIT 1;
+ result
+--------
+     60
+(1 row)
+
+RESET statement_timeout;

--- a/src/test/regress/expected/shared_scan_optimizer.out
+++ b/src/test/regress/expected/shared_scan_optimizer.out
@@ -297,3 +297,32 @@ select gp_inject_fault('inject_many_fds_for_shareinputscan', 'reset', dbid) from
 (1 row)
 
 \! rm -rf /tmp/_gpdb_fault_inject_tmp_dir/
+-- A CTE over a replicated table referenced from multiple scalar
+-- subqueries used to hang because ORCA placed the SharedScan consumer
+-- on a different slice than the producer. Fixed by inlining the
+-- producer locally in apply_shareinput_xslice.
+-- ss_t1 needs enough rows (40000) to push ORCA to the cross-slice
+-- plan; with fewer rows the bug does not manifest and the test would
+-- silently pass even without the fix.
+CREATE TABLE ss_t1 AS
+  SELECT generate_series(1, 40000) id
+  DISTRIBUTED BY (id);
+CREATE TABLE ss_t2 AS
+  SELECT * FROM (VALUES (1, 10), (2, 20)) AS v(id, v)
+  DISTRIBUTED REPLICATED;
+ANALYZE ss_t1;
+ANALYZE ss_t2;
+SET statement_timeout = '15s';
+WITH
+    cte1 AS (SELECT v FROM ss_t2 WHERE id = 1),
+    cte2 AS (SELECT v FROM ss_t2 WHERE id = 2)
+  SELECT (SELECT v FROM cte1) + (SELECT v FROM cte2) +
+         (SELECT v FROM cte1) + (SELECT v FROM cte2) AS result
+  FROM ss_t1
+  LIMIT 1;
+ result
+--------
+     60
+(1 row)
+
+RESET statement_timeout;

--- a/src/test/regress/sql/qp_orca_fallback.sql
+++ b/src/test/regress/sql/qp_orca_fallback.sql
@@ -126,3 +126,32 @@ INSERT INTO partition_key_dropped VALUES(3);
 
 -- Orca should fallback if a function in 'from' clause uses 'WITH ORDINALITY'
 SELECT * FROM jsonb_array_elements('["b", "a"]'::jsonb) WITH ORDINALITY;
+
+-- ORCA should fallback in case there are any CTE Consumers beneath a duplicate-hazard motion
+-- Should be removed after issue#13039 is fixed
+-- start_ignore
+DROP TABLE IF EXISTS tbl1, tbl2;
+CREATE TABLE tbl2 (
+	id numeric NULL,
+	refrcode varchar(255) NULL,
+	referenceid numeric NULL
+)
+DISTRIBUTED REPLICATED;
+
+CREATE TABLE tbl1 (
+	id bigserial NOT NULL,
+	iscalctrg varchar(15) NOT NULL,
+	iscalcdetail varchar(15) NULL
+)
+DISTRIBUTED REPLICATED;
+-- end_ignore
+
+EXPLAIN WITH
+t1 AS (SELECT * FROM tbl1),
+t2 AS (SELECT id, refrcode FROM tbl2 WHERE REFERENCEID = 101991)
+ SELECT p.*FROM t1 p
+  JOIN t2 r
+   ON p.isCalcTRG = r.RefrCode
+  JOIN t2 r1
+   ON p.isCalcDetail = r1.RefrCode
+ LIMIT 1;

--- a/src/test/regress/sql/shared_scan.sql
+++ b/src/test/regress/sql/shared_scan.sql
@@ -137,3 +137,29 @@ select case when ten < 5 then ten else ten * 2 end, count(distinct two), count(d
 select gp_inject_fault('inject_many_fds_for_shareinputscan', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
 
 \! rm -rf /tmp/_gpdb_fault_inject_tmp_dir/
+
+-- A CTE over a replicated table referenced from multiple scalar
+-- subqueries used to hang because ORCA placed the SharedScan consumer
+-- on a different slice than the producer. Fixed by inlining the
+-- producer locally in apply_shareinput_xslice.
+-- ss_t1 needs enough rows (40000) to push ORCA to the cross-slice
+-- plan; with fewer rows the bug does not manifest and the test would
+-- silently pass even without the fix.
+CREATE TABLE ss_t1 AS
+  SELECT generate_series(1, 40000) id
+  DISTRIBUTED BY (id);
+CREATE TABLE ss_t2 AS
+  SELECT * FROM (VALUES (1, 10), (2, 20)) AS v(id, v)
+  DISTRIBUTED REPLICATED;
+ANALYZE ss_t1;
+ANALYZE ss_t2;
+
+SET statement_timeout = '15s';
+WITH
+    cte1 AS (SELECT v FROM ss_t2 WHERE id = 1),
+    cte2 AS (SELECT v FROM ss_t2 WHERE id = 2)
+  SELECT (SELECT v FROM cte1) + (SELECT v FROM cte2) +
+         (SELECT v FROM cte1) + (SELECT v FROM cte2) AS result
+  FROM ss_t1
+  LIMIT 1;
+RESET statement_timeout;


### PR DESCRIPTION
Fix cross-slice SharedScan hang for replicated CTE in scalar subquery

When a CTE over a replicated table is referenced from multiple scalar
subqueries, ORCA puts the CTE Consumer inside a SubPlan that runs on a
different slice than the Producer. The cross-slice temp file protocol
does not work for this topology, so the query either hangs or fails
with "could not open existing temporary file".

Fix in apply_shareinput_xslice pass 2: when a cross-slice Consumer is
found inside a SubPlan and the CTE source is a replicated table, give
the Consumer its own local copy of the Producer's subtree (Materialize
and base Scan) with a fresh share_id and SHARE_MATERIAL. Since the table
is replicated, every segment already has the full data, so a local
copy is equivalent and removes the cross-slice coordination. Other
Consumers of the same CTE in the same slice reuse this inlined copy.