### PR TITLE
Force public schema for gp_interconnect_stats.control install

### DIFF
--- a/gpcontrib/gp_interconnect_stats/gp_interconnect_stats.control
+++ b/gpcontrib/gp_interconnect_stats/gp_interconnect_stats.control
@@ -1,3 +1,4 @@
 comment = 'Cummulative statistics from UDPIFC interconnect protocol'
 default_version = '1.0'
 relocatable = false
+schema = public


### PR DESCRIPTION
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
