### PR TITLE
Fix: error on creating try_convert extension

### DIFF
--- a/contrib/try_convert/try_convert.control
+++ b/contrib/try_convert/try_convert.control
@@ -1,5 +1,6 @@
 # try_convert extension
 comment = 'function for type cast'
-default_version = '1.0'
+default_version = '1.1'
 module_pathname = '$libdir/try_convert'
 relocatable = true
+trusted = true

--- a/contrib/try_convert/try_convert.control
+++ b/contrib/try_convert/try_convert.control
@@ -1,6 +1,6 @@
 # try_convert extension
 comment = 'function for type cast'
-default_version = '1.1'
+default_version = '1.0'
 module_pathname = '$libdir/try_convert'
 relocatable = true
 trusted = true


### PR DESCRIPTION
Non-superusers can't create `try_convert` extension, receiving a permission denied error.
The fix is to add `trusted = true` to try_convert.control.
`trusted = true` allows installing the extension to any users with CREATE privileges on current database. 
Extension is safe.
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community

