### PR TITLE
Add OPENGPDB compile-time identification macro

### DIFF
--- a/src/include/pg_config_manual.h
+++ b/src/include/pg_config_manual.h
@@ -311,3 +311,10 @@
 /* #define HEAPDEBUGALL */
 /* #define ACLDEBUG */
 /* #define RTDEBUG */
+
+/*
+ * OPENGPDB marks this distribution as open-gpdb, so extensions can tell it
+ * apart from other Greenplum forks (e.g. GreengageDB) at compile time and
+ * pick the right call when an internal API differs between forks.
+ */
+#define OPENGPDB 1


### PR DESCRIPTION
Add OPENGPDB compile-time identification macro

Define OPENGPDB in pg_config_manual.h so extensions can tell open-gpdb apart from other Greenplum forks (e.g. GreengageDB) at compile time.

Extensions need this because internal APIs differ between forks, so the same source must pick a different call depending on the fork. For example utils/sampling.h: open-gpdb has sampler_random_fract(void), GreengageDB has sampler_random_fract(SamplerRandomState). With this macro an extension can guard such calls via #ifdef OPENGPDB.