### PR TITLE
Backport 396 Fix cross-slice interaction detection for subplans

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -2947,20 +2947,21 @@ fixup_subplan_walker(Node *node, SubPlanWalkerContext *context)
 			 * there is more than one subplan node which refer to the same
 			 * plan_id. In this case create a duplicate subplan, append it to
 			 * the glob->subplans and update the plan_id of the subplan to
-			 * refer to the new copy of the subplan node. Note since subroot
-			 * is not used there is no need of new subroot, and initplans are
+			 * refer to the new copy of the subplan node. glob->subroots must
+			 * stay aligned with glob->subplans (same length, indexed by
+			 * plan_id); the duplicate's subroot is only ever read (e.g. by
+			 * apply_shareinput_xslice), never mutated through this slot, so we
+			 * reuse the original subroot instead of copying it. Initplans are
 			 * not needed to be duplicated.
 			 */
 			PlannerInfo *root = (PlannerInfo *) context->base.node;
 			Plan	    *dupsubplan = (Plan *) copyObject(planner_subplan_get_plan(root, subplan));
+			PlannerInfo *subroot = planner_subplan_get_root(root, subplan);
 			int			 newplan_id = list_length(root->glob->subplans) + 1;
-			PlannerInfo *dupsubroot = makeNode(PlannerInfo);
-
-			memcpy(dupsubroot, planner_subplan_get_root(root, subplan), sizeof(PlannerInfo));
-			root->glob->subroots = lappend(root->glob->subroots, dupsubroot);
 
 			subplan->plan_id = newplan_id;
 			root->glob->subplans = lappend(root->glob->subplans, dupsubplan);
