### PR TITLE
[subquery] Preserve COUNT semantics in scalar subquery pull-up

### DIFF
--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -17,6 +17,7 @@
 #include "access/htup_details.h"
 #include "access/skey.h"
 #include "catalog/pg_operator.h"
+#include "catalog/pg_proc.h"
 #include "catalog/pg_type.h"
 #include "nodes/makefuncs.h"
 #include "optimizer/clauses.h"
@@ -43,6 +44,10 @@ static JoinExpr *make_join_expr(Node *larg, int r_rtindex, int join_type);
 static Node *make_lasj_quals(PlannerInfo *root, SubLink *sublink, int subquery_indx);
 
 static Node *add_null_match_clause(Node *clause);
+static bool contains_count_agg_expr(Node *expr);
+static Expr *build_count_coalesce_expr(Var *aggVar, Expr *defaultExpr);
+static Expr *build_count_default_expr(Node *expr);
+static Node *replace_agg_with_empty_default_mutator(Node *node, void *context);
 
 typedef struct NonNullableVarsContext
 {
@@ -574,6 +579,7 @@ convert_EXPR_to_join(PlannerInfo *root, OpExpr *opexp)
 		 * targetlist.
 		 */
 		TargetEntry *origSubqueryTLE = (TargetEntry *) list_nth(subselect->targetList, 0);
+		bool		has_count_expr = contains_count_agg_expr((Node *) origSubqueryTLE->expr);
 
 		List	   *subselectTargetList = (List *) copyObject(ctx1.targetList);
 
@@ -624,12 +630,109 @@ convert_EXPR_to_join(PlannerInfo *root, OpExpr *opexp)
 											 exprCollation((Node *) subselectAggTLE->expr),
 											 0);
 
-		list_nth_replace(opexp->args, 1, aggVar);
+		if (has_count_expr)
+		{
+			/*
+			 * Expressions containing COUNT over no matching rows must evaluate
+			 * with COUNT=0 instead of NULL after pull-up. For non-COUNT
+			 * aggregates in the same expression, use NULL empty-input defaults.
+			 * Preserve semantics with LEFT JOIN + COALESCE(agg_expr, default_expr).
+			 */
+			Expr	   *defaultExpr = build_count_default_expr((Node *) origSubqueryTLE->expr);
+
+			join_expr->jointype = JOIN_LEFT;
+			list_nth_replace(opexp->args, 1, build_count_coalesce_expr(aggVar, defaultExpr));
+		}
+		else
+		{
+			list_nth_replace(opexp->args, 1, aggVar);
+		}
 
 		return join_expr;
 	}
 
 	return NULL;
