### PR TITLE
Inline simple CTEs as subqueries to avoid cross-slice shared scan deadlock

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -218,6 +218,15 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	MemoryAccountIdType curMemoryAccountId;
 
 	/*
+	 * Inline non-recursive, non-volatile CTEs as subqueries before any
+	 * optimizer (ORCA or Postgres planner) sees the query.  This avoids
+	 * cross-slice Shared Scan deadlocks that ORCA can produce when CTE
+	 * references appear as scalar subqueries.
+	 */
+	if (gp_enable_cte_inlining && parse->cteList != NIL)
+		inline_cte(parse);
+
+	/*
 	 * Use ORCA only if it is enabled and we are in a master QD process.
 	 *
 	 * ORCA excels in complex queries, most of which will access distributed

--- a/src/backend/optimizer/prep/prepjointree.c
+++ b/src/backend/optimizer/prep/prepjointree.c
@@ -115,6 +115,158 @@ static void fix_append_rel_relids(List *append_rel_list, int varno,
 static Node *find_jointree_node_for_rel(Node *jtnode, int relid);
 static bool is_simple_union_all_recurse(Node *setOp, Query *setOpQuery, List *colTypes);
 
+/* CTE inlining helper context */
+typedef struct inline_cte_walker_context
+{
+	const char *ctename;		/* name of CTE to inline */
+	Query	   *ctequery;		/* query tree of the CTE */
+	int			levelsup;		/* current nesting depth relative to CTE's owner */
+} inline_cte_walker_context;
+
+static bool inline_cte_walker(Node *node, inline_cte_walker_context *context);
+
+/*
+ * inline_cte
+ *		Inline non-recursive, non-volatile CTEs as subqueries.
+ *
+ * For each CTE defined in the query's WITH list, if the CTE is a simple
+ * SELECT (not recursive, not containing volatile functions, not a DML
+ * statement), replace every RTE_CTE reference to it with an RTE_SUBQUERY
+ * containing a copy of the CTE's query tree.  This allows the planner to
+ * optimize the CTE body together with the outer query (push down predicates,
+ * choose better join strategies, etc.).
+ *
+ * Must be called before pull_up_sublinks so that the inlined subqueries
+ * can participate in subsequent optimization steps.
+ */
+void
+inline_cte(Query *parse)
+{
+	ListCell   *lc;
+	ListCell   *prev;
+	ListCell   *next;
+
+	/* Nothing to do if no CTEs */
+	if (parse->cteList == NIL)
+		return;
+
+	prev = NULL;
+	for (lc = list_head(parse->cteList); lc != NULL; lc = next)
+	{
+		CommonTableExpr *cte = (CommonTableExpr *) lfirst(lc);
+		Query	   *ctequery;
+		inline_cte_walker_context context;
+
+		next = lnext(lc);
+
+		/* Skip recursive CTEs */
+		if (cte->cterecursive)
+		{
+			prev = lc;
+			continue;
+		}
+
+		ctequery = castNode(Query, cte->ctequery);
+
+		/* Only inline SELECT statements, not INSERT/UPDATE/DELETE */
+		if (ctequery->commandType != CMD_SELECT)
+		{
+			prev = lc;
+			continue;
+		}
+
+		/* Don't inline volatile CTEs — they must execute exactly once */
+		if (contain_volatile_functions((Node *) ctequery))
+		{
+			prev = lc;
+			continue;
+		}
+
+		/*
+		 * Walk the query tree and replace all RTE_CTE references to this CTE
+		 * with RTE_SUBQUERY entries containing a copy of the CTE's query.
+		 */
+		context.ctename = cte->ctename;
+		context.ctequery = ctequery;
+		context.levelsup = 0;
+
+		inline_cte_walker((Node *) parse, &context);
+
+		/* Remove the CTE from cteList since it's now fully inlined */
+		parse->cteList = list_delete_cell(parse->cteList, lc, prev);
+
+		/* Don't advance prev since we deleted current cell */
+	}
+}
+
+/*
+ * inline_cte_walker
+ *		Recursively walk a query tree, replacing RTE_CTE references
+ *		to the specified CTE with RTE_SUBQUERY entries.
+ */
+static bool
+inline_cte_walker(Node *node, inline_cte_walker_context *context)
+{
+	if (node == NULL)
+		return false;
+
+	if (IsA(node, Query))
+	{
+		Query	   *query = (Query *) node;
+		ListCell   *lc;
+
+		/*
+		 * Scan the range table looking for CTE references to inline.
+		 */
+		foreach(lc, query->rtable)
+		{
+			RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
+
+			if (rte->rtekind != RTE_CTE)
+				continue;
+
+			if (strcmp(rte->ctename, context->ctename) != 0)
+				continue;
+
+			if (rte->ctelevelsup != context->levelsup)
+				continue;
+
+			/*
+			 * Found a matching CTE reference. Replace it with a subquery.
+			 */
+			rte->rtekind = RTE_SUBQUERY;
+			rte->subquery = copyObject(context->ctequery);
+			rte->security_barrier = false;
+
+			/*
+			 * If the CTE was defined higher up, adjust Var levels in the
+			 * inlined subquery so they point to the right query level.
+			 */
+			if (context->levelsup > 0)
+				IncrementVarSublevelsUp((Node *) rte->subquery,
+										context->levelsup, 1);
+
+			/* Clear CTE-specific fields */
+			rte->ctename = NULL;
+			rte->ctelevelsup = 0;
+			rte->self_reference = false;
+			rte->ctecoltypes = NIL;
+			rte->ctecoltypmods = NIL;
+			rte->ctecolcollations = NIL;
+		}
+
+		/* Recurse into subqueries with bumped levelsup */
+		context->levelsup++;
+		query_tree_walker(query, inline_cte_walker, context,
+						  QTW_IGNORE_CTE_SUBQUERIES);
+		context->levelsup--;
+
+		return false;
+	}
+
+	return expression_tree_walker(node, inline_cte_walker, context);
+}
+
 
 /*
  * pull_up_sublinks

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -294,6 +294,7 @@ bool		gp_enable_groupext_distinct_gather = true;
 bool		gp_dynamic_partition_pruning = true;
 bool		gp_log_dynamic_partition_pruning = false;
 bool		gp_cte_sharing = false;
+bool		gp_enable_cte_inlining = true;
 bool		gp_enable_relsize_collection = false;
 bool		gp_recursive_cte = true;
 bool		gp_enable_mdqa_shared_scan = true;
@@ -2008,6 +2009,18 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&gp_cte_sharing,
 		false,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"gp_enable_cte_inlining", PGC_USERSET, QUERY_TUNING_METHOD,
+			gettext_noop("Enables inlining of non-recursive, non-volatile CTEs as subqueries."),
+			gettext_noop("When enabled, simple CTEs are replaced with subqueries "
+						 "before planning, allowing the optimizer to optimize "
+						 "CTE bodies together with the outer query.")
+		},
+		&gp_enable_cte_inlining,
+		true,
 		NULL, NULL, NULL
 	},
 

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -813,6 +813,8 @@ extern bool gp_dynamic_partition_pruning;
 
 /* Sharing of plan fragments for common table expressions */
 extern bool gp_cte_sharing;
