### PR TITLE
Don't use Orca to plan SELECTs with an empty range table

### DIFF
--- a/gpcontrib/pgaudit/expected/pgaudit.out
+++ b/gpcontrib/pgaudit/expected/pgaudit.out
@@ -795,10 +795,9 @@ NOTICE:  AUDIT: SESSION,31,2,READ,SELECT,,,explain select 1;,<none>
 NOTICE:  AUDIT: SESSION,31,3,MISC,EXPLAIN,,,explain select 1;,<none>
                 QUERY PLAN                
 ------------------------------------------
- Result  (cost=0.00..0.00 rows=1 width=4)
-   ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Optimizer: Pivotal Optimizer (GPORCA)
-(3 rows)
+ Result  (cost=0.00..0.01 rows=1 width=0)
+ Optimizer: Postgres query optimizer
+(2 rows)
 
 --
 -- Test that looks inside of do blocks log
@@ -880,12 +879,11 @@ BEGIN
 	EXECUTE 'DROP table ' || table_name;
 END $$;",<none>
 NOTICE:  AUDIT: SESSION,36,2,AST_SEL,SELECT,,,{QUERY...},<none>
-NOTICE:  AUDIT: SESSION,36,3,READ,SELECT,,,SELECT 'do_table',<none>
-NOTICE:  AUDIT: SESSION,36,4,AST_SEL,SELECT,,,{QUERY...},<none>
+NOTICE:  AUDIT: SESSION,36,3,AST_SEL,SELECT,,,{QUERY...},<none>
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'weird name' as the Greenplum Database data distribution key for this table.
-NOTICE:  AUDIT: SESSION,36,5,DDL,CREATE TABLE,TABLE,public.do_table,"CREATE TABLE do_table (""weird name"" INT)",<none>
-NOTICE:  AUDIT: SESSION,36,6,AST_SEL,SELECT,,,{QUERY...},<none>
-NOTICE:  AUDIT: SESSION,36,7,DDL,DROP TABLE,TABLE,public.do_table,DROP table do_table,<none>
+NOTICE:  AUDIT: SESSION,36,4,DDL,CREATE TABLE,TABLE,public.do_table,"CREATE TABLE do_table (""weird name"" INT)",<none>
+NOTICE:  AUDIT: SESSION,36,5,AST_SEL,SELECT,,,{QUERY...},<none>
+NOTICE:  AUDIT: SESSION,36,6,DDL,DROP TABLE,TABLE,public.do_table,DROP table do_table,<none>
 --
 -- Generate an error and make sure the stack gets cleared
 DO $$
@@ -1087,11 +1085,10 @@ NOTICE:  AUDIT: SESSION,60,1,AST_SEL,SELECT,,,{QUERY...}{f XXXX public.test {}},
 NOTICE:  AUDIT: SESSION,60,2,READ,SELECT,,,SELECT test();,<none>
 NOTICE:  AUDIT: SESSION,60,3,FUNCTION,EXECUTE,FUNCTION,public.test,SELECT test();,<none>
 NOTICE:  AUDIT: SESSION,60,4,AST_SEL,SELECT,,,{QUERY...},<none>
-NOTICE:  AUDIT: SESSION,60,5,READ,SELECT,,,SELECT 'cur1'::pg_catalog.refcursor,<none>
-NOTICE:  AUDIT: SESSION,60,6,AST_SEL,SELECT,,,"{QUERY...}{r XXXX public.hoge {id}}",<none>
-NOTICE:  AUDIT: SESSION,60,6,AST_SEL,SELECT,TABLE,public.hoge,"{QUERY...}{r XXXX public.hoge {id}}",<none>
-NOTICE:  AUDIT: SESSION,60,7,READ,SELECT,TABLE,public.hoge,select * from hoge,<none>
-NOTICE:  AUDIT: SESSION,60,8,AST_SEL,SELECT,,,{QUERY...},<none>
+NOTICE:  AUDIT: SESSION,60,5,AST_SEL,SELECT,,,"{QUERY...}{r XXXX public.hoge {id}}",<none>
+NOTICE:  AUDIT: SESSION,60,5,AST_SEL,SELECT,TABLE,public.hoge,"{QUERY...}{r XXXX public.hoge {id}}",<none>
+NOTICE:  AUDIT: SESSION,60,6,READ,SELECT,TABLE,public.hoge,select * from hoge,<none>
+NOTICE:  AUDIT: SESSION,60,7,AST_SEL,SELECT,,,{QUERY...},<none>
  test 
 ------
      
