### PR TITLE
Set Yezzey test vacuum protection window to zero

### DIFF
--- a/yezzey_test/yproxy.conf
+++ b/yezzey_test/yproxy.conf
@@ -36,3 +36,4 @@ backup_storage:
 
 vacuum:
   check_backup: false
+  protection_window: 0s


### PR DESCRIPTION
Set config param `protection_window: 0s` to make the Yezzey test work correctly