### PR TITLE
Pull up uncorrelated scalar subqueries from target list into LEFT JOINs

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -235,6 +235,14 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 		IS_QUERY_DISPATCHER() &&
 		(cursorOptions & CURSOR_OPT_PARALLEL_RETRIEVE) == 0)
 	{
+		/*
+		 * Pull up uncorrelated scalar subqueries from the target list into
+		 * LEFT JOINs before handing the query to ORCA, so it sees a plain
+		 * join tree rather than SubLinks, enabling Shared Scan reuse.
+		 */
+		if (parse->hasSubLinks)
+			pull_up_scalar_sublinks_in_targetlist(parse);
+
 		if (gp_log_optimization_time)
 			INSTR_TIME_SET_CURRENT(starttime);
 
@@ -612,9 +620,11 @@ subquery_planner(PlannerGlobal *glob, Query *parse,
 
 	/*
 	 * Look for ANY and EXISTS SubLinks in WHERE and JOIN/ON clauses, and try
-	 * to transform them into joins.  Note that this step does not descend
-	 * into subqueries; if we pull up any subqueries below, their SubLinks are
-	 * processed just before pulling them up.
+	 * to transform them into joins.  Also pulls up uncorrelated scalar CTE
+	 * subqueries from the target list into LEFT JOINs (via the jointree
+	 * recursion).  Note that this step does not descend into subqueries; if
+	 * we pull up any subqueries below, their SubLinks are processed just
+	 * before pulling them up.
 	 */
 	if (parse->hasSubLinks)
 		pull_up_sublinks(root);

--- a/src/backend/optimizer/prep/prepjointree.c
+++ b/src/backend/optimizer/prep/prepjointree.c
@@ -40,12 +40,13 @@
 #include "optimizer/tlist.h"
 #include "parser/parse_relation.h"
 #include "parser/parsetree.h"
-#include "parser/parse_relation.h"
 #include "rewrite/rewriteManip.h"
 #include "cdb/cdbgroup.h"
 #include "cdb/cdbsubselect.h"
+#include "cdb/cdbvars.h"
 
 #include "optimizer/transform.h"
+#include "optimizer/walkers.h"
 
 typedef struct pullup_replace_vars_context
 {
@@ -115,6 +116,18 @@ static void fix_append_rel_relids(List *append_rel_list, int varno,
 static Node *find_jointree_node_for_rel(Node *jtnode, int relid);
 static bool is_simple_union_all_recurse(Node *setOp, Query *setOpQuery, List *colTypes);
 
+/* Scalar sublink pull-up from target list */
+typedef struct ScalarSublinkReplacement
+{
+	SubLink    *sublink;		/* the SubLink to replace */
+	int			rte_index;	/* RTE index of the new subquery */
+	AttrNumber	resno;		/* target list column number */
+} ScalarSublinkReplacement;
+
+static bool can_convert_scalar_sublink_to_join(SubLink *sublink);
+static void pull_up_scalar_cte_sublinks(Query *parse, Node **jtlink);
+static Node *replace_sublink_with_var_mutator(Node *node, void *context);
+
 
 /*
  * pull_up_sublinks
@@ -163,6 +176,271 @@ pull_up_sublinks(PlannerInfo *root)
 		root->parse->jointree = (FromExpr *) jtnode;
 	else
 		root->parse->jointree = makeFromExpr(list_make1(jtnode), NULL);
+}
+
+/*
+ * pull_up_scalar_sublinks_in_targetlist
+ *		Exported entry point for the ORCA code path in standard_planner(),
+ *		where PlannerInfo is not yet available.
+ *
+ *		For the Postgres planner path this logic is called from inside
+ *		pull_up_sublinks_jointree_recurse() via pull_up_scalar_cte_sublinks().
+ */
+void
+pull_up_scalar_sublinks_in_targetlist(Query *parse)
+{
+	Node	   *jtlink;
+
+	if (!parse->hasSubLinks)
+		return;
+
+	if (list_length(parse->jointree->fromlist) == 0)
+		return;
+
+	jtlink = (Node *) linitial(parse->jointree->fromlist);
+	pull_up_scalar_cte_sublinks(parse, &jtlink);
+	linitial(parse->jointree->fromlist) = jtlink;
+}
+
+/*
+ * pull_up_scalar_cte_sublinks
+ *		Core implementation: convert uncorrelated scalar CTE subqueries in the
+ *		target list to LEFT JOINs, stacking them onto *jtlink.
+ *
+ * Only applies to subqueries whose sole FROM-clause entry is a CTE reference
+ * (RTE_CTE).  This is intentionally narrow: pulling up subqueries over regular
+ * tables would lose the runtime single-row assertion, risking silent wrong
+ * results.
+ *
+ * Transforms queries like:
+ *   SELECT (SELECT v FROM cte WHERE id=1) + (SELECT v FROM cte WHERE id=2) FROM t1
+ * into equivalent:
+ *   SELECT c1.v + c2.v FROM t1
+ *   LEFT JOIN (SELECT v FROM cte WHERE id=1) c1 ON true
+ *   LEFT JOIN (SELECT v FROM cte WHERE id=2) c2 ON true
+ *
+ * This enables Shared Scan optimization when the same CTE is referenced by
+ * multiple scalar subqueries.
+ */
+static void
+pull_up_scalar_cte_sublinks(Query *parse, Node **jtlink)
+{
+	List	   *replacements = NIL;
+	ListCell   *lc;
+	ListCell   *slc;
+
+	if (!gp_enable_scalar_sublink_pullup)
+		return;
+
+	/* Collect convertible EXPR_SUBLINK nodes and create RTEs + JOINs */
+	foreach(lc, parse->targetList)
+	{
+		TargetEntry *tle = (TargetEntry *) lfirst(lc);
+		List	   *sublinks;
+
+		if (tle->expr == NULL)
+			continue;
+
+		sublinks = extract_nodes_expression((Node *) tle->expr, T_SubLink, false);
+		if (sublinks == NIL)
+			continue;
+
+		foreach(slc, sublinks)
+		{
+			SubLink    *sublink = (SubLink *) lfirst(slc);
+			ScalarSublinkReplacement *repl;
+			Query	   *subselect;
+			RangeTblEntry *subq_rte;
+			RangeTblRef *rtr;
+			JoinExpr   *join_expr;
+			int			rte_index;
+			TargetEntry *tle_sub;
+			ListCell   *repl_lc;
+			ScalarSublinkReplacement *existing_repl = NULL;
+
+			if (sublink->subLinkType != EXPR_SUBLINK)
+				continue;
+			if (!can_convert_scalar_sublink_to_join(sublink))
+				continue;
+
+			subselect = (Query *) sublink->subselect;
+
+			/* Check for duplicate - same subquery already converted */
+			foreach(repl_lc, replacements)
+			{
+				repl = (ScalarSublinkReplacement *) lfirst(repl_lc);
+				if (equal(repl->sublink->subselect, subselect))
+				{
+					existing_repl = repl;
+					break;
+				}
+			}
+
+			if (existing_repl != NULL)
+			{
+				repl = palloc(sizeof(ScalarSublinkReplacement));
+				repl->sublink = sublink;
+				repl->rte_index = existing_repl->rte_index;
+				repl->resno = existing_repl->resno;
+				replacements = lappend(replacements, repl);
+				continue;
+			}
+
+			/* Create subquery copy for RTE - we must not modify original */
+			subselect = (Query *) copyObject(subselect);
+
+			/* Ensure target list has resnames for addRangeTableEntryForSubquery */
+			{
+				int			col_num = 0;
+				ListCell   *tlc;
+
+				foreach(tlc, subselect->targetList)
+				{
+					TargetEntry *te = (TargetEntry *) lfirst(tlc);
+					if (te->resname == NULL)
+						te->resname = psprintf("csq_c%d", col_num);
+					col_num++;
+				}
+			}
+
+			subq_rte = addRangeTableEntryForSubquery(NULL,
+													 subselect,
+													 makeAlias("scalar_subq", NIL),
+													 false,	/* not lateral */
+													 false /* inFromClause */ );
+			parse->rtable = lappend(parse->rtable, subq_rte);
+			rte_index = list_length(parse->rtable);
+
+			tle_sub = (TargetEntry *) linitial(subselect->targetList);
+
+			/* Stack LEFT JOIN onto jtlink — same pattern as qual pull-up */
+			rtr = makeNode(RangeTblRef);
+			rtr->rtindex = rte_index;
+
+			join_expr = makeNode(JoinExpr);
+			join_expr->jointype = JOIN_LEFT;
+			join_expr->isNatural = false;
+			join_expr->larg = *jtlink;
+			join_expr->rarg = (Node *) rtr;
+			join_expr->usingClause = NIL;
+			join_expr->quals = (Node *) makeBoolConst(true, false);
+			join_expr->alias = NULL;
+			join_expr->rtindex = 0;
+
+			*jtlink = (Node *) join_expr;
+
+			repl = palloc(sizeof(ScalarSublinkReplacement));
+			repl->sublink = sublink;
+			repl->rte_index = rte_index;
+			repl->resno = tle_sub->resno;
+			replacements = lappend(replacements, repl);
+		}
+	}
+
+	if (replacements == NIL)
+		return;
+
+	/* Replace SubLinks with Vars in target list */
+	foreach(lc, parse->targetList)
+	{
+		TargetEntry *tle = (TargetEntry *) lfirst(lc);
+		if (tle->expr != NULL)
+			tle->expr = (Expr *) replace_sublink_with_var_mutator((Node *) tle->expr, (void *) replacements);
+	}
+}
+
+/*
+ * Check if a scalar sublink can be safely converted to a LEFT JOIN.
+ *
+ * We only convert subqueries that reference a single CTE (RTE_CTE) in
+ * their FROM clause.  This keeps the optimization narrow and safe:
+ *  - CTE references are the motivating case (enables Shared Scan in ORCA).
+ *  - Pulling up subqueries over regular tables would lose the single-row
+ *    runtime assertion, risking silent wrong results when the subquery
+ *    returns more than one row.
+ *
+ * Additional requirements: uncorrelated, no agg/group/having/distinct/
+ * window/limit/offset/setop/SRF, exactly one target entry.
+ */
+static bool
+can_convert_scalar_sublink_to_join(SubLink *sublink)
+{
+	Query	   *subselect;
+	RangeTblRef *rtr;
+	RangeTblEntry *rte;
+
+	if (sublink->subLinkType != EXPR_SUBLINK)
+		return false;
+
+	subselect = (Query *) sublink->subselect;
+	if (subselect->jointree->fromlist == NIL)
+		return false;
+	if (list_length(subselect->jointree->fromlist) != 1)
+		return false;
+
+	/* Only pull up subqueries that scan a single CTE */
+	if (!IsA(linitial(subselect->jointree->fromlist), RangeTblRef))
+		return false;
+	rtr = (RangeTblRef *) linitial(subselect->jointree->fromlist);
+	rte = rt_fetch(rtr->rtindex, subselect->rtable);
+	if (rte->rtekind != RTE_CTE)
+		return false;
+
+	if (expression_returns_set((Node *) subselect->targetList))
+		return false;
+	if (subselect->setOperations)
+		return false;
+	if (contain_vars_of_level((Node *) subselect, 1))
+		return false;
+	if (subselect->hasAggs || subselect->groupClause || subselect->havingQual)
+		return false;
+	if (subselect->distinctClause)
+		return false;
+	if (subselect->hasWindowFuncs || subselect->windowClause)
+		return false;
+	if (subselect->limitOffset || subselect->limitCount)
+		return false;
+	if (list_length(subselect->targetList) != 1)
+		return false;
+
+	return true;
+}
+
+/*
+ * Mutator to replace SubLinks in our replacement list with Var nodes.
+ */
+static Node *
+replace_sublink_with_var_mutator(Node *node, void *context)
+{
+	List	   *replacements = (List *) context;
+	ListCell   *lc;
+
+	if (node == NULL)
+		return NULL;
+
+	if (IsA(node, SubLink))
+	{
+		SubLink    *sublink = (SubLink *) node;
+		TargetEntry *tle;
+
+		foreach(lc, replacements)
+		{
+			ScalarSublinkReplacement *repl = (ScalarSublinkReplacement *) lfirst(lc);
+			if (repl->sublink == sublink)
+			{
+				Query	   *subselect = (Query *) sublink->subselect;
+				tle = (TargetEntry *) linitial(subselect->targetList);
+				return (Node *) makeVar(repl->rte_index,
+									   repl->resno,
+									   exprType((Node *) tle->expr),
+									   exprTypmod((Node *) tle->expr),
+									   exprCollation((Node *) tle->expr),
+									   0);
+			}
+		}
+	}
+
+	return expression_tree_mutator(node, replace_sublink_with_var_mutator, context);
 }
 
 /*
@@ -215,6 +493,13 @@ pull_up_sublinks_jointree_recurse(PlannerInfo *root, Node *jtnode,
 		newf->quals = pull_up_sublinks_qual_recurse(root, f->quals,
 													&jtlink, frelids,
 													NULL, NULL);
+
+		/*
+		 * Also pull up uncorrelated scalar CTE subqueries from the target
+		 * list into LEFT JOINs, stacking them onto the same jtlink.
+		 */
+		if (root->parse->hasSubLinks)
+			pull_up_scalar_cte_sublinks(root->parse, &jtlink);
 
 		/*
 		 * Note that the result will be either newf, or a stack of JoinExprs

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -280,6 +280,7 @@ bool		dml_ignore_target_partition_check = false;
 bool		gp_enable_hashjoin_size_heuristic = false;
 bool		gp_enable_predicate_propagation = false;
 bool		gp_enable_minmax_optimization = true;
+bool		gp_enable_scalar_sublink_pullup = true;
 bool		gp_enable_multiphase_agg = true;
 bool		gp_enable_preunique = TRUE;
 bool		gp_eager_preunique = FALSE;
@@ -758,6 +759,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&gp_enable_minmax_optimization,
 		true, NULL, NULL
+	},
+
+	{
+		{"gp_enable_scalar_sublink_pullup", PGC_USERSET, QUERY_TUNING_METHOD,
+			gettext_noop("Enables pulling up scalar CTE subqueries from the target list into LEFT JOINs."),
+			gettext_noop("When enabled, uncorrelated scalar subqueries over CTEs are converted to joins, enabling Shared Scan optimization.")
+		},
+		&gp_enable_scalar_sublink_pullup,
+		true,
+		NULL, NULL, NULL
 	},
 
 	{

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -596,6 +596,14 @@ extern int      gp_segments_for_planner;
 extern bool gp_enable_minmax_optimization;
 
 /*
+ * "gp_enable_scalar_sublink_pullup"
+ *
+ * When true, the planner pulls up uncorrelated scalar CTE subqueries from
+ * the target list into LEFT JOINs, enabling Shared Scan optimization.
+ */
+extern bool gp_enable_scalar_sublink_pullup;
+
+/*
  * "gp_enable_multiphase_agg"
  *
  * Unlike some other enable... vars, gp_enable_multiphase_agg is not cost based.

--- a/src/include/optimizer/prep.h
+++ b/src/include/optimizer/prep.h
@@ -24,6 +24,7 @@
  * prototypes for prepjointree.c
  */
 extern void pull_up_sublinks(PlannerInfo *root);
+extern void pull_up_scalar_sublinks_in_targetlist(Query *parse);
 extern void inline_set_returning_functions(PlannerInfo *root);
 extern Node *pull_up_subqueries(PlannerInfo *root, Node *jtnode);
 extern void flatten_simple_union_all(PlannerInfo *root);

--- a/src/test/regress/expected/bfv_cte.out
+++ b/src/test/regress/expected/bfv_cte.out
@@ -430,6 +430,7 @@ create table rep (a int, b int) distributed replicated;
 insert into dist1 select 1, generate_series(1,10);
 insert into dist2 select 1, generate_series(1,20);
 insert into rep select 1, 1;
+set gp_enable_scalar_sublink_pullup = off;
 explain (analyze off, costs off, verbose off)
 with t1_cte as (select b from dist1),
 rep_cte as (select a from rep)
@@ -438,7 +439,7 @@ case when (dist2.b in (1,2)) then (select rep_cte.a from rep_cte)
 when (dist2.b in (1,2)) then (select rep_cte.a from rep_cte)
 end as rep_cte_a
 from t1_cte join dist2 on t1_cte.b = dist2.b;
-                                              QUERY PLAN                                              
+                                              QUERY PLAN
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice5; segments: 3)
    ->  Hash Join
@@ -480,6 +481,7 @@ from t1_cte join dist2 on t1_cte.b = dist2.b;
           
 (10 rows)
 
+reset gp_enable_scalar_sublink_pullup;
 drop table dist1, dist2, rep;
 --
 -- Test for a bug in ORCA optimizing a CTE view.

--- a/src/test/regress/expected/bfv_cte_optimizer.out
+++ b/src/test/regress/expected/bfv_cte_optimizer.out
@@ -430,6 +430,7 @@ create table rep (a int, b int) distributed replicated;
 insert into dist1 select 1, generate_series(1,10);
 insert into dist2 select 1, generate_series(1,20);
 insert into rep select 1, 1;
+set gp_enable_scalar_sublink_pullup = off;
 explain (analyze off, costs off, verbose off)
 with t1_cte as (select b from dist1),
 rep_cte as (select a from rep)
@@ -438,7 +439,7 @@ case when (dist2.b in (1,2)) then (select rep_cte.a from rep_cte)
 when (dist2.b in (1,2)) then (select rep_cte.a from rep_cte)
 end as rep_cte_a
 from t1_cte join dist2 on t1_cte.b = dist2.b;
-                                              QUERY PLAN                                              
+                                              QUERY PLAN
 ------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice7; segments: 3)
    ->  Sequence
@@ -501,6 +502,7 @@ from t1_cte join dist2 on t1_cte.b = dist2.b;
           
 (10 rows)
 
+reset gp_enable_scalar_sublink_pullup;
 drop table dist1, dist2, rep;
 --
 -- Test for a bug in ORCA optimizing a CTE view.

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -663,6 +663,192 @@ SELECT * FROM csq_r WHERE a IN (SELECT csq_f FROM csq_f(csq_r.a),csq_r);
 (1 row)
 
 --
+-- Test pullup of scalar CTE subqueries in target list to LEFT JOIN
+-- (only subqueries whose FROM is a single CTE reference are eligible)
+--
+drop table if exists scalar_subq_t1;
+drop table if exists scalar_subq_t2;
+create table scalar_subq_t1(a int) distributed by (a);
+create table scalar_subq_t2(id int, v int) distributed by (id);
+insert into scalar_subq_t1 select i from generate_series(1, 100) i;
+insert into scalar_subq_t2 values (1, 10), (2, 20), (3, 30);
+-- Positive: uncorrelated scalar CTE subqueries -> should become LEFT JOINs
+explain (costs off) with cte1 as (select id, v from scalar_subq_t2)
+select (select v from cte1 where id = 1) + (select v from cte1 where id = 2)
+from scalar_subq_t1;
+QUERY PLAN
+___________
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Nested Loop Left Join
+         ->  Nested Loop Left Join
+               ->  Seq Scan on scalar_subq_t1
+               ->  Materialize
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                           ->  Subquery Scan on cte1
+                                 ->  Seq Scan on scalar_subq_t2
+                                       Filter: (id = 1)
+         ->  Materialize
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     ->  Subquery Scan on cte1_1
+                           ->  Seq Scan on scalar_subq_t2 scalar_subq_t2_1
+                                 Filter: (id = 2)
+GP_IGNORE:(15 rows)
+
+with cte1 as (select id, v from scalar_subq_t2)
+select (select v from cte1 where id = 1) + (select v from cte1 where id = 2)
+from scalar_subq_t1
+limit 3;
+ ?column?
+----------
+       30
+       30
+       30
+(3 rows)
+
+-- Positive: CTE subquery returning NULL (no matching rows)
+with cte1 as (select id, v from scalar_subq_t2)
+select a, (select v from cte1 where id = 999)
+from scalar_subq_t1
+limit 3;
+ a | v
+---+---
+ 2 |
+ 3 |
+ 4 |
+(3 rows)
+
+-- Positive: multiple CTE subqueries in separate target list entries
+with cte1 as (select id, v from scalar_subq_t2)
+select (select v from cte1 where id = 1),
+       (select v from cte1 where id = 2),
+       (select v from cte1 where id = 3)
+from scalar_subq_t1
+limit 1;
+ v  | v  | v
+----+----+----
+ 10 | 20 | 30
+(1 row)
+
+-- Positive: duplicate CTE subqueries should reuse the same RTE
+explain (costs off) with cte1 as (select id, v from scalar_subq_t2)
+select (select v from cte1 where id = 1),
+       (select v from cte1 where id = 1)
+from scalar_subq_t1;
+QUERY PLAN
+___________
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Nested Loop Left Join
+         ->  Seq Scan on scalar_subq_t1
+         ->  Materialize
+               ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                     ->  Subquery Scan on cte1
+                           ->  Seq Scan on scalar_subq_t2
+                                 Filter: (id = 1)
+GP_IGNORE:(9 rows)
+
+with cte1 as (select id, v from scalar_subq_t2)
+select (select v from cte1 where id = 1),
+       (select v from cte1 where id = 1)
+from scalar_subq_t1
+limit 1;
+ v  | v
+----+----
+ 10 | 10
+(1 row)
+
+-- Positive: CTE subquery nested inside a CASE expression
+with cte1 as (select id, v from scalar_subq_t2)
+select case when a < 50
+            then (select v from cte1 where id = 1)
+            else (select v from cte1 where id = 2)
+       end
+from scalar_subq_t1
+where a in (1, 50, 100);
+ v
+----
+ 10
+ 20
+ 20
+(3 rows)
+
+-- Negative: subquery from regular table should NOT be pulled up
+explain (costs off)
+select (select v from scalar_subq_t2 where id = 1)
+from scalar_subq_t1;
+QUERY PLAN
+___________
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Seq Scan on scalar_subq_t1
+         InitPlan 1 (returns $0)  (slice3)
+           ->  Gather Motion 1:1  (slice1; segments: 1)
+                 ->  Seq Scan on scalar_subq_t2
+                       Filter: (id = 1)
+GP_IGNORE:(7 rows)
+
+-- Negative: correlated CTE subquery should NOT be pulled up
+explain (costs off) with cte1 as (select id, v from scalar_subq_t2)
+select (select v from cte1 where id = scalar_subq_t1.a)
+from scalar_subq_t1;
+QUERY PLAN
+___________
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Seq Scan on scalar_subq_t1
+         SubPlan 1  (slice2; segments: 3)
+           ->  Subquery Scan on cte1
+                 ->  Result
+                       Filter: (scalar_subq_t2.id = scalar_subq_t1.a)
+                       ->  Materialize
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                   ->  Seq Scan on scalar_subq_t2
+GP_IGNORE:(10 rows)
+
+-- Negative: CTE subquery with aggregate should NOT be pulled up
+explain (costs off) with cte1 as (select id, v from scalar_subq_t2)
+select (select count(*) from cte1)
+from scalar_subq_t1;
+QUERY PLAN
+___________
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Seq Scan on scalar_subq_t1
+         InitPlan 1 (returns $0)  (slice3)
+           ->  Aggregate
+                 ->  Gather Motion 3:1  (slice1; segments: 3)
+                       ->  Aggregate
+                             ->  Subquery Scan on cte1
+                                   ->  Seq Scan on scalar_subq_t2
+GP_IGNORE:(9 rows)
+
+-- Negative: CTE subquery with LIMIT should NOT be pulled up
+explain (costs off) with cte1 as (select id, v from scalar_subq_t2)
+select (select v from cte1 limit 1)
+from scalar_subq_t1;
+QUERY PLAN
+___________
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Seq Scan on scalar_subq_t1
+         InitPlan 1 (returns $0)  (slice3)
+           ->  Limit
+                 ->  Gather Motion 3:1  (slice1; segments: 3)
+                       ->  Limit
+                             ->  Subquery Scan on cte1
+                                   ->  Seq Scan on scalar_subq_t2
+GP_IGNORE:(9 rows)
+
+-- Negative: subquery without FROM should NOT be pulled up
+explain (costs off)
+select (select 42) from scalar_subq_t1;
+QUERY PLAN
+___________
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on scalar_subq_t1
+         InitPlan 1 (returns $0)  (slice2)
+           ->  Result
+GP_IGNORE:(5 rows)
+
+-- cleanup
+drop table scalar_subq_t1;
+drop table scalar_subq_t2;
+--
 -- Test pullup of expr CSQs to joins
 --
 --

--- a/src/test/regress/sql/bfv_cte.sql
+++ b/src/test/regress/sql/bfv_cte.sql
@@ -267,6 +267,7 @@ insert into dist1 select 1, generate_series(1,10);
 insert into dist2 select 1, generate_series(1,20);
 insert into rep select 1, 1;
 
+set gp_enable_scalar_sublink_pullup = off;
 explain (analyze off, costs off, verbose off)
 with t1_cte as (select b from dist1),
 rep_cte as (select a from rep)
@@ -283,6 +284,7 @@ case when (dist2.b in (1,2)) then (select rep_cte.a from rep_cte)
 when (dist2.b in (1,2)) then (select rep_cte.a from rep_cte)
 end as rep_cte_a
 from t1_cte join dist2 on t1_cte.b = dist2.b;
+reset gp_enable_scalar_sublink_pullup;
 drop table dist1, dist2, rep;
 
 --

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -276,6 +276,91 @@ explain SELECT * FROM csq_r WHERE a IN (SELECT csq_f FROM csq_f(csq_r.a),csq_r);
 SELECT * FROM csq_r WHERE a IN (SELECT csq_f FROM csq_f(csq_r.a),csq_r);
 
 --
+-- Test pullup of scalar CTE subqueries in target list to LEFT JOIN
+-- (only subqueries whose FROM is a single CTE reference are eligible)
+--
+
+drop table if exists scalar_subq_t1;
+drop table if exists scalar_subq_t2;
+create table scalar_subq_t1(a int) distributed by (a);
+create table scalar_subq_t2(id int, v int) distributed by (id);
+insert into scalar_subq_t1 select i from generate_series(1, 100) i;
+insert into scalar_subq_t2 values (1, 10), (2, 20), (3, 30);
+
+-- Positive: uncorrelated scalar CTE subqueries -> should become LEFT JOINs
+explain (costs off) with cte1 as (select id, v from scalar_subq_t2)
+select (select v from cte1 where id = 1) + (select v from cte1 where id = 2)
+from scalar_subq_t1;
+
+with cte1 as (select id, v from scalar_subq_t2)
+select (select v from cte1 where id = 1) + (select v from cte1 where id = 2)
+from scalar_subq_t1
+limit 3;
+
+-- Positive: CTE subquery returning NULL (no matching rows)
+with cte1 as (select id, v from scalar_subq_t2)
+select a, (select v from cte1 where id = 999)
+from scalar_subq_t1
+limit 3;
+
+-- Positive: multiple CTE subqueries in separate target list entries
+with cte1 as (select id, v from scalar_subq_t2)
+select (select v from cte1 where id = 1),
+       (select v from cte1 where id = 2),
+       (select v from cte1 where id = 3)
+from scalar_subq_t1
+limit 1;
+
+-- Positive: duplicate CTE subqueries should reuse the same RTE
+explain (costs off) with cte1 as (select id, v from scalar_subq_t2)
+select (select v from cte1 where id = 1),
+       (select v from cte1 where id = 1)
+from scalar_subq_t1;
+
+with cte1 as (select id, v from scalar_subq_t2)
+select (select v from cte1 where id = 1),
+       (select v from cte1 where id = 1)
+from scalar_subq_t1
+limit 1;
+
+-- Positive: CTE subquery nested inside a CASE expression
+with cte1 as (select id, v from scalar_subq_t2)
+select case when a < 50
+            then (select v from cte1 where id = 1)
+            else (select v from cte1 where id = 2)
+       end
+from scalar_subq_t1
+where a in (1, 50, 100);
+
+-- Negative: subquery from regular table should NOT be pulled up
+explain (costs off)
+select (select v from scalar_subq_t2 where id = 1)
+from scalar_subq_t1;
+
+-- Negative: correlated CTE subquery should NOT be pulled up
+explain (costs off) with cte1 as (select id, v from scalar_subq_t2)
+select (select v from cte1 where id = scalar_subq_t1.a)
+from scalar_subq_t1;
+
+-- Negative: CTE subquery with aggregate should NOT be pulled up
+explain (costs off) with cte1 as (select id, v from scalar_subq_t2)
+select (select count(*) from cte1)
+from scalar_subq_t1;
+
+-- Negative: CTE subquery with LIMIT should NOT be pulled up
+explain (costs off) with cte1 as (select id, v from scalar_subq_t2)
+select (select v from cte1 limit 1)
+from scalar_subq_t1;
+
+-- Negative: subquery without FROM should NOT be pulled up
+explain (costs off)
+select (select 42) from scalar_subq_t1;
+
+-- cleanup
+drop table scalar_subq_t1;
+drop table scalar_subq_t2;
+
+--
 -- Test pullup of expr CSQs to joins
 --
 


### PR DESCRIPTION
Convert uncorrelated scalar EXPR_SUBLINK nodes in the SELECT target list into LEFT JOIN ... ON true, so that the optimizer (both ORCA and Postgres planner) sees a plain join tree instead of SubLinks. This enables Shared Scan reuse when the same CTE is referenced by multiple scalar subqueries in the target list.

Example transformation:

  SELECT (SELECT v FROM cte WHERE id=1) + (SELECT v FROM cte WHERE id=2) FROM t
  =>
  SELECT s1.v + s2.v FROM t
    LEFT JOIN (SELECT v FROM cte WHERE id=1) s1 ON true
    LEFT JOIN (SELECT v FROM cte WHERE id=2) s2 ON true

Only simple uncorrelated subqueries are eligible: no aggregates, GROUP BY, HAVING, DISTINCT, window functions, LIMIT/OFFSET, set operations, SRFs, or correlated references. Duplicate subqueries reuse the same RTE.