@@ -1232,10 +1229,9 @@ NOTICE:  AUDIT: SESSION,72,1,AST_SEL,SELECT,,,"{QUERY...}{f XXXX public.get_out_
 NOTICE:  AUDIT: SESSION,72,2,READ,SELECT,,,SELECT * FROM get_out_args(3);,<none>
 NOTICE:  AUDIT: SESSION,72,3,FUNCTION,EXECUTE,FUNCTION,public.get_out_args,SELECT * FROM get_out_args(3);,<none>
 NOTICE:  AUDIT: SESSION,72,4,AST_SEL,SELECT,,,{QUERY...},<none>
-NOTICE:  AUDIT: SESSION,72,5,READ,SELECT,,,SELECT 1,<none>
+NOTICE:  AUDIT: SESSION,72,5,AST_SEL,SELECT,,,{QUERY...},<none>
 NOTICE:  AUDIT: SESSION,72,6,AST_SEL,SELECT,,,{QUERY...},<none>
 NOTICE:  AUDIT: SESSION,72,7,AST_SEL,SELECT,,,{QUERY...},<none>
-NOTICE:  AUDIT: SESSION,72,8,AST_SEL,SELECT,,,{QUERY...},<none>
  col_o1 | col_o2 
 --------+--------
       2 |      3
@@ -1273,10 +1269,9 @@ NOTICE:  AUDIT: SESSION,74,1,AST_SEL,SELECT,,,"{QUERY...}{f XXXX public.get_tabl
 NOTICE:  AUDIT: SESSION,74,2,READ,SELECT,,,SELECT * FROM get_table(2);,<none>
 NOTICE:  AUDIT: SESSION,74,3,FUNCTION,EXECUTE,FUNCTION,public.get_table,SELECT * FROM get_table(2);,<none>
 NOTICE:  AUDIT: SESSION,74,4,AST_SEL,SELECT,,,{QUERY...},<none>
-NOTICE:  AUDIT: SESSION,74,5,READ,SELECT,,,SELECT 1,<none>
+NOTICE:  AUDIT: SESSION,74,5,AST_SEL,SELECT,,,{QUERY...},<none>
 NOTICE:  AUDIT: SESSION,74,6,AST_SEL,SELECT,,,{QUERY...},<none>
 NOTICE:  AUDIT: SESSION,74,7,AST_SEL,SELECT,,,{QUERY...},<none>
-NOTICE:  AUDIT: SESSION,74,8,AST_SEL,SELECT,,,{QUERY...},<none>
  col_t1 | col_t2 
 --------+--------
       2 |      3

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -157,6 +157,7 @@ static Plan *pushdown_preliminary_limit(Plan *plan, Node *limitCount, int64 coun
 
 static Plan *getAnySubplan(Plan *node);
 static bool isSimplyUpdatableQuery(Query *query);
+static bool isQueryForOrca(Query *parse);
 
 
 /*****************************************************************************
@@ -229,11 +230,15 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	 * For these reasons, restrict to using ORCA on the master QD processes only.
 	 *
 	 * PARALLEL RETRIEVE CURSOR is not supported by ORCA yet.
+	 *
+	 * isQueryForOrca() additionally lets us bypass ORCA for queries where it
+	 * has nothing to optimize, such as SELECTs with an empty range table.
 	 */
 	if (optimizer &&
 		GP_ROLE_DISPATCH == Gp_role &&
 		IS_QUERY_DISPATCHER() &&
-		(cursorOptions & CURSOR_OPT_PARALLEL_RETRIEVE) == 0)
+		(cursorOptions & CURSOR_OPT_PARALLEL_RETRIEVE) == 0 &&
+		isQueryForOrca(parse))
 	{
 		if (gp_log_optimization_time)
 			INSTR_TIME_SET_CURRENT(starttime);
@@ -5860,4 +5865,31 @@ isSimplyUpdatableQuery(Query *query)
 			return true;
 	}
 	return false;
