### PR TITLE
Fix the figures reported by "Rows out" in EXPLAIN ANALYZE

### DIFF
--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -2020,59 +2020,76 @@ cdbexplain_showExecStats(struct PlanState *planstate, ExplainState *es)
 	 * Print "Rows out"
 	 */
 
-	if (gp_enable_explain_rows_out && es->analyze && ns->ninst > 0) {
-		double alltuples = 0;
-		double maxtuples = ns->insts[0].ntuples;
-		int maxseg = 0;
-		double mintuples = ns->insts[0].ntuples;
-		int minseg = 0;
+	if (gp_enable_explain_rows_out && es->analyze && ns->ninst > 0)
+	{
+		double		alltuples = 0;
+		double		maxtuples = 0;
+		int			maxseg = -1;
+		double		mintuples = 0;
+		int			minseg = -1;
+		int			workercount = 0;
 
 		for (i = 0; i < ns->ninst; i++)
 		{
 			CdbExplain_StatInst *nsi = &ns->insts[i];
+			double		rows;
 
-			alltuples += nsi->ntuples;
+			/*
+			 * The insts array is allocated with palloc0 and only the slots of
+			 * the segments that actually ran this node are filled in, so an
+			 * unset pstype means the segment did not participate.  Counting
+			 * such slots would report a bogus minimum of zero rows and drag
+			 * the average down.
+			 */
+			if (nsi->pstype == T_Invalid)
+				continue;
 
-			if (nsi->ntuples > maxtuples) {
-				maxtuples = nsi->ntuples;
+			/* Report rows per loop, like the row count on the node itself. */
+			rows = nsi->nloops > 0 ? nsi->ntuples / nsi->nloops : 0;
+
+			if (workercount == 0 || rows > maxtuples)
+			{
+				maxtuples = rows;
 				maxseg = ns->segindex0 + i;
 			}
 
-			if (nsi->ntuples < mintuples) {
-				mintuples = nsi->ntuples;
+			if (workercount == 0 || rows < mintuples)
+			{
+				mintuples = rows;
 				minseg = ns->segindex0 + i;
 			}
+
+			alltuples += rows;
+			workercount++;
 		}
 
-		double avgtuples = alltuples / ns->ninst;
-
-		if (es->format == EXPLAIN_FORMAT_TEXT)
+		if (workercount > 0)
 		{
-			/*
-			 * create a header for all stats: separate each individual stat by an
-			 * underscore, separate the grouped stats for each node by a slash
-			 */
-			appendStringInfoSpaces(es->str, es->indent * 2);
-			appendStringInfoString(es->str, "Rows out: ");
+			double		avgtuples = alltuples / workercount;
 
-			appendStringInfo(es->str,
-								 "%0.2f rows avg x %d workers, %0.f rows max (seg%d), %0.f rows min (seg%d).\n",
+			if (es->format == EXPLAIN_FORMAT_TEXT)
+			{
+				appendStringInfoSpaces(es->str, es->indent * 2);
+				appendStringInfoString(es->str, "Rows out: ");
+
+				appendStringInfo(es->str,
+								 "%.2f rows avg x %d workers, %.0f rows max (seg%d), %.0f rows min (seg%d).\n",
 								 avgtuples,
-								 ns->ninst,
+								 workercount,
 								 maxtuples,
 								 maxseg,
 								 mintuples,
 								 minseg);
-		}
-		else {
-			// ExplainOpenGroup("Rows Out", NULL, false, es);
-			ExplainPropertyInteger("Workers", ns->ninst, es);
-			ExplainPropertyFloat("Average Rows", avgtuples, 1, es);
-			ExplainPropertyFloat("Max Rows", maxtuples, 0, es);
-			ExplainPropertyInteger("Max Rows Segment", maxseg, es);
-			ExplainPropertyFloat("Min Rows", mintuples, 0, es);
-			ExplainPropertyInteger("Min Rows Segment", minseg, es);
-			// ExplainCloseGroup("Rows out", NULL, false, es);
+			}
+			else
+			{
+				ExplainPropertyInteger("Workers", workercount, es);
+				ExplainPropertyFloat("Average Rows", avgtuples, 2, es);
+				ExplainPropertyFloat("Max Rows", maxtuples, 0, es);
+				ExplainPropertyInteger("Max Rows Segment", maxseg, es);
+				ExplainPropertyFloat("Min Rows", mintuples, 0, es);
+				ExplainPropertyInteger("Min Rows Segment", minseg, es);
+			}
 		}
 	}
 

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -348,6 +348,58 @@ explain analyze SELECT * FROM explaintest;
  Total runtime: 2.600 ms
 (8 rows)
 
+-- The checks below depend on the shape of the plan, so use the Postgres
+-- planner to keep them independent of the optimizer in use.  They pick the
+-- "Rows out" lines out of the plan instead of printing it whole, so atmsort
+-- must be told not to treat the result as a plan of its own.
+set optimizer=off;
+-- Segments that did not run the node must not be counted.  Direct dispatch
+-- sends the scan to segments 0 and 2 only, so segment 1 must not show up as
+-- a worker that produced zero rows.
+-- explain_processing_off
+WITH query_plan (et) AS
+(
+  select get_explain_analyze_output($$
+    SELECT * FROM explaintest WHERE id in (2, 5);
+  $$)
+)
+SELECT trim(et) FROM query_plan WHERE et like '%Rows out:%';
+                                    btrim                                     
+------------------------------------------------------------------------------
+ Rows out: 2.00 rows avg x 1 workers, 2 rows max (seg-1), 2 rows min (seg-1).
+ Rows out: 1.00 rows avg x 2 workers, 1 rows max (seg0), 1 rows min (seg0).
+(2 rows)
+
+-- explain_processing_on
+-- The figures are reported per loop, so that they match the row count
+-- printed on the node itself.  The Materialize node below is rescanned once
+-- per outer row.
+set enable_hashjoin=off;
+set enable_mergejoin=off;
+CREATE TABLE explaintest_small (id int4) DISTRIBUTED BY (id);
+INSERT INTO explaintest_small SELECT generate_series(1, 3);
+-- explain_processing_off
+WITH query_plan (et) AS
+(
+  select get_explain_analyze_output($$
+    SELECT * FROM explaintest e, explaintest_small s WHERE e.id = s.id;
+  $$)
+)
+SELECT trim(et) FROM query_plan WHERE et like '%Rows out:%';
+                                    btrim                                     
+------------------------------------------------------------------------------
+ Rows out: 3.00 rows avg x 1 workers, 3 rows max (seg-1), 3 rows min (seg-1).
+ Rows out: 1.00 rows avg x 3 workers, 2 rows max (seg0), 0 rows min (seg2).
+ Rows out: 3.33 rows avg x 3 workers, 5 rows max (seg0), 1 rows min (seg1).
+ Rows out: 1.00 rows avg x 3 workers, 2 rows max (seg0), 0 rows min (seg2).
+ Rows out: 1.00 rows avg x 3 workers, 2 rows max (seg0), 0 rows min (seg2).
+(5 rows)
+
+-- explain_processing_on
+DROP TABLE explaintest_small;
+set enable_hashjoin=DEFAULT;
+set enable_mergejoin=DEFAULT;
+set optimizer=DEFAULT;
 set gp_enable_explain_rows_out=DEFAULT;
 -- Test explain node summary.
 set gp_enable_explain_node_summary=on;

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -379,6 +379,58 @@ explain analyze SELECT * FROM explaintest;
  Total runtime: 1.577 ms
 (8 rows)
 
+-- The checks below depend on the shape of the plan, so use the Postgres
+-- planner to keep them independent of the optimizer in use.  They pick the
+-- "Rows out" lines out of the plan instead of printing it whole, so atmsort
+-- must be told not to treat the result as a plan of its own.
+set optimizer=off;
+-- Segments that did not run the node must not be counted.  Direct dispatch
+-- sends the scan to segments 0 and 2 only, so segment 1 must not show up as
+-- a worker that produced zero rows.
+-- explain_processing_off
+WITH query_plan (et) AS
+(
+  select get_explain_analyze_output($$
+    SELECT * FROM explaintest WHERE id in (2, 5);
+  $$)
+)
+SELECT trim(et) FROM query_plan WHERE et like '%Rows out:%';
+                                    btrim                                     
+------------------------------------------------------------------------------
+ Rows out: 2.00 rows avg x 1 workers, 2 rows max (seg-1), 2 rows min (seg-1).
+ Rows out: 1.00 rows avg x 2 workers, 1 rows max (seg0), 1 rows min (seg0).
+(2 rows)
+
+-- explain_processing_on
+-- The figures are reported per loop, so that they match the row count
+-- printed on the node itself.  The Materialize node below is rescanned once
+-- per outer row.
+set enable_hashjoin=off;
+set enable_mergejoin=off;
+CREATE TABLE explaintest_small (id int4) DISTRIBUTED BY (id);
+INSERT INTO explaintest_small SELECT generate_series(1, 3);
+-- explain_processing_off
+WITH query_plan (et) AS
+(
+  select get_explain_analyze_output($$
+    SELECT * FROM explaintest e, explaintest_small s WHERE e.id = s.id;
+  $$)
+)
+SELECT trim(et) FROM query_plan WHERE et like '%Rows out:%';
+                                    btrim                                     
+------------------------------------------------------------------------------
+ Rows out: 3.00 rows avg x 1 workers, 3 rows max (seg-1), 3 rows min (seg-1).
+ Rows out: 1.00 rows avg x 3 workers, 2 rows max (seg0), 0 rows min (seg2).
+ Rows out: 3.33 rows avg x 3 workers, 5 rows max (seg0), 1 rows min (seg1).
+ Rows out: 1.00 rows avg x 3 workers, 2 rows max (seg0), 0 rows min (seg2).
+ Rows out: 1.00 rows avg x 3 workers, 2 rows max (seg0), 0 rows min (seg2).
+(5 rows)
+
+-- explain_processing_on
+DROP TABLE explaintest_small;
+set enable_hashjoin=DEFAULT;
+set enable_mergejoin=DEFAULT;
+set optimizer=DEFAULT;
 set gp_enable_explain_rows_out=DEFAULT;
 -- Test explain node summary.
 set gp_enable_explain_node_summary=on;

--- a/src/test/regress/sql/gp_explain.sql
+++ b/src/test/regress/sql/gp_explain.sql
@@ -159,6 +159,47 @@ set gp_enable_explain_allstat=DEFAULT;
 -- Test explain rows out.
 set gp_enable_explain_rows_out=on;
 explain analyze SELECT * FROM explaintest;
+
+-- The checks below depend on the shape of the plan, so use the Postgres
+-- planner to keep them independent of the optimizer in use.  They pick the
+-- "Rows out" lines out of the plan instead of printing it whole, so atmsort
+-- must be told not to treat the result as a plan of its own.
+set optimizer=off;
+
+-- Segments that did not run the node must not be counted.  Direct dispatch
+-- sends the scan to segments 0 and 2 only, so segment 1 must not show up as
+-- a worker that produced zero rows.
+-- explain_processing_off
+WITH query_plan (et) AS
+(
+  select get_explain_analyze_output($$
+    SELECT * FROM explaintest WHERE id in (2, 5);
+  $$)
+)
+SELECT trim(et) FROM query_plan WHERE et like '%Rows out:%';
+-- explain_processing_on
+
+-- The figures are reported per loop, so that they match the row count
+-- printed on the node itself.  The Materialize node below is rescanned once
+-- per outer row.
+set enable_hashjoin=off;
+set enable_mergejoin=off;
+CREATE TABLE explaintest_small (id int4) DISTRIBUTED BY (id);
+INSERT INTO explaintest_small SELECT generate_series(1, 3);
+-- explain_processing_off
+WITH query_plan (et) AS
+(
+  select get_explain_analyze_output($$
+    SELECT * FROM explaintest e, explaintest_small s WHERE e.id = s.id;
+  $$)
+)
+SELECT trim(et) FROM query_plan WHERE et like '%Rows out:%';
+-- explain_processing_on
+DROP TABLE explaintest_small;
+set enable_hashjoin=DEFAULT;
+set enable_mergejoin=DEFAULT;
+
+set optimizer=DEFAULT;
 set gp_enable_explain_rows_out=DEFAULT;
 
 -- Test explain node summary.


### PR DESCRIPTION
Fix the figures reported by "Rows out" in EXPLAIN ANALYZE

Skip the segments that did not run the node instead of counting them as
workers producing zero rows, report rows per loop so that rescanned
nodes match their own row count, and take the segment numbers relative
to the slice rather than to the insts array.

Taken from GreengageDB/greengage#524, which fixed the feature while
backporting it from here.