+/* Inline simple CTEs as subqueries before planning */
+extern bool gp_enable_cte_inlining;
 /* Enable RECURSIVE clauses in common table expressions */
 extern bool gp_recursive_cte;
 /* Enable shared scan in three stage agg */

--- a/src/include/optimizer/prep.h
+++ b/src/include/optimizer/prep.h
@@ -23,6 +23,7 @@
 /*
  * prototypes for prepjointree.c
  */
+extern void inline_cte(Query *parse);
 extern void pull_up_sublinks(PlannerInfo *root);
 extern void inline_set_returning_functions(PlannerInfo *root);
 extern Node *pull_up_subqueries(PlannerInfo *root, Node *jtnode);

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -154,6 +154,7 @@
 		"gp_count_host_segments_using_address",
 		"gp_create_table_random_default_distribution",
 		"gp_cte_sharing",
+		"gp_enable_cte_inlining",
 		"gp_dbid",
 		"gp_debug_pgproc",
 		"gp_debug_resqueue_priority",

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -3456,3 +3456,149 @@ select (select b from bar)[(select 1)][1:3] from bar;
 (1 row)
 
 drop table bar;
+-- Test: CTE inlining avoids cross-slice shared scan deadlock.
+-- When the same CTE is referenced multiple times as scalar subqueries,
+-- without inlining the planner may produce a shared scan that spans
+-- multiple slices, causing the query to hang.  With CTE inlining each
+-- reference becomes an independent subquery and the hang disappears.
+CREATE TABLE ss_t1 (id int) DISTRIBUTED BY (id);
+INSERT INTO ss_t1 SELECT i FROM generate_series(1, 10) i;
+CREATE TABLE ss_t2 (id int, v int) DISTRIBUTED REPLICATED;
+INSERT INTO ss_t2 VALUES (1, 10), (2, 20);
+ANALYZE ss_t1;
+ANALYZE ss_t2;
+EXPLAIN (costs off)
+WITH
+  cte1 AS (SELECT v FROM ss_t2 WHERE id = 1),
+  cte2 AS (SELECT v FROM ss_t2 WHERE id = 2)
+SELECT DISTINCT
+       (SELECT v FROM cte1) + (SELECT v FROM cte2) +
+       (SELECT v FROM cte1) + (SELECT v FROM cte2) AS result
+FROM ss_t1;
+                            QUERY PLAN
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice6; segments: 3)
+   ->  GroupAggregate
+         Group Key: (((($0 + $1) + $2) + $3))
+         InitPlan 1 (returns $0)  (slice8)
+           ->  Gather Motion 1:1  (slice2; segments: 1)
+                 ->  Seq Scan on ss_t2
+                       Filter: (id = 1)
+         InitPlan 2 (returns $1)  (slice9)
+           ->  Gather Motion 1:1  (slice3; segments: 1)
+                 ->  Seq Scan on ss_t2 ss_t2_1
+                       Filter: (id = 2)
+         InitPlan 3 (returns $2)  (slice10)
+           ->  Gather Motion 1:1  (slice4; segments: 1)
+                 ->  Seq Scan on ss_t2 ss_t2_2
+                       Filter: (id = 1)
+         InitPlan 4 (returns $3)  (slice7)
+           ->  Gather Motion 1:1  (slice5; segments: 1)
+                 ->  Seq Scan on ss_t2 ss_t2_3
+                       Filter: (id = 2)
+         ->  Sort
+               Sort Key: (((($0 + $1) + $2) + $3))
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                     Hash Key: (((($0 + $1) + $2) + $3))
+                     ->  GroupAggregate
+                           Group Key: ((($0 + $1) + $2) + $3)
+                           ->  Seq Scan on ss_t1
+ Optimizer: Postgres query optimizer
+(27 rows)
+
+WITH
+  cte1 AS (SELECT v FROM ss_t2 WHERE id = 1),
+  cte2 AS (SELECT v FROM ss_t2 WHERE id = 2)
+SELECT DISTINCT
+       (SELECT v FROM cte1) + (SELECT v FROM cte2) +
+       (SELECT v FROM cte1) + (SELECT v FROM cte2) AS result
+FROM ss_t1;
+ result
+--------
+     60
+(1 row)
+
+DROP TABLE ss_t1;
+DROP TABLE ss_t2;
+-- Test: Recursive CTE must NOT be inlined — verify it still works correctly.
+WITH RECURSIVE r(n) AS (
+  VALUES (1)
+  UNION ALL
+  SELECT n + 1 FROM r WHERE n < 5
+)
+SELECT * FROM r ORDER BY n;
+ n
+---
+ 1
+ 2
+ 3
+ 4
+ 5
+(5 rows)
+
+-- Test: Volatile CTE is skipped by early CTE inlining (inline_cte),
+-- but may still be inlined later by the optimizer's own CTE handling.
+WITH cte_vol AS (SELECT random() AS r)
+SELECT (SELECT r FROM cte_vol) = (SELECT r FROM cte_vol) AS same_value;
+ same_value
+------------
+ f
+(1 row)
+
+-- Test: CTE with multiple references in a JOIN — should be inlined and
+-- produce correct results.
+CREATE TABLE ss_t3 (a int, b text) DISTRIBUTED BY (a);
+INSERT INTO ss_t3 VALUES (1, 'x'), (2, 'y'), (3, 'z');
+ANALYZE ss_t3;
+WITH cte AS (SELECT a, b FROM ss_t3 WHERE a <= 2)
+SELECT t1.a AS a1, t2.a AS a2, t1.b || t2.b AS combined
+FROM cte t1 JOIN cte t2 ON t1.a < t2.a
+ORDER BY t1.a, t2.a;
+ a1 | a2 | combined
+----+----+----------
+  1 |  2 | xy
+(1 row)
+
+DROP TABLE ss_t3;
+-- Test: gp_enable_cte_inlining GUC controls early CTE inlining.
+-- With inlining disabled and ORCA, EXPLAIN shows Shared Scan nodes.
+-- With inlining enabled (default), CTE references become subqueries.
+CREATE TABLE ss_t4 (id int) DISTRIBUTED BY (id);
+INSERT INTO ss_t4 VALUES (1), (2), (3);
+ANALYZE ss_t4;
+SET gp_enable_cte_inlining = off;
+EXPLAIN (costs off)
+WITH cte AS (SELECT id FROM ss_t4 WHERE id <= 2)
+SELECT * FROM cte t1 JOIN cte t2 ON t1.id = t2.id;
+                 QUERY PLAN
+---------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (ss_t4.id = ss_t4_1.id)
+         ->  Seq Scan on ss_t4
+               Filter: (id <= 2)
+         ->  Hash
+               ->  Seq Scan on ss_t4 ss_t4_1
+                     Filter: (id <= 2)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+SET gp_enable_cte_inlining = on;
+EXPLAIN (costs off)
+WITH cte AS (SELECT id FROM ss_t4 WHERE id <= 2)
+SELECT * FROM cte t1 JOIN cte t2 ON t1.id = t2.id;
+                 QUERY PLAN
+---------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (ss_t4.id = ss_t4_1.id)
+         ->  Seq Scan on ss_t4
+               Filter: (id <= 2)
+         ->  Hash
+               ->  Seq Scan on ss_t4 ss_t4_1
+                     Filter: (id <= 2)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+RESET gp_enable_cte_inlining;
+DROP TABLE ss_t4;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -3646,3 +3646,181 @@ select (select b from bar)[(select 1)][1:3] from bar;
 (1 row)
 
 drop table bar;