+}
+
+/*
+ * isQueryForOrca
+ *		Should this query be handed to the ORCA optimizer at all?
+ *
+ * A SELECT with an empty range table - "SELECT 42" or
+ * "SELECT pg_column_size('...')" - has nothing to distribute across segments,
+ * so ORCA's plan is no better than the Postgres planner's.
+ * The optimization attempt is pure overhead, and we skip it.
+ *
+ * Sublinks and utility statements are excluded.  A sublink can hide a
+ * subquery over a distributed relation, and for CTAS the result row has to be
+ * distributed according to the target table's policy.
+ *
+ * Additional rules for bypassing ORCA can be added here.
+ */
+static bool
+isQueryForOrca(Query *parse)
+{
+	if (parse->commandType == CMD_SELECT &&
+		parse->rtable == NIL &&
+		!parse->hasSubLinks &&
+		parse->parentStmtType == PARENTSTMTTYPE_NONE)
+		return false;
+
+	return true;
 }

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -338,9 +338,6 @@ SELECT oldcnt(*) AS cnt_1000 FROM onek;
 (1 row)
 
 SELECT sum2(q1,q2) FROM int8_tbl;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Use optimizer_enable_query_parameter to enable Orca with query parameters
-CONTEXT:  SQL function "sum3" during startup
        sum2        
 -------------------
  18271560493827981
@@ -1041,9 +1038,6 @@ select array_agg(distinct a order by a desc nulls last)
 -- multi-arg aggs, strict/nonstrict, distinct/order by
 select aggfstr(a,b,c)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
-CONTEXT:  SQL function "aggf_trans" during startup
                 aggfstr                
 ---------------------------------------
  {"(1,3,foo)","(2,2,bar)","(3,1,baz)"}
@@ -1051,9 +1045,6 @@ CONTEXT:  SQL function "aggf_trans" during startup
 
 select aggfns(a,b,c)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
-CONTEXT:  SQL function "aggfns_trans" during startup
                     aggfns                     
 -----------------------------------------------
  {"(1,3,foo)","(0,,)","(2,2,bar)","(3,1,baz)"}
@@ -1062,9 +1053,6 @@ CONTEXT:  SQL function "aggfns_trans" during startup
 select aggfstr(distinct a,b,c)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,3) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
-CONTEXT:  SQL function "aggf_trans" during startup
                 aggfstr                
 ---------------------------------------
  {"(1,3,foo)","(2,2,bar)","(3,1,baz)"}
@@ -1073,9 +1061,6 @@ CONTEXT:  SQL function "aggf_trans" during startup
 select aggfns(distinct a,b,c)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,3) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
-CONTEXT:  SQL function "aggfns_trans" during startup
                     aggfns                     
 -----------------------------------------------
  {"(0,,)","(1,3,foo)","(2,2,bar)","(3,1,baz)"}
@@ -1084,9 +1069,6 @@ CONTEXT:  SQL function "aggfns_trans" during startup
 select aggfstr(distinct a,b,c order by b)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,3) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
-CONTEXT:  SQL function "aggf_trans" during startup
                 aggfstr                
 ---------------------------------------
  {"(3,1,baz)","(2,2,bar)","(1,3,foo)"}
@@ -1095,9 +1077,6 @@ CONTEXT:  SQL function "aggf_trans" during startup
 select aggfns(distinct a,b,c order by b)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,3) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
-CONTEXT:  SQL function "aggfns_trans" during startup
                     aggfns                     
 -----------------------------------------------
  {"(3,1,baz)","(2,2,bar)","(1,3,foo)","(0,,)"}
@@ -1107,9 +1086,6 @@ CONTEXT:  SQL function "aggfns_trans" during startup
 select aggfns(distinct a,a,c order by c using ~<~,a)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,2) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
-CONTEXT:  SQL function "aggfns_trans" during startup
                      aggfns                     
 ------------------------------------------------
  {"(2,2,bar)","(3,3,baz)","(1,1,foo)","(0,0,)"}
@@ -1118,9 +1094,6 @@ CONTEXT:  SQL function "aggfns_trans" during startup
 select aggfns(distinct a,a,c order by c using ~<~)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,2) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
-CONTEXT:  SQL function "aggfns_trans" during startup
                      aggfns                     
 ------------------------------------------------
  {"(2,2,bar)","(3,3,baz)","(1,1,foo)","(0,0,)"}
@@ -1129,9 +1102,6 @@ CONTEXT:  SQL function "aggfns_trans" during startup
 select aggfns(distinct a,a,c order by a)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,2) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
-CONTEXT:  SQL function "aggfns_trans" during startup
                      aggfns                     
 ------------------------------------------------
  {"(0,0,)","(1,1,foo)","(2,2,bar)","(3,3,baz)"}
