### PR TITLE
Fix distribution by resjunk column

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -465,39 +465,38 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
 					 */
 					if (!targetPolicy)
 					{
-						int			i;
 						List	   *policykeys = NIL;
 						List	   *policyopclasses = NIL;
+						ListCell   *lc;
 
-						for (i = 0; i < list_length(plan->targetlist); i++)
+						foreach(lc, plan->targetlist)
 						{
-							TargetEntry *target =
-							get_tle_by_resno(plan->targetlist, i + 1);
+							TargetEntry *target = lfirst(lc);
 
-							if (target)
+							if (target->resjunk)
+								continue;
+
+							Oid			typeOid = exprType((Node *) target->expr);
+							Oid			opclass = InvalidOid;
+
+							/*
+							 * Check for a legacy hash operator class if
+							 * gp_use_legacy_hashops GUC is set. If
+							 * InvalidOid is returned or the GUC is not
+							 * set, we'll get the default operator class.
+							 */
+							if (gp_use_legacy_hashops)
+								opclass = get_legacy_cdbhash_opclass_for_base_type(typeOid);
+
+							if (!OidIsValid(opclass))
+								opclass = cdb_default_distribution_opclass_for_type(typeOid);
+
+
+							if (OidIsValid(opclass))
 							{
-								Oid			typeOid = exprType((Node *) target->expr);
-								Oid			opclass = InvalidOid;
-
-								/*
-								 * Check for a legacy hash operator class if
-								 * gp_use_legacy_hashops GUC is set. If
-								 * InvalidOid is returned or the GUC is not
-								 * set, we'll get the default operator class.
-								 */
-								if (gp_use_legacy_hashops)
-									opclass = get_legacy_cdbhash_opclass_for_base_type(typeOid);
-
-								if (!OidIsValid(opclass))
-									opclass = cdb_default_distribution_opclass_for_type(typeOid);
-
-
-								if (OidIsValid(opclass))
-								{
-									policykeys = lappend_int(policykeys, i + 1);
-									policyopclasses = lappend_oid(policyopclasses, opclass);
-									break;
-								}
+								policykeys = lappend_int(policykeys, target->resno);
+								policyopclasses = lappend_oid(policyopclasses, opclass);
+								break;
 							}
 						}
 						targetPolicy = createHashPartitionedPolicy(policykeys,

--- a/src/test/regress/expected/gp_create_table.out
+++ b/src/test/regress/expected/gp_create_table.out
@@ -46,6 +46,25 @@ select distkey, distclass from gp_distribution_policy where localoid = 'distpol'
 (1 row)
 
 drop table distpol;
+-- Make sure that we don't end up distributing by resjunk when
+-- no explicit distribution key is present.
+create table resjunk_test as
+    with cte as (select point(1, 2) as a, random() as b)
+    select a from cte order by b;
+select policytype, distkey, distclass from
+    gp_distribution_policy where localoid = 'resjunk_test'::regclass;
+ policytype | distkey | distclass 
+------------+---------+-----------
+ p          |         | 
+(1 row)
+
+select * from resjunk_test;
+   a   
+-------
+ (1,2)
+(1 row)
+
+drop table resjunk_test;
 -- if the datatype of the index column is not hashable, can't update distribution
 -- key to it.
 create table distpol_ts (i int4, t tsvector) distributed by (i);

--- a/src/test/regress/sql/gp_create_table.sql
+++ b/src/test/regress/sql/gp_create_table.sql
@@ -32,6 +32,19 @@ create table distpol as select random(), 2 as foo distributed by (foo);
 select distkey, distclass from gp_distribution_policy where localoid = 'distpol'::regclass;
 drop table distpol;
 
+-- Make sure that we don't end up distributing by resjunk when
+-- no explicit distribution key is present.
+-- start_ignore
+drop table if exists resjunk_test;
+-- end_ignore
+create table resjunk_test as
+    with cte as (select point(1, 2) as a, random() as b)
+    select a from cte order by b;
+select policytype, distkey, distclass from
+    gp_distribution_policy where localoid = 'resjunk_test'::regclass;
+select * from resjunk_test;
+drop table resjunk_test;
+
 -- if the datatype of the index column is not hashable, can't update distribution
 -- key to it.
 create table distpol_ts (i int4, t tsvector) distributed by (i);


### PR DESCRIPTION
Fix distribution by resjunk column

In the PostgreSQL planner, some queries require auxiliary resjunk columns in
the targetlist.

These columns are necessary for query execution but do not appear in the
resulting relation.

Our logic for CTAS expressions, however, did not account this case.
If a query didn't contain an explicit DISTRIBUTED BY clause,
and other columns in the targetlist were not hashable,
the planner could use resjunk column in the distribution policy,
resulting in a segmentation fault.

To fix this issue, simply filter out resjunk columns.

Also, make attribute selection more efficient, as the targetlist
was re-examined for each entry.

Cherry-pick from GreengageDB/greengage#318
