### PR TITLE
Fix typo in comment

### DIFF
--- a/src/backend/storage/lmgr/lmgr.c
+++ b/src/backend/storage/lmgr/lmgr.c
@@ -1144,7 +1144,7 @@ LockTagIsTemp(const LOCKTAG *tag)
 }
 
 /*
- * Because of the current disign of AO table's visibility map,
+ * Because of the current design of AO table's visibility map,
  * we have to keep upgrading locks for AO table.
  */
 bool


### PR DESCRIPTION
Fix a typo in a comment: `disign` to `design`.