@@ -1140,9 +1110,6 @@ CONTEXT:  SQL function "aggfns_trans" during startup
 select aggfns(distinct a,b,c order by a,c using ~<~,b)
   from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
        generate_series(1,2) i;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
-CONTEXT:  SQL function "aggfns_trans" during startup
                     aggfns                     
 -----------------------------------------------
  {"(0,,)","(1,3,foo)","(2,2,bar)","(3,1,baz)"}
@@ -1443,9 +1410,6 @@ select aggfns(distinct a,b,c order by a,c using ~<~,b) filter (where a > 1)
     generate_series(1,2) i;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Aggregate functions with FILTER
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
-CONTEXT:  SQL function "aggfns_trans" during startup
           aggfns           
 ---------------------------
  {"(2,2,bar)","(3,1,baz)"}
@@ -1875,9 +1839,6 @@ select aggfns(distinct a,b,c order by a,c using ~<~,b) filter (where a > 1)
     generate_series(1,2) i;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Aggregate functions with FILTER
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: ROW EXPRESSION
-CONTEXT:  SQL function "aggfns_trans" during startup
           aggfns           
 ---------------------------
  {"(2,2,bar)","(3,1,baz)"}

--- a/src/test/regress/expected/bfv_catalog_optimizer.out
+++ b/src/test/regress/expected/bfv_catalog_optimizer.out
@@ -257,22 +257,18 @@ reset optimizer_enable_indexscan;
 create table mpp_bfv_2(a int, b text, primary key (a)) distributed by (a);
 -- stop falling back to planner when catalog functions are encountered
 explain select pg_column_size('mpp_bfv_2');
-                   QUERY PLAN                   
-------------------------------------------------
- Result  (cost=0.00..0.00 rows=1 width=4)
-   ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.23.0
-(4 rows)
+                QUERY PLAN                
+------------------------------------------
+ Result  (cost=0.00..0.01 rows=1 width=0)
+ Optimizer: Postgres query optimizer
+(2 rows)
 
 explain select pg_lock_status();
-                   QUERY PLAN                   
-------------------------------------------------
- Result  (cost=0.00..0.00 rows=1 width=8)
-   ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.23.0
-(4 rows)
+                 QUERY PLAN                 
+--------------------------------------------
+ Result  (cost=0.00..5.01 rows=334 width=0)
+ Optimizer: Postgres query optimizer
+(2 rows)
 
 select pg_get_constraintdef(pg_constraint.oid) from pg_constraint, pg_class where conrelid=pg_class.oid and pg_class.relname='mpp_bfv_2';
  pg_get_constraintdef 

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -9184,9 +9184,6 @@ CREATE FUNCTION sum_sfunc(anyelement,anyelement) returns anyelement AS 'select $
 CREATE FUNCTION sum_combinefunc(anyelement,anyelement) returns anyelement AS 'select $1+$2' LANGUAGE SQL STRICT;
 CREATE AGGREGATE myagg1(anyelement) (SFUNC = sum_sfunc, COMBINEFUNC = sum_combinefunc, STYPE = anyelement, INITCOND = '0');
 SELECT myagg1(i) FROM orca.tab1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Use optimizer_enable_query_parameter to enable Orca with query parameters
-CONTEXT:  SQL function "sum_sfunc" during startup
  myagg1 
 --------
      55
@@ -9195,9 +9192,6 @@ CONTEXT:  SQL function "sum_sfunc" during startup
 CREATE FUNCTION sum_sfunc2(anyelement,anyelement,anyelement) returns anyelement AS 'select $1+$2+$3' LANGUAGE SQL STRICT;
 CREATE AGGREGATE myagg2(anyelement,anyelement) (SFUNC = sum_sfunc2, STYPE = anyelement, INITCOND = '0');
 SELECT myagg2(i,j) FROM orca.tab1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Use optimizer_enable_query_parameter to enable Orca with query parameters
-CONTEXT:  SQL function "sum_sfunc2" during startup
  myagg2 
 --------
      60
@@ -9218,12 +9212,6 @@ INSERT INTO array_table values(6,array[222],'c');
 INSERT INTO array_table values(7,array[3],'a');
 INSERT INTO array_table values(8,array[3],'b');
 SELECT f3, myagg3(f1) from (select * from array_table order by f1 limit 10) as foo GROUP BY f3 ORDER BY f3;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Use optimizer_enable_query_parameter to enable Orca with query parameters
