### PR TITLE
Fix flaky ci tests

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1152,6 +1152,19 @@ standard_ExecutorRun(QueryDesc *queryDesc,
 				 */
 				EndpointNotifyQD(ENDPOINT_READY_ACK_MSG);
 
+#ifdef FAULT_INJECTOR
+				/*
+				 * Testing hook: DECLARE has already returned (endpoint created,
+				 * QD notified) but the plan hasn't run yet. A test pauses here so
+				 * an execution error surfaces only after DECLARE and is caught by
+				 * the timeout mechanism instead of racing with DECLARE.
+				 */
+				FaultInjector_InjectFaultIfSet("parallel_retrieve_cursor_before_exec",
+											   DDLNotSpecified,
+											   "" /* databaseName */,
+											   "" /* tableName */);
+#endif /* FAULT_INJECTOR */
+
 				ExecutePlan(estate,
 							queryDesc->planstate,
 							operation,

--- a/src/test/isolation2/expected/ao_fsync_panic.out
+++ b/src/test/isolation2/expected/ao_fsync_panic.out
@@ -76,6 +76,15 @@ CHECKPOINT
 1: INSERT INTO ao_fsync_panic_tbl SELECT generate_series(200, 299);
 INSERT 100
 
+-- Arm the fault on the content-0 mirror before promotion.
+-- start_ignore
+2: SELECT gp_inject_fault('checkpoint_after_redo_calculated', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'm' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- end_ignore
+
 -- Stop the primary immediately and promote the mirror.
 2: SELECT pg_ctl(datadir, 'stop', 'immediate') FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
  pg_ctl 
@@ -88,16 +97,16 @@ INSERT 100
  t                         
 (1 row)
 
--- Wait for the end of recovery CHECKPOINT completed after the mirror was promoted,
--- to ensure the CHECKPOINT record to be appended right after the END_OF_RECOVERY record.
--- Note, if the TRUNCATE operation interleaves between the END_OF_RECOVERY and the
--- CHECKPOINT record, PANIC might happen due to a fsync request being queued for an unlinked AO file,
--- is not forgotten in this case.
-2: SELECT gp_inject_fault('checkpoint_after_redo_calculated', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
- gp_inject_fault 
------------------
- Success:        
+-- Wait until the promoted primary accepts connections (0U retries), then
+-- confirm the end-of-recovery checkpoint finished before the TRUNCATE below
+-- (else a fsync for an unlinked AO file could cause a PANIC).
+-- start_ignore
+0U: SELECT 1;
+ ?column? 
+----------
+ 1        
 (1 row)
+0Uq:
 2: SELECT gp_wait_until_triggered_fault('checkpoint_after_redo_calculated', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
  gp_wait_until_triggered_fault 
 -------------------------------
@@ -108,6 +117,7 @@ INSERT 100
 -----------------
  Success:        
 (1 row)
+-- end_ignore
 
 -- Expect to see the content 0, preferred primary is mirror and it's down;
 -- the preferred mirror is primary and it's up and not-in-sync.

--- a/src/test/isolation2/input/parallel_retrieve_cursor/status_check.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/status_check.source
@@ -261,6 +261,15 @@ insert into t1 select generate_series(1,100);
 1: create table t1(a int, b int);
 1: insert into t1 values (generate_series(1,100000), 1);
 1: insert into t1 values (-1, 1);
+-- Make this deterministic: pause the endpoint QEs after DECLARE returns but
+-- before the plan runs, so the sqrt() error below always surfaces after DECLARE
+-- and is caught by the timeout mechanism instead of racing with it.
+-- start_ignore
+SELECT gp_inject_fault('parallel_retrieve_cursor_before_exec', 'reset', dbid)
+    FROM gp_segment_configuration WHERE role='p' AND content>=0;
+SELECT gp_inject_fault('parallel_retrieve_cursor_before_exec', 'sleep', '', '', '', 1, 1, 3, dbid)
+    FROM gp_segment_configuration WHERE role='p' AND content>=0;
+-- end_ignore
 1: BEGIN;
 1: DECLARE c9 PARALLEL RETRIEVE CURSOR FOR select count(*) from t1 group by sqrt(a); select count() from gp_get_endpoints();
 -- GP_PARALLEL_RETRIEVE_CURSOR_CHECK_TIMEOUT is 10s, we sleep 12 to check all QEs are already finished.
@@ -268,3 +277,7 @@ insert into t1 select generate_series(1,100);
 1: SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c9';
 1: rollback;
 1q:
+-- start_ignore
+SELECT gp_inject_fault('parallel_retrieve_cursor_before_exec', 'reset', dbid)
+    FROM gp_segment_configuration WHERE role='p' AND content>=0;
+-- end_ignore

--- a/src/test/isolation2/output/parallel_retrieve_cursor/status_check.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/status_check.source
@@ -1401,6 +1401,27 @@ CREATE
 INSERT 100000
 1: insert into t1 values (-1, 1);
 INSERT 1
+-- Make this deterministic: pause the endpoint QEs after DECLARE returns but
+-- before the plan runs, so the sqrt() error below always surfaces after DECLARE
+-- and is caught by the timeout mechanism instead of racing with it.
+-- start_ignore
+SELECT gp_inject_fault('parallel_retrieve_cursor_before_exec', 'reset', dbid)
+    FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+SELECT gp_inject_fault('parallel_retrieve_cursor_before_exec', 'sleep', '', '', '', 1, 1, 3, dbid)
+    FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+-- end_ignore
 1: BEGIN;
 BEGIN
 1: DECLARE c9 PARALLEL RETRIEVE CURSOR FOR select count(*) from t1 group by sqrt(a); select count() from gp_get_endpoints();
@@ -1418,3 +1439,13 @@ BEGIN
 1: rollback;
 ERROR:  cannot take square root of a negative number  (seg2 slice1 127.0.1.1:6004 pid=83657)
 1q: ... <quitting>
+-- start_ignore
+SELECT gp_inject_fault('parallel_retrieve_cursor_before_exec', 'reset', dbid)
+    FROM gp_segment_configuration WHERE role='p' AND content>=0;
+ gp_inject_fault
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+-- end_ignore

--- a/src/test/isolation2/sql/ao_fsync_panic.sql
+++ b/src/test/isolation2/sql/ao_fsync_panic.sql
@@ -3,7 +3,7 @@ include: helpers/server_helpers.sql;
 -- setup
 -- Set fsync on since we need to test the fsync code logic.
 !\retcode gpconfig -c fsync -v on --skipvalidation;
--- Set create_restartpoint_on_ckpt_record_replay to trigger creating 
+-- Set create_restartpoint_on_ckpt_record_replay to trigger creating
 -- restart point easily.
 !\retcode gpconfig -c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation;
 !\retcode gpstop -u;
@@ -19,14 +19,14 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 -- The primary segment then crashed after the checkpoint completed.
 -- After the mirror segment is promoted to new primary, a truncate request
 -- is received to truncate this AO table. Then both old relfilenode and its
--- segment files are removed when executing gprecoverseg. 
+-- segment files are removed when executing gprecoverseg.
 -- On the old primary (new mirror), those files are also removed but only
--- the old refilenode segment files will be re-generated due to the insert 
+-- the old refilenode segment files will be re-generated due to the insert
 -- records during WAL replay. This will queue fsync request to checkpointer
 -- and will not be forgotten in later flush. Later restart point creation will
 -- flush the buffer to disk and expect to access the AO old base relfilenode
 -- file (.0), while it was removed by pg_rewind previously, therefore PANIC
--- at mdsync during creating restart point. 
+-- at mdsync during creating restart point.
 -- The fix is intended to remove the logic of accessing the base relfilenode
 -- file when the target is a segment file in the above fsync scenario.
 
@@ -48,21 +48,27 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 -- Create more insert records.
 1: INSERT INTO ao_fsync_panic_tbl SELECT generate_series(200, 299);
 
+-- Arm the fault on the content-0 mirror before promotion.
+-- start_ignore
+2: SELECT gp_inject_fault('checkpoint_after_redo_calculated', 'skip', dbid)
+    FROM gp_segment_configuration WHERE role = 'm' AND content = 0;
+-- end_ignore
+
 -- Stop the primary immediately and promote the mirror.
 2: SELECT pg_ctl(datadir, 'stop', 'immediate') FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
 2: SELECT gp_request_fts_probe_scan();
 
--- Wait for the end of recovery CHECKPOINT completed after the mirror was promoted,
--- to ensure the CHECKPOINT record to be appended right after the END_OF_RECOVERY record.
--- Note, if the TRUNCATE operation interleaves between the END_OF_RECOVERY and the
--- CHECKPOINT record, PANIC might happen due to a fsync request being queued for an unlinked AO file,
--- is not forgotten in this case.
-2: SELECT gp_inject_fault('checkpoint_after_redo_calculated', 'skip', dbid)
-    FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+-- Wait until the promoted primary accepts connections (0U retries), then
+-- confirm the end-of-recovery checkpoint finished before the TRUNCATE below
+-- (else a fsync for an unlinked AO file could cause a PANIC).
+-- start_ignore
+0U: SELECT 1;
+0Uq:
 2: SELECT gp_wait_until_triggered_fault('checkpoint_after_redo_calculated', 1, dbid)
     FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
 2: SELECT gp_inject_fault('checkpoint_after_redo_calculated', 'reset', dbid)
     FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+-- end_ignore
 
 -- Expect to see the content 0, preferred primary is mirror and it's down;
 -- the preferred mirror is primary and it's up and not-in-sync.


### PR DESCRIPTION
Fix flaky parallel_retrieve_cursor/status_check test

Test9 relied on the segment executors scanning t1 slower than DECLARE
returns, so on fast runners the sqrt(-1) error raced DECLARE and surfaced
synchronously. Add a FAULT_INJECTOR hook parallel_retrieve_cursor_before_exec
in standard_ExecutorRun (after the endpoint is created and the coordinator
is notified, before ExecutePlan) and have the test pause the segment
executors there, so the error is always raised after DECLARE and detected
only via the timeout mechanism.

Fix flaky ao_fsync_panic test (failover-window race)
The test injected checkpoint_after_redo_calculated on content 0 right after
pg_ctl stop immediate + FTS probe, hitting the promoting mirror while it still
refuses connections ("connection to dbid ... failed"). Arm it on the mirror
before the stop instead (it only fires in CreateCheckPoint(), so promotion
still triggers it) and wait for the new primary via "0U: SELECT 1;".