+}
+
+static bool
+contains_count_agg_expr(Node *expr)
+{
+	if (expr == NULL)
+		return false;
+
+	if (IsA(expr, Aggref))
+	{
+		Aggref	   *aggref = (Aggref *) expr;
+		return aggref->aggfnoid == COUNT_ANY_OID ||
+			   aggref->aggfnoid == COUNT_STAR_OID;
+	}
+
+	return expression_tree_walker(expr,
+								  contains_count_agg_expr,
+								  NULL);
+}
+
+static Expr *
+build_count_coalesce_expr(Var *aggVar, Expr *defaultExpr)
+{
+	CoalesceExpr *coalesce;
+
+	Assert(aggVar != NULL);
+	Assert(defaultExpr != NULL);
+
+	coalesce = makeNode(CoalesceExpr);
+	coalesce->coalescetype = exprType((Node *) aggVar);
+	coalesce->coalescecollid = exprCollation((Node *) aggVar);
+	coalesce->args = list_make2(aggVar, defaultExpr);
+	coalesce->location = -1;
+
+	return (Expr *) coalesce;
+}
+
+static Expr *
+build_count_default_expr(Node *expr)
+{
+	Node	   *rewritten;
+
+	rewritten = replace_agg_with_empty_default_mutator(copyObject(expr), NULL);
+	return (Expr *) rewritten;
+}
+
+static Node *
+replace_agg_with_empty_default_mutator(Node *node, void *context)
+{
+	Aggref	   *aggref;
+	Oid			default_type;
+	Oid			default_collation;
+	int16		typlen;
+	bool		typbyval;
+
+	if (node == NULL)
+		return NULL;
+
+	if (IsA(node, Aggref))
+	{
+		aggref = (Aggref *) node;
+		if (aggref->aggfnoid == COUNT_ANY_OID ||
+			aggref->aggfnoid == COUNT_STAR_OID)
+		{
+			default_type = INT8OID;
+			default_collation = InvalidOid;
+		}
+		else
+		{
+			default_type = aggref->aggtype;
+			default_collation = exprCollation((Node *) aggref);
+		}
+
+		get_typlenbyval(default_type, &typlen, &typbyval);
+		return (Node *) makeConst(default_type, -1, default_collation, typlen,
+								  (default_type == INT8OID) ? Int64GetDatum(0) : (Datum) 0,
+								  (default_type != INT8OID), typbyval);
+	}
+
+	return expression_tree_mutator(node, replace_agg_with_empty_default_mutator,
+								   context);
 }
 
 /* NOTIN subquery transformation -start */

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -499,6 +499,121 @@ select count(*) from csq_t1 t1 where a > ( select avg(a)::int from csq_t1 t2 whe
     49
 (1 row)
 
+-- COUNT correlated scalar subquery should keep no-match rows (COUNT = 0)
+-- Scenario 1: optimizer=off (always PostgreSQL planner path)
+set optimizer=off;
+SET
+select count(*) from csq_t1 t1 where a > (select count(*) from csq_t1 t2 where t2.a = t1.d);
+ count 
+-------
+   100
+(1 row)
+
+select min(a), max(a) from csq_t1 t1 where (select count(*) from csq_t1 t2 where t2.a = t1.d) = 0;
+ min | max 
+-----+-----
+ 100 | 100
+(1 row)
+
+reset optimizer;
+RESET
+-- Scenario 2: optimizer=on, but query shape forces ORCA fallback to PostgreSQL planner
+-- (ordered aggregate disabled in ORCA by default)
+set optimizer=on;
+SET
+set optimizer_enable_orderedagg=off;
+SET
+explain select string_agg(t1.a::text, ',' order by t1.a)
+from csq_t1 t1
+where t1.a > (select count(*) from csq_t1 t2 where t2.a = t1.d);
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Aggregate  (cost=20.13..20.14 rows=1 width=32)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=7.75..19.38 rows=100 width=4)
+         ->  Hash Left Join  (cost=7.75..15.38 rows=34 width=4)
+               Hash Cond: (t1.d = "Expr_SUBQUERY".csq_c0)
+               Join Filter: (t1.a > COALESCE("Expr_SUBQUERY".csq_c1, '0'::bigint))
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..6.00 rows=34 width=8)
+                     Hash Key: t1.d
+                     ->  Seq Scan on csq_t1 t1  (cost=0.00..4.00 rows=34 width=8)
+               ->  Hash  (cost=6.50..6.50 rows=34 width=12)
+                     ->  Subquery Scan on "Expr_SUBQUERY"  (cost=4.50..6.50 rows=34 width=12)
+                           ->  HashAggregate  (cost=4.50..5.50 rows=34 width=12)
+                                 Group Key: t2.a
+                                 ->  Seq Scan on csq_t1 t2  (cost=0.00..4.00 rows=34 width=4)
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+select string_agg(t1.a::text, ',' order by t1.a)
+from csq_t1 t1
+where t1.a > (select count(*) from csq_t1 t2 where t2.a = t1.d);
+                                                                                                                                             string_agg                                                                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100
+(1 row)
+
+-- Non-plain COUNT expression (COUNT(*) + 1) should also preserve no-match semantics
+-- Scenario 1: optimizer=off (always PostgreSQL planner path)
+set optimizer=off;
+SET
+select min(a), max(a), count(*) from csq_t1 t1
+where (select count(*) + 1 from csq_t1 t2 where t2.a = t1.d) = 1;
+ min | max | count 
+-----+-----+-------
+ 100 | 100 |     1
+(1 row)
+
+select min(a), max(a), count(*) from csq_t1 t1
+where (select (count(*) + 1)::bigint from csq_t1 t2 where t2.a = t1.d) = 1;
+ min | max | count 
+-----+-----+-------
+ 100 | 100 |     1
+(1 row)
+
+select min(a), max(a), count(*) from csq_t1 t1
+where (select case when count(*) > 0 then count(*) + 1 else 1 end
+       from csq_t1 t2 where t2.a = t1.d) = 1;
+ min | max | count 
+-----+-----+-------
+ 100 | 100 |     1
+(1 row)
+
+select min(a), max(a), count(*) from csq_t1 t1
+where (select abs(count(*) - 1) from csq_t1 t2 where t2.a = t1.d) = 1;
+ min | max | count 
+-----+-----+-------
+ 100 | 100 |     1
+(1 row)
+
+select min(a), max(a), count(*) from csq_t1 t1
+where (select count(*) + coalesce(sum(t2.a), 0) from csq_t1 t2 where t2.a = t1.d) = 0;
+ min | max | count 
+-----+-----+-------
+ 100 | 100 |     1
+(1 row)
+
+select min(a), max(a), count(*) from csq_t1 t1
+where (select coalesce(count(*) + sum(t2.a), -1) from csq_t1 t2 where t2.a = t1.d) = -1;
+ min | max | count 
+-----+-----+-------
+ 100 | 100 |     1
+(1 row)
+
+reset optimizer;
+RESET
+-- Scenario 2: optimizer=on, but query shape forces ORCA fallback to PostgreSQL planner
+set optimizer=on;
+SET
+set optimizer_enable_orderedagg=off;
+SET
+select string_agg(t1.a::text, ',' order by t1.a)
+from csq_t1 t1
+where (select count(*) + 1 from csq_t1 t2 where t2.a = t1.d) = 1;
+ string_agg 
+------------
+ 100
+(1 row)
+
 --
 -- correlation in a func expr
 --

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -452,6 +452,68 @@ select count(*) from csq_t1 t1 where a > ( select avg(a)::int from csq_t1 t2 whe
     49
 (1 row)
 
+-- Non-plain COUNT expression (COUNT(*) + 1) should also preserve no-match semantics
+-- Scenario 1: optimizer=off (always PostgreSQL planner path)
+set optimizer=off;
+SET
+select min(a), max(a), count(*) from csq_t1 t1
+where (select count(*) + 1 from csq_t1 t2 where t2.a = t1.d) = 1;
+ min | max | count 
+-----+-----+-------
+ 100 | 100 |     1
+(1 row)
+
+select min(a), max(a), count(*) from csq_t1 t1
+where (select (count(*) + 1)::bigint from csq_t1 t2 where t2.a = t1.d) = 1;
+ min | max | count 
+-----+-----+-------
+ 100 | 100 |     1
+(1 row)
+
+select min(a), max(a), count(*) from csq_t1 t1
+where (select case when count(*) > 0 then count(*) + 1 else 1 end
+       from csq_t1 t2 where t2.a = t1.d) = 1;
+ min | max | count 
+-----+-----+-------
+ 100 | 100 |     1
+(1 row)
+
+select min(a), max(a), count(*) from csq_t1 t1
+where (select abs(count(*) - 1) from csq_t1 t2 where t2.a = t1.d) = 1;
+ min | max | count 
+-----+-----+-------
+ 100 | 100 |     1
+(1 row)
+
+select min(a), max(a), count(*) from csq_t1 t1
+where (select count(*) + coalesce(sum(t2.a), 0) from csq_t1 t2 where t2.a = t1.d) = 0;
+ min | max | count 
+-----+-----+-------
+ 100 | 100 |     1
+(1 row)
+
+select min(a), max(a), count(*) from csq_t1 t1
+where (select coalesce(count(*) + sum(t2.a), -1) from csq_t1 t2 where t2.a = t1.d) = -1;
+ min | max | count 
+-----+-----+-------
+ 100 | 100 |     1
+(1 row)
+
+reset optimizer;
+RESET
+-- Scenario 2: optimizer=on, but query shape forces ORCA fallback to PostgreSQL planner
+set optimizer=on;
+SET
+set optimizer_enable_orderedagg=off;
+SET
+select string_agg(t1.a::text, ',' order by t1.a)
+from csq_t1 t1
+where (select count(*) + 1 from csq_t1 t2 where t2.a = t1.d) = 1;
+ string_agg 
+------------
+ 100
+(1 row)
+
 --
 -- correlation in a func expr
 --

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -224,6 +224,49 @@ select count(*) from csq_t1 t1 where a > (SELECT x.b FROM ( select avg(a)::int a
 
 select count(*) from csq_t1 t1 where a > ( select avg(a)::int from csq_t1 t2 where t2.a=t1.d) ;
 
+-- COUNT correlated scalar subquery should keep no-match rows (COUNT = 0)
+-- Scenario 1: optimizer=off (always PostgreSQL planner path)
+set optimizer=off;
+select count(*) from csq_t1 t1 where a > (select count(*) from csq_t1 t2 where t2.a = t1.d);
+select min(a), max(a) from csq_t1 t1 where (select count(*) from csq_t1 t2 where t2.a = t1.d) = 0;
+reset optimizer;
+
+-- Scenario 2: optimizer=on, but query shape forces ORCA fallback to PostgreSQL planner
+-- (ordered aggregate disabled in ORCA by default)
+set optimizer=on;
+set optimizer_enable_orderedagg=off;
+explain select string_agg(t1.a::text, ',' order by t1.a)
+from csq_t1 t1
+where t1.a > (select count(*) from csq_t1 t2 where t2.a = t1.d);
+select string_agg(t1.a::text, ',' order by t1.a)
+from csq_t1 t1
+where t1.a > (select count(*) from csq_t1 t2 where t2.a = t1.d);
+
+-- Non-plain COUNT expression (COUNT(*) + 1) should also preserve no-match semantics
+-- Scenario 1: optimizer=off (always PostgreSQL planner path)
+set optimizer=off;
+select min(a), max(a), count(*) from csq_t1 t1
+where (select count(*) + 1 from csq_t1 t2 where t2.a = t1.d) = 1;
+select min(a), max(a), count(*) from csq_t1 t1
+where (select (count(*) + 1)::bigint from csq_t1 t2 where t2.a = t1.d) = 1;
+select min(a), max(a), count(*) from csq_t1 t1
+where (select case when count(*) > 0 then count(*) + 1 else 1 end
+       from csq_t1 t2 where t2.a = t1.d) = 1;
+select min(a), max(a), count(*) from csq_t1 t1
+where (select abs(count(*) - 1) from csq_t1 t2 where t2.a = t1.d) = 1;
+select min(a), max(a), count(*) from csq_t1 t1
+where (select count(*) + coalesce(sum(t2.a), 0) from csq_t1 t2 where t2.a = t1.d) = 0;
+select min(a), max(a), count(*) from csq_t1 t1
+where (select coalesce(count(*) + sum(t2.a), -1) from csq_t1 t2 where t2.a = t1.d) = -1;
+reset optimizer;
+
+-- Scenario 2: optimizer=on, but query shape forces ORCA fallback to PostgreSQL planner
+set optimizer=on;
+set optimizer_enable_orderedagg=off;
+select string_agg(t1.a::text, ',' order by t1.a)
+from csq_t1 t1
+where (select count(*) + 1 from csq_t1 t2 where t2.a = t1.d) = 1;
+
 --
 -- correlation in a func expr
 --


### PR DESCRIPTION
Fixes #378

## Summary
This is not an ORCA issue; it occurs in the fallback PostgreSQL optimizer rewrite path.

Fix incorrect semantics in correlated scalar aggregate subquery pull-up when target expression contains `COUNT`.

This risk applies not only to manual `optimizer=off`, but also to other cases where planning falls back from ORCA to PostgreSQL optimizer.

## What Changed
In `cdbsubselect.c` (`convert_EXPR_to_join`), for COUNT-containing scalar aggregate expressions:
- use `LEFT JOIN` in rewrite
- replace pulled-up expression with `COALESCE(agg_expr, default_expr)`
- derive `default_expr` from empty-input aggregate defaults:
  - `COUNT(...) -> 0`
  - non-COUNT aggregates -> `NULL` (aggregate result type)

This preserves no-match semantics for both COUNT-only and mixed COUNT+other aggregate expressions.

## Tests Updated
Added/updated `subselect_gp` regression cases for:
- `count(*) + 1`
- `(count(*) + 1)::bigint`
- `case when count(*) > 0 then count(*) + 1 else 1 end`
- `abs(count(*) - 1)`
- `count(*) + coalesce(sum(...), 0)`
- `coalesce(count(*) + sum(...), -1)`

## Files
- `src/backend/cdb/cdbsubselect.c`
- `src/test/regress/sql/subselect_gp.sql`
- `src/test/regress/expected/subselect_gp.out`
- `src/test/regress/expected/subselect_gp_optimizer.out`