-CONTEXT:  SQL function "gptfp" during startup
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Use optimizer_enable_query_parameter to enable Orca with query parameters
-CONTEXT:  SQL function "gpffp" during startup
  f3 | myagg3  
 ----+---------
  a  | {1,4,7}
@@ -11006,9 +10994,6 @@ CREATE TYPE rainbow AS ENUM('red','yellow','blue');
 CREATE FUNCTION func_enum_element(ANYENUM, ANYELEMENT) RETURNS TABLE(a ANYENUM, b ANYARRAY)
 AS $$ SELECT $1, ARRAY[$2] $$ LANGUAGE SQL STABLE;
 SELECT * FROM func_enum_element('red'::rainbow, 'blue'::rainbow::anyelement);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Use optimizer_enable_query_parameter to enable Orca with query parameters
-CONTEXT:  SQL function "func_enum_element" during startup
   a  |   b    
 -----+--------
  red | {blue}
@@ -11019,9 +11004,6 @@ DROP FUNCTION IF EXISTS func_enum_element(ANYENUM, ANYELEMENT);
 CREATE FUNCTION func_element_array(ANYELEMENT, ANYARRAY) RETURNS TABLE(a ANYELEMENT, b ANYENUM)
 AS $$ SELECT $1, $2[1]$$ LANGUAGE SQL STABLE;
 SELECT * FROM func_element_array('red'::rainbow, ARRAY['blue'::rainbow]);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Use optimizer_enable_query_parameter to enable Orca with query parameters
-CONTEXT:  SQL function "func_element_array" during startup
   a  |  b   
 -----+------
  red | blue
@@ -11032,9 +11014,6 @@ DROP FUNCTION IF EXISTS func_element_array(ANYELEMENT, ANYARRAY);
 CREATE FUNCTION func_element_array(ANYARRAY, ANYENUM) RETURNS TABLE(a ANYELEMENT, b ANYELEMENT)
 AS $$ SELECT $1[1], $2 $$ LANGUAGE SQL STABLE;
 SELECT * FROM func_element_array(ARRAY['blue'::rainbow], 'blue'::rainbow);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Use optimizer_enable_query_parameter to enable Orca with query parameters
-CONTEXT:  SQL function "func_element_array" during startup
   a   |  b   
 ------+------
  blue | blue
@@ -11045,9 +11024,6 @@ DROP FUNCTION IF EXISTS func_element_array(ANYARRAY, ANYENUM);
 CREATE FUNCTION func_array(ANYARRAY) RETURNS TABLE(a ANYELEMENT, b ANYENUM)
 AS $$ SELECT $1[1], $1[2] $$ LANGUAGE SQL STABLE;
 SELECT * FROM func_array(ARRAY['blue'::rainbow, 'yellow'::rainbow]);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Use optimizer_enable_query_parameter to enable Orca with query parameters
-CONTEXT:  SQL function "func_array" during startup
   a   |   b    
 ------+--------
  blue | yellow
@@ -11058,9 +11034,6 @@ DROP FUNCTION IF EXISTS func_array(ANYARRAY);
 CREATE FUNCTION func_element_variadic(ANYELEMENT, VARIADIC ANYARRAY) RETURNS TABLE(a ANYARRAY)
 AS $$ SELECT array_prepend($1, $2); $$ LANGUAGE SQL STABLE;
 SELECT * FROM func_element_variadic(1.1, 1.1, 2.2, 3.3);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Use optimizer_enable_query_parameter to enable Orca with query parameters
-CONTEXT:  SQL function "func_element_variadic" during startup
          a         
 -------------------
  {1.1,1.1,2.2,3.3}
@@ -11071,9 +11044,6 @@ DROP FUNCTION IF EXISTS func_element_variadic(ANYELEMENT, VARIADIC ANYARRAY);
 CREATE FUNCTION func_nonarray(ANYNONARRAY) RETURNS TABLE(a ANYNONARRAY)
 AS $$ SELECT $1; $$ LANGUAGE SQL STABLE;
 SELECT * FROM func_nonarray(5);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Use optimizer_enable_query_parameter to enable Orca with query parameters
-CONTEXT:  SQL function "func_nonarray" during startup
  a 
 ---
  5