+-- Test: CTE inlining avoids cross-slice shared scan deadlock.
+-- When the same CTE is referenced multiple times as scalar subqueries,
+-- without inlining the planner may produce a shared scan that spans
+-- multiple slices, causing the query to hang.  With CTE inlining each
+-- reference becomes an independent subquery and the hang disappears.
+CREATE TABLE ss_t1 (id int) DISTRIBUTED BY (id);
+INSERT INTO ss_t1 SELECT i FROM generate_series(1, 10) i;
+CREATE TABLE ss_t2 (id int, v int) DISTRIBUTED REPLICATED;
+INSERT INTO ss_t2 VALUES (1, 10), (2, 20);
+ANALYZE ss_t1;
+ANALYZE ss_t2;
+EXPLAIN (costs off)
+WITH
+  cte1 AS (SELECT v FROM ss_t2 WHERE id = 1),
+  cte2 AS (SELECT v FROM ss_t2 WHERE id = 2)
+SELECT DISTINCT
+       (SELECT v FROM cte1) + (SELECT v FROM cte2) +
+       (SELECT v FROM cte1) + (SELECT v FROM cte2) AS result
+FROM ss_t1;
+                                                       QUERY PLAN
+------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice10; segments: 3)
+   ->  HashAggregate
+         Group Key: ((((ss_t2_3.v + ss_t2_2.v) + ss_t2_1.v) + ss_t2.v))
+         ->  Redistribute Motion 3:3  (slice9; segments: 3)
+               Hash Key: ((((ss_t2_3.v + ss_t2_2.v) + ss_t2_1.v) + ss_t2.v))
+               ->  Result
+                     ->  Nested Loop Left Join
+                           Join Filter: true
+                           ->  Nested Loop Left Join
+                                 Join Filter: true
+                                 ->  Nested Loop Left Join
+                                       Join Filter: true
+                                       ->  Nested Loop Left Join
+                                             Join Filter: true
+                                             ->  Seq Scan on ss_t1
+                                             ->  Assert
+                                                   Assert Cond: ((row_number() OVER (?)) = 1)
+                                                   ->  Materialize
+                                                         ->  Broadcast Motion 1:3  (slice8)
+                                                               ->  Result
+                                                                     ->  WindowAgg
+                                                                           ->  Gather Motion 1:1  (slice7; segments: 1)
+                                                                                 ->  Seq Scan on ss_t2 ss_t2_3
+                                                                                       Filter: (id = 1)
+                                       ->  Assert
+                                             Assert Cond: ((row_number() OVER (?)) = 1)
+                                             ->  Materialize
+                                                   ->  Broadcast Motion 1:3  (slice6)
+                                                         ->  Result
+                                                               ->  WindowAgg
+                                                                     ->  Gather Motion 1:1  (slice5; segments: 1)
+                                                                           ->  Seq Scan on ss_t2 ss_t2_2
+                                                                                 Filter: (id = 2)
+                                 ->  Assert
+                                       Assert Cond: ((row_number() OVER (?)) = 1)
+                                       ->  Materialize
+                                             ->  Broadcast Motion 1:3  (slice4)
+                                                   ->  Result
+                                                         ->  WindowAgg
+                                                               ->  Gather Motion 1:1  (slice3; segments: 1)
+                                                                     ->  Seq Scan on ss_t2 ss_t2_1
+                                                                           Filter: (id = 1)
+                           ->  Assert
+                                 Assert Cond: ((row_number() OVER (?)) = 1)
+                                 ->  Materialize
+                                       ->  Broadcast Motion 1:3  (slice2)
+                                             ->  Result
+                                                   ->  WindowAgg
+                                                         ->  Gather Motion 1:1  (slice1; segments: 1)
+                                                               ->  Seq Scan on ss_t2
+                                                                     Filter: (id = 2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(52 rows)
+
+WITH
+  cte1 AS (SELECT v FROM ss_t2 WHERE id = 1),
+  cte2 AS (SELECT v FROM ss_t2 WHERE id = 2)
+SELECT DISTINCT
+       (SELECT v FROM cte1) + (SELECT v FROM cte2) +
+       (SELECT v FROM cte1) + (SELECT v FROM cte2) AS result
+FROM ss_t1;
+ result
+--------
+     60
+(1 row)
+
+DROP TABLE ss_t1;
+DROP TABLE ss_t2;
+-- Test: Recursive CTE must NOT be inlined — verify it still works correctly.
+WITH RECURSIVE r(n) AS (
+  VALUES (1)
+  UNION ALL
+  SELECT n + 1 FROM r WHERE n < 5
+)
+SELECT * FROM r ORDER BY n;
+ n
+---
+ 1
+ 2
+ 3
+ 4
+ 5
+(5 rows)
+
+-- Test: Volatile CTE is skipped by early CTE inlining (inline_cte),
+-- but may still be inlined later by the optimizer's own CTE handling.
+WITH cte_vol AS (SELECT random() AS r)
+SELECT (SELECT r FROM cte_vol) = (SELECT r FROM cte_vol) AS same_value;
+ same_value
+------------
+ f
+(1 row)
+
+-- Test: CTE with multiple references in a JOIN — should be inlined and
+-- produce correct results.
+CREATE TABLE ss_t3 (a int, b text) DISTRIBUTED BY (a);
+INSERT INTO ss_t3 VALUES (1, 'x'), (2, 'y'), (3, 'z');
+ANALYZE ss_t3;
+WITH cte AS (SELECT a, b FROM ss_t3 WHERE a <= 2)
+SELECT t1.a AS a1, t2.a AS a2, t1.b || t2.b AS combined
+FROM cte t1 JOIN cte t2 ON t1.a < t2.a
+ORDER BY t1.a, t2.a;
+ a1 | a2 | combined
+----+----+----------
+  1 |  2 | xy
+(1 row)
+
+DROP TABLE ss_t3;
+-- Test: gp_enable_cte_inlining GUC controls early CTE inlining.
+-- With inlining disabled and ORCA, EXPLAIN shows Shared Scan nodes.
+-- With inlining enabled (default), CTE references become subqueries.
+CREATE TABLE ss_t4 (id int) DISTRIBUTED BY (id);
+INSERT INTO ss_t4 VALUES (1), (2), (3);
+ANALYZE ss_t4;
+SET gp_enable_cte_inlining = off;
+EXPLAIN (costs off)
+WITH cte AS (SELECT id FROM ss_t4 WHERE id <= 2)
+SELECT * FROM cte t1 JOIN cte t2 ON t1.id = t2.id;
+                           QUERY PLAN
+----------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 1:0)
+               ->  Materialize
+                     ->  Seq Scan on ss_t4
+                           Filter: (id <= 2)
+         ->  Hash Join
+               Hash Cond: (share0_ref3.id = share0_ref2.id)
+               ->  Result
+                     Filter: (share0_ref3.id <= 2)
+                     ->  Shared Scan (share slice:id 1:0)
+               ->  Hash
+                     ->  Result
+                           Filter: (share0_ref2.id <= 2)
+                           ->  Shared Scan (share slice:id 1:0)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(16 rows)
+
+SET gp_enable_cte_inlining = on;
+EXPLAIN (costs off)
+WITH cte AS (SELECT id FROM ss_t4 WHERE id <= 2)
+SELECT * FROM cte t1 JOIN cte t2 ON t1.id = t2.id;
+                 QUERY PLAN
+---------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (ss_t4.id = ss_t4_1.id)
+         ->  Seq Scan on ss_t4
+               Filter: (id <= 2)
+         ->  Hash
+               ->  Seq Scan on ss_t4 ss_t4_1
+                     Filter: (id <= 2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+RESET gp_enable_cte_inlining;
+DROP TABLE ss_t4;

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -1314,3 +1314,81 @@ explain (costs off) select (select b from bar)[(select 1)][1:3] from bar;
 select (select b from bar)[(select 1)][1:3] from bar;
 
 drop table bar;
+
+-- Test: CTE inlining avoids cross-slice shared scan deadlock.
+-- When the same CTE is referenced multiple times as scalar subqueries,
+-- without inlining the planner may produce a shared scan that spans
+-- multiple slices, causing the query to hang.  With CTE inlining each
+-- reference becomes an independent subquery and the hang disappears.
+CREATE TABLE ss_t1 (id int) DISTRIBUTED BY (id);
+INSERT INTO ss_t1 SELECT i FROM generate_series(1, 10) i;
+CREATE TABLE ss_t2 (id int, v int) DISTRIBUTED REPLICATED;
+INSERT INTO ss_t2 VALUES (1, 10), (2, 20);
+ANALYZE ss_t1;
+ANALYZE ss_t2;
+
+EXPLAIN (costs off)
+WITH
+  cte1 AS (SELECT v FROM ss_t2 WHERE id = 1),
+  cte2 AS (SELECT v FROM ss_t2 WHERE id = 2)
+SELECT DISTINCT
+       (SELECT v FROM cte1) + (SELECT v FROM cte2) +
+       (SELECT v FROM cte1) + (SELECT v FROM cte2) AS result
+FROM ss_t1;
+
+WITH
+  cte1 AS (SELECT v FROM ss_t2 WHERE id = 1),
+  cte2 AS (SELECT v FROM ss_t2 WHERE id = 2)
+SELECT DISTINCT
+       (SELECT v FROM cte1) + (SELECT v FROM cte2) +
+       (SELECT v FROM cte1) + (SELECT v FROM cte2) AS result
+FROM ss_t1;
+
+DROP TABLE ss_t1;
+DROP TABLE ss_t2;
+
+-- Test: Recursive CTE must NOT be inlined — verify it still works correctly.
+WITH RECURSIVE r(n) AS (
+  VALUES (1)
+  UNION ALL
+  SELECT n + 1 FROM r WHERE n < 5
+)
+SELECT * FROM r ORDER BY n;
+
+-- Test: Volatile CTE is skipped by early CTE inlining (inline_cte),
+-- but may still be inlined later by the optimizer's own CTE handling.
+WITH cte_vol AS (SELECT random() AS r)
+SELECT (SELECT r FROM cte_vol) = (SELECT r FROM cte_vol) AS same_value;
+
+-- Test: CTE with multiple references in a JOIN — should be inlined and
+-- produce correct results.
+CREATE TABLE ss_t3 (a int, b text) DISTRIBUTED BY (a);
+INSERT INTO ss_t3 VALUES (1, 'x'), (2, 'y'), (3, 'z');
+ANALYZE ss_t3;
+
+WITH cte AS (SELECT a, b FROM ss_t3 WHERE a <= 2)
+SELECT t1.a AS a1, t2.a AS a2, t1.b || t2.b AS combined
+FROM cte t1 JOIN cte t2 ON t1.a < t2.a
+ORDER BY t1.a, t2.a;
+
+DROP TABLE ss_t3;
+
+-- Test: gp_enable_cte_inlining GUC controls early CTE inlining.
+-- With inlining disabled and ORCA, EXPLAIN shows Shared Scan nodes.
+-- With inlining enabled (default), CTE references become subqueries.
+CREATE TABLE ss_t4 (id int) DISTRIBUTED BY (id);
+INSERT INTO ss_t4 VALUES (1), (2), (3);
+ANALYZE ss_t4;
+
+SET gp_enable_cte_inlining = off;
+EXPLAIN (costs off)
+WITH cte AS (SELECT id FROM ss_t4 WHERE id <= 2)
+SELECT * FROM cte t1 JOIN cte t2 ON t1.id = t2.id;
+
+SET gp_enable_cte_inlining = on;
+EXPLAIN (costs off)
+WITH cte AS (SELECT id FROM ss_t4 WHERE id <= 2)
+SELECT * FROM cte t1 JOIN cte t2 ON t1.id = t2.id;
+
+RESET gp_enable_cte_inlining;
+DROP TABLE ss_t4;


### PR DESCRIPTION
It is PR is trying to fix the same problem when a non-recursive CTE is referenced multiple times (e.g. as scalar subqueries), the planner may produce a shared scan that spans multiple slices, causing the query to hang indefinitely (the same issue that was raised here https://github.com/open-gpdb/gpdb/pull/370). inlining simple cte that allow us to convert them in scalar in orca transformation and our plan will be built like if we used subqueries instead of ctes.
Fix this by inlining non-recursive, non-volatile CTEs as subqueries in standard_planner() before either ORCA or the Postgres optimizer sees the query. Each CTE reference becomes an independent subquery, eliminating the cross-slice shared scan.

The transformation is guarded by the new GUC gp_enable_cte_inlining (default: on). Recursive CTEs, CTEs containing volatile functions, and DML CTEs are left unchanged.