+			root->glob->subroots = lappend(root->glob->subroots, subroot);
 			context->bms_subplans = bms_add_member(context->bms_subplans, newplan_id);
 			return false;
 		}

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -1764,143 +1764,121 @@ cdbmutate_warn_ctid_without_segid(struct PlannerInfo *root, struct RelOptInfo *r
  */
 
 /* Walk the tree for shareinput.
- * Shareinput fix shared_as_id and underlying_share_id of nodes in place.  We do not want to use
- * the ordinary tree walker as it is unnecessary to make copies etc.
+ * Shareinput fix shared_as_id and underlying_share_id of nodes in place.
  */
 typedef bool (*SHAREINPUT_MUTATOR) (Node *node, PlannerInfo *root, bool fPop);
-static void
-shareinput_walker(SHAREINPUT_MUTATOR f, Node *node, PlannerInfo *root)
+typedef struct ShareInputContext
 {
-	Plan	   *plan = NULL;
+	plan_tree_base_prefix base;
+	SHAREINPUT_MUTATOR mutator;
+}	ShareInputContext;
+static bool
+shareinput_walker(Node *node, ShareInputContext *ctx)
+{
 	bool		recursive_down;
+	PlannerInfo *root = (PlannerInfo *) ctx->base.node;
+	PlannerGlobal *glob = root->glob;
+	SHAREINPUT_MUTATOR mutator = ctx->mutator;
 
 	if (node == NULL)
-		return;
+		return false;
 
-	if (IsA(node, List))
-	{
-		List	   *l = (List *) node;
-		ListCell   *lc;
-
-		foreach(lc, l)
-		{
-			Node	   *n = lfirst(lc);
-
-			shareinput_walker(f, n, root);
-		}
-		return;
-	}
-
-	if (!is_plan_node(node))
-		return;
-
-	plan = (Plan *) node;
-	recursive_down = (*f) (node, root, false);
+	/*
+	 * Always dig into non-plan nodes trying to find plan node. If plan node
+	 * found, call a mutator to decide should we dig more.
+	 */
+	if (is_plan_node(node))
+		recursive_down = (*mutator) (node, root, false);
+	else
+		recursive_down = true;
 
 	if (recursive_down)
 	{
-		if (IsA(node, Append))
-		{
-			ListCell   *cell;
-			Append	   *app = (Append *) node;
+		/*
+		 * The code below can modify various params depends on it's logic.
+		 * Save old values all at once to make it uniform and to avoid
+		 * copypaste. 'root' is already saved above.
+		 */
+		Plan	   *plan = (Plan *) node;
+		List	   *save_rtable = glob->share.curr_rtable;
+		Plan	   *save_lefttree = plan->lefttree;
+		Plan	   *save_righttree = plan->righttree;
 
-			foreach(cell, app->appendplans)
-				shareinput_walker(f, (Node *) lfirst(cell), root);
-		}
-		else if (IsA(node, MergeAppend))
+		/*
+		 * The general comment to all SubPlan nodes. Before, we walked through
+		 * subplans separately from main plan. 'motStack' we use in mutators
+		 * not contains possible motion(slice) id from main plan in this case.
+		 * This caused underlying subplan's nodes not marked as cross-slice -
+		 * we didn't respect upper slices from main plan. To avoid this, we
+		 * now iterate over all nodes (even non-plan nodes), iterate through
+		 * subplans as parts of main tree and right on their places.
+		 */
+		if (IsA(node, SubPlan))
 		{
-			ListCell   *cell;
-			MergeAppend	   *mapp = (MergeAppend *) node;
+			SubPlan    *subplan = (SubPlan *) node;
 
-			foreach(cell, mapp->mergeplans)
-				shareinput_walker(f, (Node *) lfirst(cell), root);
-		}
-		else if (IsA(node, ModifyTable))
-		{
-			ListCell   *cell;
-			ModifyTable *mt = (ModifyTable *) node;
-
-			foreach(cell, mt->plans)
-				shareinput_walker(f, (Node *) lfirst(cell), root);
+			/*
+			 * The code around rtables (for SubqueryScan and
+			 * TableFunctionScan) works only with appropriate subroot. Find
+			 * one and copy to context.
+			 */
+			ctx->base.node = (Node *) planner_subplan_get_root(root, subplan);
 		}
 		else if (IsA(node, SubqueryScan))
 		{
-			SubqueryScan  *subqscan = (SubqueryScan *) node;
-			PlannerGlobal *glob = root->glob;
-			PlannerInfo   *subroot;
-			List	      *save_rtable;
-			RelOptInfo    *rel;
+			SubqueryScan *subqscan = (SubqueryScan *) node;
+			RelOptInfo *rel;
 
 			/*
 			 * If glob->finalrtable is not NULL, rtables have been flatten,
 			 * thus we should use glob->finalrtable instead.
 			 */
-			save_rtable = glob->share.curr_rtable;
-			if (root->glob->finalrtable == NULL)
+			if (glob->finalrtable == NULL)
 			{
 				rel = find_base_rel(root, subqscan->scan.scanrelid);
+
 				/*
-				 * The Assert() on RelOptInfo's subplan being
-				 * same as the subqueryscan's subplan, is valid
-				 * in Upstream but for not for GPDB, since we
-				 * create a new copy of the subplan if two
+				 * The Assert() on RelOptInfo's subplan being same as the
+				 * subqueryscan's subplan, is valid in Upstream but for not
+				 * for GPDB, since we create a new copy of the subplan if two
 				 * SubPlans refer to the same initplan.
 				 */
-				subroot = rel->subroot;
-				glob->share.curr_rtable = subroot->parse->rtable;
+				ctx->base.node = (Node *) rel->subroot;
+				glob->share.curr_rtable = rel->subroot->parse->rtable;
 			}
 			else
-			{
-				subroot = root;
 				glob->share.curr_rtable = glob->finalrtable;
-			}
-			shareinput_walker(f, (Node *) subqscan->subplan, subroot);
-			glob->share.curr_rtable = save_rtable;
 		}
 		else if (IsA(node, TableFunctionScan))
 		{
-			TableFunctionScan  *tfscan = (TableFunctionScan *) node;
-			PlannerGlobal *glob = root->glob;
-			PlannerInfo   *subroot;
-			List	      *save_rtable;
-			RelOptInfo    *rel;
+			TableFunctionScan *tfscan = (TableFunctionScan *) node;
+			RelOptInfo *rel;
 
 			/*
 			 * If glob->finalrtable is not NULL, rtables have been flatten,
 			 * thus we should use glob->finalrtable instead.
 			 */
-			save_rtable = glob->share.curr_rtable;
-			if (root->glob->finalrtable == NULL)
+			if (glob->finalrtable == NULL)
 			{
 				rel = find_base_rel(root, tfscan->scan.scanrelid);
 				Assert(rel->subplan == tfscan->scan.plan.lefttree);
-				subroot = rel->subroot;
-				glob->share.curr_rtable = subroot->parse->rtable;
+				ctx->base.node = (Node *) rel->subroot;
+				glob->share.curr_rtable = rel->subroot->parse->rtable;
 			}
 			else
-			{
-				subroot = root;
 				glob->share.curr_rtable = glob->finalrtable;
-			}
-			shareinput_walker(f, (Node *)  tfscan->scan.plan.lefttree, subroot);
-			glob->share.curr_rtable = save_rtable;
 		}
-		else if (IsA(node, BitmapAnd))
-		{
-			ListCell   *cell;
-			BitmapAnd  *ba = (BitmapAnd *) node;
 
-			foreach(cell, ba->bitmapplans)
-				shareinput_walker(f, (Node *) lfirst(cell), root);
-		}
-		else if (IsA(node, BitmapOr))
-		{
-			ListCell   *cell;
-			BitmapOr   *bo = (BitmapOr *) node;
-
-			foreach(cell, bo->bitmapplans)
-				shareinput_walker(f, (Node *) lfirst(cell), root);
-		}
+		/*
+		 * Shared scan can be producer or consumer. As descibed in the
+		 * function comment, we should respect execution order, otherwise,
+		 * deadlock between producer and consumer may rise. plan_tree_walker()
+		 * use the standard order of processing - lefttree, then rigttree.
+		 * Ignoring of execution order here may move producer to another part
+		 * of join and consumer (which should be producer normally) to wait
+		 * infinitely for nothing. Let's fool standard plan_tree_walker() by
+		 * temporary switching join parts.
+		 */
 		else if (IsA(node, NestLoop))
 		{
 			/*
@@ -1911,20 +1889,14 @@ shareinput_walker(SHAREINPUT_MUTATOR f, Node *node, PlannerInfo *root)
 
 			if (nl->join.prefetch_inner)
 			{
-				shareinput_walker(f, (Node *) plan->righttree, root);
-				shareinput_walker(f, (Node *) plan->lefttree, root);
-			}
-			else
-			{
-				shareinput_walker(f, (Node *) plan->lefttree, root);
-				shareinput_walker(f, (Node *) plan->righttree, root);
+				plan->lefttree = save_righttree;
+				plan->righttree = save_lefttree;
 			}
 		}
 		else if (IsA(node, HashJoin))
 		{
-			/* Hash join the hash table is at inner */
-			shareinput_walker(f, (Node *) plan->righttree, root);
-			shareinput_walker(f, (Node *) plan->lefttree, root);
+			plan->lefttree = save_righttree;
+			plan->righttree = save_lefttree;
 		}
 		else if (IsA(node, MergeJoin))
 		{
@@ -1932,34 +1904,24 @@ shareinput_walker(SHAREINPUT_MUTATOR f, Node *node, PlannerInfo *root)
 
 			if (mj->unique_outer)
 			{
-				shareinput_walker(f, (Node *) plan->lefttree, root);
-				shareinput_walker(f, (Node *) plan->righttree, root);
-			}
-			else
-			{
-				shareinput_walker(f, (Node *) plan->righttree, root);
-				shareinput_walker(f, (Node *) plan->lefttree, root);
+				plan->lefttree = save_righttree;
+				plan->righttree = save_lefttree;
 			}
 		}
-		else if (IsA(node, Sequence))
-		{
-			ListCell   *cell = NULL;
-			Sequence   *sequence = (Sequence *) node;
 
-			foreach(cell, sequence->subplans)
-			{
-				shareinput_walker(f, (Node *) lfirst(cell), root);
-			}
-		}
-		else
-		{
-			shareinput_walker(f, (Node *) plan->lefttree, root);
-			shareinput_walker(f, (Node *) plan->righttree, root);
-			shareinput_walker(f, (Node *) plan->initPlan, root);
-		}
+		plan_tree_walker(node, shareinput_walker, ctx);
+
+		/* Restore all values which could be changed above */
+		ctx->base.node = (Node *) root;
+		glob->share.curr_rtable = save_rtable;
+		plan->lefttree = save_lefttree;
+		plan->righttree = save_righttree;
 	}
 
-	(*f) (node, root, true);
+	if (is_plan_node(node))
+		(*mutator) (node, root, true);
+
+	return false;
 }
 
 typedef struct
@@ -2177,9 +2139,13 @@ Plan *
 apply_shareinput_dag_to_tree(PlannerInfo *root, Plan *plan)
 {
 	PlannerGlobal *glob = root->glob;
+	ShareInputContext ctx;
+
+	ctx.base.node = (Node *) root;
+	ctx.mutator = shareinput_mutator_dag_to_tree;
 
 	glob->share.curr_rtable = root->parse->rtable;
-	shareinput_walker(shareinput_mutator_dag_to_tree, (Node *) plan, root);
+	shareinput_walker((Node *) plan, &ctx);
 	return plan;
 }
 
@@ -2220,9 +2186,13 @@ void
 collect_shareinput_producers(PlannerInfo *root, Plan *plan)
 {
 	PlannerGlobal *glob = root->glob;
+	ShareInputContext ctx;
+
+	ctx.base.node = (Node *) root;
+	ctx.mutator = collect_shareinput_producers_walker;
 
 	glob->share.curr_rtable = glob->finalrtable;
-	shareinput_walker(collect_shareinput_producers_walker, (Node *) plan, root);
+	shareinput_walker((Node *) plan, &ctx);
 }
 
 /* Some helper: implements a stack using List. */
@@ -2262,7 +2232,12 @@ shareinput_peekmot(ApplyShareInputContext *ctxt)
 Plan *
 replace_shareinput_targetlists(PlannerInfo *root, Plan *plan)
 {
-	shareinput_walker(replace_shareinput_targetlists_walker, (Node *) plan, root);
+	ShareInputContext ctx;
+
+	ctx.base.node = (Node *) root;
+	ctx.mutator = replace_shareinput_targetlists_walker;
+
+	shareinput_walker((Node *) plan, &ctx);
 	return plan;
 }
 
@@ -2616,7 +2591,7 @@ apply_shareinput_xslice(Plan *plan, PlannerInfo *root)
 {
 	PlannerGlobal *glob = root->glob;
 	ApplyShareInputContext *ctxt = &glob->share;
-	ListCell   *lp, *lr;
+	ShareInputContext walker_ctxt;
 
 	ctxt->motStack = NULL;
 	ctxt->qdShares = NULL;
@@ -2626,6 +2601,8 @@ apply_shareinput_xslice(Plan *plan, PlannerInfo *root)
 	ctxt->sliceMarks = palloc0(ctxt->producer_count * sizeof(int));
 
 	shareinput_pushmot(ctxt, 0);
+
+	walker_ctxt.base.node = (Node *) root;
 
 	/*
 	 * Walk the tree.  See comment for each pass for what each pass will do.
@@ -2639,42 +2616,18 @@ apply_shareinput_xslice(Plan *plan, PlannerInfo *root)
 	 * walk through all plans and collect all producer subplans into the
 	 * context, before processing the consumers.
 	 */
-	forboth(lp, glob->subplans, lr, glob->subroots)
-	{
-		Plan	   *subplan = (Plan *) lfirst(lp);
-		PlannerInfo *subroot =  (PlannerInfo *) lfirst(lr);
-
-		shareinput_walker(shareinput_mutator_xslice_1, (Node *) subplan, subroot);
-	}
-	shareinput_walker(shareinput_mutator_xslice_1, (Node *) plan, root);
+	walker_ctxt.mutator = shareinput_mutator_xslice_1;
+	shareinput_walker((Node *) plan, &walker_ctxt);
 
 	/* Now walk the tree again, and process all the consumers. */
-	forboth(lp, glob->subplans, lr, glob->subroots)
-	{
-		Plan	   *subplan = (Plan *) lfirst(lp);
-		PlannerInfo *subroot =  (PlannerInfo *) lfirst(lr);
+	walker_ctxt.mutator = shareinput_mutator_xslice_2;
+	shareinput_walker((Node *) plan, &walker_ctxt);
 
-		shareinput_walker(shareinput_mutator_xslice_2, (Node *) subplan, subroot);
-	}
-	shareinput_walker(shareinput_mutator_xslice_2, (Node *) plan, root);
+	walker_ctxt.mutator = shareinput_mutator_xslice_3;
+	shareinput_walker((Node *) plan, &walker_ctxt);
 
-	forboth(lp, glob->subplans, lr, glob->subroots)
-	{
-		Plan	   *subplan = (Plan *) lfirst(lp);
-		PlannerInfo *subroot =  (PlannerInfo *) lfirst(lr);
-
-		shareinput_walker(shareinput_mutator_xslice_3, (Node *) subplan, subroot);
-	}
-	shareinput_walker(shareinput_mutator_xslice_3, (Node *) plan, root);
-
-	forboth(lp, glob->subplans, lr, glob->subroots)
-	{
-		Plan	   *subplan = (Plan *) lfirst(lp);
-		PlannerInfo *subroot =  (PlannerInfo *) lfirst(lr);
-
-		shareinput_walker(shareinput_mutator_xslice_4, (Node *) subplan, subroot);
-	}
-	shareinput_walker(shareinput_mutator_xslice_4, (Node *) plan, root);
+	walker_ctxt.mutator = shareinput_mutator_xslice_4;
+	shareinput_walker((Node *) plan, &walker_ctxt);
 
 	return plan;
 }
@@ -3001,6 +2954,10 @@ fixup_subplan_walker(Node *node, SubPlanWalkerContext *context)
 			PlannerInfo *root = (PlannerInfo *) context->base.node;
 			Plan	    *dupsubplan = (Plan *) copyObject(planner_subplan_get_plan(root, subplan));
 			int			 newplan_id = list_length(root->glob->subplans) + 1;
+			PlannerInfo *dupsubroot = makeNode(PlannerInfo);
+
+			memcpy(dupsubroot, planner_subplan_get_root(root, subplan), sizeof(PlannerInfo));
+			root->glob->subroots = lappend(root->glob->subroots, dupsubroot);
 
 			subplan->plan_id = newplan_id;
 			root->glob->subplans = lappend(root->glob->subplans, dupsubplan);

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -3174,6 +3174,7 @@ ExecutePlan(EState *estate,
 {
 	TupleTableSlot *slot;
 	long		current_tuple_count;
+	ListCell *lc;
 
 	/*
 	 * For holdable cursor, the plan is executed without rewinding on gpdb. We
@@ -3195,6 +3196,12 @@ ExecutePlan(EState *estate,
 	/*
 	 * Make sure slice dependencies are met
 	 */
+	foreach(lc, estate->es_subplanstates)
+	{
+		PlanState	   *splanstate = (PlanState *) lfirst(lc);
+
+		ExecSliceDependencyNode(splanstate);
+	}
 	ExecSliceDependencyNode(planstate);
 
 #ifdef FAULT_INJECTOR

--- a/src/backend/executor/nodeMaterial.c
+++ b/src/backend/executor/nodeMaterial.c
@@ -31,6 +31,7 @@
 #include "miscadmin.h"
 
 #include "cdb/cdbvars.h"
+#include "utils/faultinjector.h"
 
 static void ExecMaterialExplainEnd(PlanState *planstate, struct StringInfoData *buf);
 static void ExecChildRescan(MaterialState *node);
@@ -164,6 +165,7 @@ ExecMaterial(MaterialState *node)
 			{
 				if (ma->driver_slice == currentSliceId)
 				{
+					SIMPLE_FAULT_INJECTOR("material_pre_tuplestore_flush");
 					ntuplestore_flush(ts);
 					shareinput_writer_notifyready(node->share_lk_ctxt, ma->share_id,
 												  ma->nsharer_xslice, estate->es_plannedstmt->planGen);

--- a/src/backend/optimizer/plan/orca.c
+++ b/src/backend/optimizer/plan/orca.c
@@ -179,12 +179,6 @@ optimize_query(Query *parse, ParamListInfo boundParams)
 	 * that will be later used for readable column names in EXPLAIN, if
 	 * needed.
 	 */
-	foreach(lp, glob->subplans)
-	{
-		Plan	   *subplan = (Plan *) lfirst(lp);
-
-		collect_shareinput_producers(root, subplan);
-	}
 	collect_shareinput_producers(root, result->planTree);
 
 	/* Post-process ShareInputScan nodes */
@@ -194,12 +188,6 @@ optimize_query(Query *parse, ParamListInfo boundParams)
 	 * Fix ShareInputScans for EXPLAIN, like in standard_planner(). For all
 	 * subplans first, and then for the main plan tree.
 	 */
-	foreach(lp, glob->subplans)
-	{
-		Plan	   *subplan = (Plan *) lfirst(lp);
-
-		lfirst(lp) = replace_shareinput_targetlists(root, subplan);
-	}
 	result->planTree = replace_shareinput_targetlists(root, result->planTree);
 
 	/*

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -371,13 +371,6 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	 *
 	 * apply_shareinput will fix shared_id, and change the DAG to a tree.
 	 */
-	forboth(lp, glob->subplans, lr, glob->subroots)
-	{
-		Plan	   *subplan = (Plan *) lfirst(lp);
-		PlannerInfo	   *subroot = (PlannerInfo *) lfirst(lr);
-
-		lfirst(lp) = apply_shareinput_dag_to_tree(subroot, subplan);
-	}
 	top_plan = apply_shareinput_dag_to_tree(root, top_plan);
 
 	/* final cleanup of the plan */
@@ -435,12 +428,6 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	bms_free(subplan_context.bms_subplans);
 
 	/* fix ShareInputScans for EXPLAIN */
-	foreach(lp, glob->subplans)
-	{
-		Plan	   *subplan = (Plan *) lfirst(lp);
-
-		lfirst(lp) = replace_shareinput_targetlists(root, subplan);
-	}
 	top_plan = replace_shareinput_targetlists(root, top_plan);
 
 	/* build the PlannedStmt result */

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -11598,7 +11598,7 @@ EXPLAIN (COSTS OFF) WITH abc AS (SELECT onetimefilter1.a, onetimefilter1.b FROM 
                                                ->  Shared Scan (share slice:id 4:0)
                SubPlan 3  (slice6; segments: 3)
                  ->  Result
-                       Filter: (share0_ref3.b = onetimefilter1.b)
+                       Filter: (share0_ref4.b = onetimefilter1.b)
                        ->  Materialize
                              ->  Broadcast Motion 3:3  (slice5; segments: 3)
                                    ->  Result

--- a/src/test/regress/expected/shared_scan.out
+++ b/src/test/regress/expected/shared_scan.out
@@ -312,3 +312,136 @@ select gp_inject_fault('inject_many_fds_for_shareinputscan', 'reset', dbid) from
 (1 row)
 
 \! rm -rf /tmp/_gpdb_fault_inject_tmp_dir/
+-- To be able to pass this test, Shared Scan's Material node should be marked
+-- as cross-slice. Previously, we processed all subplans separately from main
+-- plan, which caused Material node not marked as cross-slice (upper main plan's
+-- slice1 motion was ignored in processing).
+-- No error like "ERROR:  cannot execute inactive Motion (nodeMotion.c:264)"
+-- should be shown.
+create table t1 (a int, b int, c int) distributed by (a);
+explain (costs off)
+with cte1 as (
+  select max(c) as c from t1
+), 
+cte2 as (
+  select d as c
+  from generate_series(
+    (select c from cte1) - 4,
+    (select c from cte1), 1) d
+)
+select l.c from cte2 l
+left join t1 u on l.c = u.c;
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Hash Right Join
+   Hash Cond: (u.c = d.d)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on t1 u
+   ->  Hash
+         ->  Function Scan on generate_series d
+               InitPlan 1 (returns $0)  (slice4)
+                 ->  Aggregate
+                       ->  Gather Motion 3:1  (slice2; segments: 3)
+                             ->  Aggregate
+                                   ->  Seq Scan on t1
+               InitPlan 2 (returns $1)  (slice5)
+                 ->  Aggregate
+                       ->  Gather Motion 3:1  (slice3; segments: 3)
+                             ->  Aggregate
+                                   ->  Seq Scan on t1 t1_1
+ Optimizer: Postgres query optimizer
+(17 rows)
+
+with cte1 as (
+  select max(c) as c from t1
+), 
+cte2 as (
+  select d as c
+  from generate_series(
+    (select c from cte1) - 4,
+    (select c from cte1), 1) d
+)
+select l.c from cte2 l
+left join t1 u on l.c = u.c;
+ c 
+---
+(0 rows)
+
+-- This case shows flacky count(*) result on pre-patched version. To make it
+-- stable wrong we use new fault point.
+-- Shared Scan consumer from slice1 not marked as cross-slice and not
+-- initialized tuple store. We got '1' as the result of the query - only
+-- Shared Scan from slice2 (the part below UNION) executed correctly.
+-- From now, cross-slice interaction detection fixed for subplans and we have
+-- stable '100' as a result.
+create table t2(i int, j int) distributed by (i);
+insert into t2 select i, i * 10 from generate_series(1, 10) i;
+select gp_inject_fault('material_pre_tuplestore_flush', 'reset', dbid)
+from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+select gp_inject_fault('material_pre_tuplestore_flush',
+       'sleep', '', '', '', 1, 1, 5, dbid)
+from gp_segment_configuration where role = 'p' and content = -1;       
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+set optimizer_parallel_union = on;
+explain (costs off)
+with cte1 as (
+  select max(j) as max_j from t2
+)
+select count(*) c
+from (
+  select s * 10 s
+  from generate_series(1, (select max_j from cte1)) s
+  union
+  select max_j from cte1
+) t;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Aggregate
+   ->  HashAggregate
+         Group Key: ((s.s * 10))
+         ->  Append
+               ->  Function Scan on generate_series s
+                     InitPlan 1 (returns $0)  (slice3)
+                       ->  Aggregate
+                             ->  Gather Motion 3:1  (slice1; segments: 3)
+                                   ->  Aggregate
+                                         ->  Seq Scan on t2 t2_1
+               ->  Aggregate
+                     ->  Gather Motion 3:1  (slice2; segments: 3)
+                           ->  Aggregate
+                                 ->  Seq Scan on t2
+ Optimizer: Postgres query optimizer
+(15 rows)
+
+with cte1 as (
+  select max(j) as max_j from t2
+)
+select count(*) c
+from (
+  select s * 10 s
+  from generate_series(1, (select max_j from cte1)) s
+  union
+  select max_j from cte1
+) t;
+  c  
+-----
+ 100
+(1 row)
+
+reset optimizer_parallel_union;
+select gp_inject_fault_infinite('material_pre_tuplestore_flush', 'reset', dbid)
+from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+

--- a/src/test/regress/expected/shared_scan_optimizer.out
+++ b/src/test/regress/expected/shared_scan_optimizer.out
@@ -325,3 +325,173 @@ select gp_inject_fault('inject_many_fds_for_shareinputscan', 'reset', dbid) from
 (1 row)
 
 \! rm -rf /tmp/_gpdb_fault_inject_tmp_dir/
+-- To be able to pass this test, Shared Scan's Material node should be marked
+-- as cross-slice. Previously, we processed all subplans separately from main
+-- plan, which caused Material node not marked as cross-slice (upper main plan's
+-- slice1 motion was ignored in processing).
+-- No error like "ERROR:  cannot execute inactive Motion (nodeMotion.c:264)"
+-- should be shown.
+create table t1 (a int, b int, c int) distributed by (a);
+explain (costs off)
+with cte1 as (
+  select max(c) as c from t1
+), 
+cte2 as (
+  select d as c
+  from generate_series(
+    (select c from cte1) - 4,
+    (select c from cte1), 1) d
+)
+select l.c from cte2 l
+left join t1 u on l.c = u.c;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Sequence
+   ->  Shared Scan (share slice:id 0:0)
+         ->  Materialize
+               ->  Aggregate
+                     ->  Gather Motion 3:1  (slice4; segments: 3)
+                           ->  Seq Scan on t1 t1_1
+   ->  Gather Motion 3:1  (slice3; segments: 3)
+         ->  Hash Left Join
+               Hash Cond: (generate_series.generate_series = t1.c)
+               ->  Redistribute Motion 1:3  (slice1)
+                     Hash Key: generate_series.generate_series
+                     ->  Function Scan on generate_series
+                           SubPlan 1  (slice1)
+                             ->  Result
+                                   ->  Result
+                                         ->  Nested Loop Left Join
+                                               Join Filter: true
+                                               ->  Nested Loop Left Join
+                                                     Join Filter: true
+                                                     ->  Result
+                                                     ->  Materialize
+                                                           ->  Shared Scan (share slice:id 1:0)
+                                               ->  Materialize
+                                                     ->  Shared Scan (share slice:id 1:0)
+                           SubPlan 2  (slice1)
+                             ->  Result
+                                   ->  Result
+                                         ->  Nested Loop Left Join
+                                               Join Filter: true
+                                               ->  Nested Loop Left Join
+                                                     Join Filter: true
+                                                     ->  Result
+                                                     ->  Materialize
+                                                           ->  Shared Scan (share slice:id 1:0)
+                                               ->  Materialize
+                                                     ->  Shared Scan (share slice:id 1:0)
+               ->  Hash
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: t1.c
+                           ->  Seq Scan on t1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(41 rows)
+
+with cte1 as (
+  select max(c) as c from t1
+), 
+cte2 as (
+  select d as c
+  from generate_series(
+    (select c from cte1) - 4,
+    (select c from cte1), 1) d
+)
+select l.c from cte2 l
+left join t1 u on l.c = u.c;
+ c 
+---
+(0 rows)
+
+-- This case shows flacky count(*) result on pre-patched version. To make it
+-- stable wrong we use new fault point.
+-- Shared Scan consumer from slice1 not marked as cross-slice and not
+-- initialized tuple store. We got '1' as the result of the query - only
+-- Shared Scan from slice2 (the part below UNION) executed correctly.
+-- From now, cross-slice interaction detection fixed for subplans and we have
+-- stable '100' as a result.
+create table t2(i int, j int) distributed by (i);
+insert into t2 select i, i * 10 from generate_series(1, 10) i;
+select gp_inject_fault('material_pre_tuplestore_flush', 'reset', dbid)
+from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+select gp_inject_fault('material_pre_tuplestore_flush',
+       'sleep', '', '', '', 1, 1, 5, dbid)
+from gp_segment_configuration where role = 'p' and content = -1;       
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+set optimizer_parallel_union = on;
+explain (costs off)
+with cte1 as (
+  select max(j) as max_j from t2
+)
+select count(*) c
+from (
+  select s * 10 s
+  from generate_series(1, (select max_j from cte1)) s
+  union
+  select max_j from cte1
+) t;
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Sequence
+   ->  Shared Scan (share slice:id 0:0)
+         ->  Materialize
+               ->  Aggregate
+                     ->  Gather Motion 3:1  (slice4; segments: 3)
+                           ->  Aggregate
+                                 ->  Seq Scan on t2
+   ->  Aggregate
+         ->  Gather Motion 3:1  (slice3; segments: 3)
+               ->  Aggregate
+                     ->  HashAggregate
+                           Group Key: ((generate_series.generate_series * 10))
+                           ->  Append
+                                 ->  Redistribute Motion 1:3  (slice1)
+                                       Hash Key: ((generate_series.generate_series * 10))
+                                       ->  Result
+                                             ->  Function Scan on generate_series
+                                                   SubPlan 1  (slice1)
+                                                     ->  Result
+                                                           ->  Nested Loop Left Join
+                                                                 Join Filter: true
+                                                                 ->  Result
+                                                                 ->  Materialize
+                                                                       ->  Shared Scan (share slice:id 1:0)
+                                 ->  Redistribute Motion 1:3  (slice2)
+                                       Hash Key: share0_ref3.max_j
+                                       ->  Shared Scan (share slice:id 2:0)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(28 rows)
+
+with cte1 as (
+  select max(j) as max_j from t2
+)
+select count(*) c
+from (
+  select s * 10 s
+  from generate_series(1, (select max_j from cte1)) s
+  union
+  select max_j from cte1
+) t;
+  c  
+-----
+ 100
+(1 row)
+
+reset optimizer_parallel_union;
+select gp_inject_fault_infinite('material_pre_tuplestore_flush', 'reset', dbid)
+from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+

--- a/src/test/regress/sql/shared_scan.sql
+++ b/src/test/regress/sql/shared_scan.sql
@@ -162,3 +162,79 @@ select case when ten < 5 then ten else ten * 2 end, count(distinct two), count(d
 select gp_inject_fault('inject_many_fds_for_shareinputscan', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
 
 \! rm -rf /tmp/_gpdb_fault_inject_tmp_dir/
+
+-- To be able to pass this test, Shared Scan's Material node should be marked
+-- as cross-slice. Previously, we processed all subplans separately from main
+-- plan, which caused Material node not marked as cross-slice (upper main plan's
+-- slice1 motion was ignored in processing).
+-- No error like "ERROR:  cannot execute inactive Motion (nodeMotion.c:264)"
+-- should be shown.
+create table t1 (a int, b int, c int) distributed by (a);
+explain (costs off)
+with cte1 as (
+  select max(c) as c from t1
+), 
+cte2 as (
+  select d as c
+  from generate_series(
+    (select c from cte1) - 4,
+    (select c from cte1), 1) d
+)
+select l.c from cte2 l
+left join t1 u on l.c = u.c;
+
+with cte1 as (
+  select max(c) as c from t1
+), 
+cte2 as (
+  select d as c
+  from generate_series(
+    (select c from cte1) - 4,
+    (select c from cte1), 1) d
+)
+select l.c from cte2 l
+left join t1 u on l.c = u.c;
+
+-- This case shows flacky count(*) result on pre-patched version. To make it
+-- stable wrong we use new fault point.
+-- Shared Scan consumer from slice1 not marked as cross-slice and not
+-- initialized tuple store. We got '1' as the result of the query - only
+-- Shared Scan from slice2 (the part below UNION) executed correctly.
+-- From now, cross-slice interaction detection fixed for subplans and we have
+-- stable '100' as a result.
+create table t2(i int, j int) distributed by (i);
+insert into t2 select i, i * 10 from generate_series(1, 10) i;
+
+select gp_inject_fault('material_pre_tuplestore_flush', 'reset', dbid)
+from gp_segment_configuration where role = 'p' and content = -1;
+select gp_inject_fault('material_pre_tuplestore_flush',
+       'sleep', '', '', '', 1, 1, 5, dbid)
+from gp_segment_configuration where role = 'p' and content = -1;       
+set optimizer_parallel_union = on;
+
+explain (costs off)
+with cte1 as (
+  select max(j) as max_j from t2
+)
+select count(*) c
+from (
+  select s * 10 s
+  from generate_series(1, (select max_j from cte1)) s
+  union
+  select max_j from cte1
+) t;
+
+with cte1 as (
+  select max(j) as max_j from t2
+)
+select count(*) c
+from (
+  select s * 10 s
+  from generate_series(1, (select max_j from cte1)) s
+  union
+  select max_j from cte1
+) t;
+
+reset optimizer_parallel_union;
+select gp_inject_fault_infinite('material_pre_tuplestore_flush', 'reset', dbid)
+from gp_segment_configuration where role = 'p' and content = -1;


### PR DESCRIPTION
Fix cross-slice interaction detection for subplans

GPDB has Shared Scan node to share the output of a subplan. Each Shared Scan
node can act like producer or consumer. Each one may be a part of different
slice. One of essential parts of Shared Scan processing is cross-slice
interaction detection. It helps to find the difference in producer's and
consumer's slices and mark underlying Material or Sort nodes as cross-slice.
Cross-slice producer reads all the tuples from child plan before the consumer
Shared Scan can read it.

Before this patch, cross-slice interaction detection of underlying subplan nodes
was broken. We walked through subplans separately from main plan. This, in case
subplan has no motion, caused shareinput_mutator_xslice_2() to think we don't
need to mark node as cross-slice - motion stack (motStack) used for
cross-slice interaction detection contained only default motion id (0) which
equals to producer's slice id.

Here is the simplified part of new regression test. It shows Shared Scan
consumer under Subplan, which has different (compared to producer upper) slice
id.

Sequence
 ->  Shared Scan (share slice:id 0:0)
   ->  Seq Scan on t1 t1_1
 ->  Gather Motion 3:1  (slice3; segments: 3)
   ->  Redistribute Motion 1:3  (slice1)
     ->  Function Scan on generate_series
       SubPlan 1  (slice1)
         ->  Shared Scan (share slice:id 1:0)
Before this patch, we didn't have upper motions in motStack. From now, we dive
into subplans as parts of main plan according to the plan tree hierarchy.
Cross-slice detector understands that our slice(1) is different from producer's
slice(0) and marks node as cross-slice.

Existing logic and comments around rtables left almost unchanged.
Existing tricky logic around joins execution order changed to another tricky
logic which is compatible with plan_tree_walker().
gporca_optimizer.out test output changed as we now start
shareinput_mutator_dag_to_tree() from the main plan. Before, we started from
subplans and global share input context contained only 3 producers at the time
set_plan_share_id() called. Now, at the same place producers count is equal to
4, so RangeTblEntry's name changed.

There was a bug when duplicate subplans were added without new corresponded
subroots. The old shareinput_walker() implementation not called for all
subplans, because forboth() loop stopped early. New shareinput_walker()
implementation not found appropriate subplan's subroot (and used main root as
default). From now, we fix old mistake and create new subroot for each new
subplan.

Author: Alexey Gordeev [lexa-first@ya.ru](mailto:lexa-first@ya.ru)
cherry-pick from https://github.com/open-gpdb/gpdb/commit/a39683f1b7474835b0656ef86b8b78fb43ddc339 https://github.com/open-gpdb/gpdb/pull/342 (https://github.com/GreengageDB/greengage)