@@ -11084,9 +11054,6 @@ DROP FUNCTION IF EXISTS func_nonarray(ANYNONARRAY);
 CREATE FUNCTION func_nonarray_enum(ANYNONARRAY, ANYENUM) RETURNS TABLE(a ANYARRAY)
 AS $$ SELECT ARRAY[$1, $2]; $$ LANGUAGE SQL STABLE;
 SELECT * FROM func_nonarray_enum('blue'::rainbow, 'red'::rainbow);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Use optimizer_enable_query_parameter to enable Orca with query parameters
-CONTEXT:  SQL function "func_nonarray_enum" during startup
      a      
 ------------
  {blue,red}
@@ -11097,9 +11064,6 @@ DROP FUNCTION IF EXISTS func_nonarray_enum(ANYNONARRAY, ANYENUM);
 CREATE FUNCTION func_array_nonarray_enum(ANYARRAY, ANYNONARRAY, ANYENUM) RETURNS TABLE(a ANYNONARRAY)
 AS $$ SELECT $1[1]; $$ LANGUAGE SQL STABLE;
 SELECT * FROM func_array_nonarray_enum(ARRAY['blue'::rainbow, 'red'::rainbow], 'red'::rainbow, 'yellow'::rainbow);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Use optimizer_enable_query_parameter to enable Orca with query parameters
-CONTEXT:  SQL function "func_array_nonarray_enum" during startup
   a   
 ------
  blue
@@ -11110,9 +11074,6 @@ DROP FUNCTION IF EXISTS func_array_nonarray_enum(ANYARRAY, ANYNONARRAY, ANYENUM)
 CREATE FUNCTION return_enum_as_array(ANYENUM, ANYELEMENT, ANYELEMENT) RETURNS TABLE (ae ANYENUM, aa ANYARRAY)
 AS $$ SELECT $1, array[$2, $3] $$ LANGUAGE SQL STABLE;
 SELECT * FROM return_enum_as_array('red'::rainbow, 'yellow'::rainbow, 'blue'::rainbow);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Use optimizer_enable_query_parameter to enable Orca with query parameters
-CONTEXT:  SQL function "return_enum_as_array" during startup
  ae  |      aa       
 -----+---------------
  red | {yellow,blue}

--- a/src/test/regress/expected/qp_subquery_optimizer.out
+++ b/src/test/regress/expected/qp_subquery_optimizer.out
@@ -706,9 +706,6 @@ select Tbl01.*,foo(Tbl01.a) as foo from Tbl01; -- showing foo values
 (4 rows)
 
 select Tbl01.* from Tbl01 where foo(Tbl01.a) not in (select a from Tbl03);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Use optimizer_enable_query_parameter to enable Orca with query parameters
-CONTEXT:  SQL function "foo" during startup
  a | b  | c  
 ---+----+----
    | 11 | 12

--- a/src/test/regress/output/qp_gist_indexes2_optimizer.source
+++ b/src/test/regress/output/qp_gist_indexes2_optimizer.source
@@ -413,8 +413,6 @@ DETAIL:  No plan has been computed for required properties
 
 SELECT count_index_scans('EXPLAIN SELECT owner, property FROM GistTable1 WHERE property IS NULL ORDER BY id;');
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
-INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  No plan has been computed for required properties
 CONTEXT:  SQL statement "EXPLAIN SELECT owner, property FROM GistTable1 WHERE property IS NULL ORDER BY id;"
 PL/Python function "count_index_scans"
@@ -459,8 +457,6 @@ DETAIL:  No plan has been computed for required properties
 (4 rows)
 
 SELECT count_index_scans('EXPLAIN SELECT id, property FROM GistTable1 WHERE property IS NULL ORDER BY id;');
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: SIRV functions
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  No plan has been computed for required properties
 CONTEXT:  SQL statement "EXPLAIN SELECT id, property FROM GistTable1 WHERE property IS NULL ORDER BY id;"


### PR DESCRIPTION
Skip Orca for a SELECT with an empty range table, no sublinks and no parent
utility statement.  This covers FROM-less SQL function bodies too. The rule also 
applies to the bodies of SQL functions.  That is why some Orca fallback messages 
disappear even for queries that do have a FROM clause: the message came from 
planning the function body, not the query execution itself.

For some of these queries - the ones with parameters or with SIRV functions - 
Orca does not produce a plan at all and falls back, so the attempt is wasted twice over.  
Skipping it makes such queries about 16x faster.

Co-Authored-By: andr-sokolov [sokolov.andrey.yurevich@gmail.com](mailto:sokolov.andrey.yurevich@gmail.com)