### PR TITLE
Fix CI: add S3 credentials for OTM buckets in yproxy.conf

### DIFF
--- a/yezzey_test/yproxy.conf
+++ b/yezzey_test/yproxy.conf
@@ -14,6 +14,16 @@ storage:
     "pg_default": "gpyezzey"
     "tab1": "gpyezzey2"
     "tab2": "gpyezzey3"
+  credential_map:
+    "gpyezzey":
+      access_key_id: "$AWS_ACCESS_KEY_ID"
+      secret_access_key: "$AWS_SECRET_ACCESS_KEY"
+    "gpyezzey2":
+      access_key_id: "$AWS_ACCESS_KEY_ID"
+      secret_access_key: "$AWS_SECRET_ACCESS_KEY"
+    "gpyezzey3":
+      access_key_id: "$AWS_ACCESS_KEY_ID"
+      secret_access_key: "$AWS_SECRET_ACCESS_KEY"
 
 backup_storage:
   access_key_id: "$AWS_ACCESS_KEY_ID"


### PR DESCRIPTION
Fix CI: add S3 credentials for OTM buckets in yproxy.conf

The OTM buckets gpyezzey2/gpyezzey3 had no credentials, so yproxy rejected offload into the tab1/tab2 tablespaces. Add a credential_map with the access keys for all buckets to fix it.
