### PR TITLE
cherry-pick: Avoid fetching one past the end of translate()'s "to" parameter.

### DIFF
--- a/src/backend/utils/adt/oracle_compat.c
+++ b/src/backend/utils/adt/oracle_compat.c
@@ -722,7 +722,8 @@ translate(PG_FUNCTION_ARGS)
 	text	   *to = PG_GETARG_TEXT_PP(2);
 	text	   *result;
 	char	   *from_ptr,
-			   *to_ptr;
+			   *to_ptr,
+			   *to_end;
 	char	   *source,
 			   *target;
 	int			m,
@@ -744,6 +745,7 @@ translate(PG_FUNCTION_ARGS)
 	from_ptr = VARDATA_ANY(from);
 	tolen = VARSIZE_ANY_EXHDR(to);
 	to_ptr = VARDATA_ANY(to);
+	to_end = to_ptr + tolen;
 
 	/*
 	 * The worst-case expansion is to substitute a max-length character for a
@@ -777,16 +779,16 @@ translate(PG_FUNCTION_ARGS)
 		}
 		if (i < fromlen)
 		{
-			/* substitute */
+			/* substitute, or delete if no corresponding "to" character */
 			char	   *p = to_ptr;
 
 			for (i = 0; i < from_index; i++)
 			{
-				p += pg_mblen(p);
-				if (p >= (to_ptr + tolen))
+				if (p >= to_end)
 					break;
+				p += pg_mblen(p);
 			}
-			if (p < (to_ptr + tolen))
+			if (p < to_end)
 			{
 				len = pg_mblen(p);
 				memcpy(target, p, len);

--- a/src/test/regress/expected/strings.out
+++ b/src/test/regress/expected/strings.out
@@ -1859,6 +1859,12 @@ SELECT translate('12345', '14', 'ax');
  a23x5
 (1 row)
 
+SELECT translate('12345', '134', 'a');
+ translate 
+-----------
+ a25
+(1 row)
+
 SELECT ascii('x');
  ascii 
 -------

--- a/src/test/regress/sql/strings.sql
+++ b/src/test/regress/sql/strings.sql
@@ -626,6 +626,7 @@ SELECT ltrim('zzzytrim', 'xyz');
 
 SELECT translate('', '14', 'ax');
 SELECT translate('12345', '14', 'ax');
+SELECT translate('12345', '134', 'a');
 
 SELECT ascii('x');
 SELECT ascii('');


### PR DESCRIPTION
This is usually harmless, but if you were very unlucky it could provoke a segfault due to the "to" string being right up against the end of memory.  Found via valgrind testing (so we might've found it earlier, except that our regression tests lacked any exercise of translate()'s deletion feature).

Fix by switching the order of the test-for-end-of-string and advance-pointer steps.  While here, compute "to_ptr + tolen" just once.  (Smarter compilers might figure that out for themselves, but let's just make sure.)

Report and fix by Daniil Anisimov, in bug #17816.

Discussion: https://postgr.es/m/17816-70f3d2764e88a108@postgresql.org

cherry-pick from https://git.postgresql.org/cgit/postgresql.git/commit/?h=1a9356f657e19ae1abeb0ffea0b7edaf69e315cb

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
