### PR TITLE
explicitly discard write syscall result in syslogger

### DIFF
--- a/src/backend/access/bitmap/bitmapinsert.c
+++ b/src/backend/access/bitmap/bitmapinsert.c
@@ -2157,7 +2157,7 @@ insertsetbit(Relation rel, BlockNumber lovBlock, OffsetNumber lovOffset,
 				buf->num_cwords * sizeof(BM_HRL_WORD));
 	}
 	MemSet(buf->hwords, 0,
-		   BM_CALC_H_WORDS(buf->num_cwords) * sizeof(BM_HRL_WORD));
+		   BM_NUM_OF_HEADER_WORDS * sizeof(BM_HRL_WORD));
 	if (buf->last_tids)
 		MemSet(buf->last_tids, 0,
 				buf->num_cwords * sizeof(uint64));

--- a/src/backend/postmaster/syslogger.c
+++ b/src/backend/postmaster/syslogger.c
@@ -140,7 +140,10 @@ syslogger_write_to_logfile(bool amsyslogger, const char *data, int len)
 	if (amsyslogger)
 		write_syslogger_file_binary(data, len, LOG_DESTINATION_STDERR);
 	else
-		write(fileno(stderr), data, len);
+	{
+		ssize_t		write_rc pg_attribute_unused();
+		write_rc = write(fileno(stderr), data, len);
+	}
 }
 
 static bool chunk_is_postgres_chunk(PipeProtoHeader *hdr)
@@ -1246,6 +1249,8 @@ syslogger_parseArgs(int argc, char *argv[])
 void
 syslogger_append_timestamp(pg_time_t stamp_time, bool amsyslogger, bool append_comma)
 {
+	ssize_t		write_rc pg_attribute_unused();
+
     if(stamp_time != 0)
     {
         char strbuf[128];
@@ -1261,7 +1266,7 @@ syslogger_append_timestamp(pg_time_t stamp_time, bool amsyslogger, bool append_c
 		if (amsyslogger)
 			write_syslogger_file_binary(strbuf, strlen(strbuf), LOG_DESTINATION_STDERR);
 		else
-			write(fileno(stderr), strbuf, strlen(strbuf));
+			write_rc = write(fileno(stderr), strbuf, strlen(strbuf));
     }
 
     if (append_comma)
@@ -1269,7 +1274,7 @@ syslogger_append_timestamp(pg_time_t stamp_time, bool amsyslogger, bool append_c
 		if (amsyslogger)
 			write_syslogger_file_binary(",", 1, LOG_DESTINATION_STDERR);
 		else
-			write(fileno(stderr), ",", 1);
+			write_rc = write(fileno(stderr), ",", 1);
 	}
 }
 
@@ -1286,6 +1291,7 @@ syslogger_append_timestamp(pg_time_t stamp_time, bool amsyslogger, bool append_c
 void
 syslogger_append_current_timestamp(bool amsyslogger)
 {
+	ssize_t		write_rc pg_attribute_unused();
     struct timeval tv;
     pg_time_t	stamp_time;
     char strbuf[128];
@@ -1315,8 +1321,8 @@ syslogger_append_current_timestamp(bool amsyslogger)
 	}
 	else
 	{
-		write(fileno(stderr), strbuf, strlen(strbuf));
-		write(fileno(stderr), ",", 1);
+		write_rc = write(fileno(stderr), strbuf, strlen(strbuf));
+		write_rc = write(fileno(stderr), ",", 1);
 	}
 }
 
@@ -1462,6 +1468,7 @@ syslogger_write_str_from_chunk(CSVChunkStr *chunkstr, bool csv,
 void
 syslogger_write_int32(bool test0, const char *prefix, int32 i, bool amsyslogger, bool append_comma)
 {
+	ssize_t		write_rc pg_attribute_unused();
     char buf[1024];
     int len;
 
@@ -1471,14 +1478,14 @@ syslogger_write_int32(bool test0, const char *prefix, int32 i, bool amsyslogger,
 		if (amsyslogger)
 			write_syslogger_file_binary(buf, len, LOG_DESTINATION_STDERR);
 		else
-			write(fileno(stderr), buf, len);
+			write_rc = write(fileno(stderr), buf, len);
     }
     if (append_comma)
 	{
 		if (amsyslogger)
 			write_syslogger_file_binary(",", 1, LOG_DESTINATION_STDERR);
 		else
-			write(fileno(stderr), ",", 1);
+			write_rc = write(fileno(stderr), ",", 1);
 	}
 }
 

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -3751,6 +3751,7 @@ append_stacktrace(PipeProtoChunk *buffer, StringInfo append, void *const *stacka
 	char symbol[SYMBOL_SIZE]; /* a reasonable size for a symbol */
 	Dl_info dli;
 	int symbol_len;
+	ssize_t		write_rc pg_attribute_unused();
 
 
 	FILE * fd;
@@ -3940,7 +3941,7 @@ append_stacktrace(PipeProtoChunk *buffer, StringInfo append, void *const *stacka
 				if (amsyslogger)
 					write_syslogger_file_binary(symbol, symbol_len, LOG_DESTINATION_STDERR);
 				else
-					write(fileno(stderr), symbol, symbol_len);
+					write_rc = write(fileno(stderr), symbol, symbol_len);
 			}
 		}
 	}
@@ -3953,6 +3954,8 @@ append_stacktrace(PipeProtoChunk *buffer, StringInfo append, void *const *stacka
 static inline void
 write_syslogger_file_string(const char *str, bool amsyslogger, bool append_comma)
 {
+	ssize_t		write_rc pg_attribute_unused();
+
 	if (str != NULL && str[0] != '\0')
 	{
 		if (amsyslogger)
@@ -3963,9 +3966,9 @@ write_syslogger_file_string(const char *str, bool amsyslogger, bool append_comma
 		}
 		else
 		{
-			write(fileno(stderr), "\"", 1);
+			write_rc = write(fileno(stderr), "\"", 1);
 			syslogger_write_str(str, strlen(str), false, true);
-			write(fileno(stderr), "\"", 1);
+			write_rc = write(fileno(stderr), "\"", 1);
 		}
 	}
 
@@ -3974,7 +3977,7 @@ write_syslogger_file_string(const char *str, bool amsyslogger, bool append_comma
 		if (amsyslogger)
 			write_syslogger_file_binary(",", 1, LOG_DESTINATION_STDERR);
 		else
-			write(fileno(stderr), ",", 1);
+			write_rc = write(fileno(stderr), ",", 1);
 	}
 }
 
@@ -3985,6 +3988,8 @@ write_syslogger_file_string(const char *str, bool amsyslogger, bool append_comma
 static void
 write_syslogger_in_csv(ErrorData *edata, bool amsyslogger)
 {
+	ssize_t		write_rc pg_attribute_unused();
+
 	/* timestamp_with_millisecond */
 	syslogger_append_current_timestamp(amsyslogger);
 
@@ -4102,7 +4107,7 @@ write_syslogger_in_csv(ErrorData *edata, bool amsyslogger)
 	if (amsyslogger)
 		write_syslogger_file_binary(LOG_EOL, strlen(LOG_EOL), LOG_DESTINATION_STDERR);
 	else
-		write(fileno(stderr), LOG_EOL, strlen(LOG_EOL));
+		write_rc = write(fileno(stderr), LOG_EOL, strlen(LOG_EOL));
 }
 
 /*
@@ -4603,6 +4608,7 @@ write_pipe_chunks(char *data, int len, int dest)
 {
 	PipeProtoChunk p;
 	int			fd = fileno(stderr);
+	ssize_t		write_rc pg_attribute_unused();
 
 	Assert(len > 0);
 
@@ -4627,7 +4633,7 @@ write_pipe_chunks(char *data, int len, int dest)
 				Assert(p.hdr.pid != 0);
 				Assert(p.hdr.thid != 0);
 #endif
-		write(fd, &p, PIPE_CHUNK_SIZE);
+		write_rc = write(fd, &p, PIPE_CHUNK_SIZE);
 		data += PIPE_MAX_PAYLOAD;
 		len -= PIPE_MAX_PAYLOAD;
 
@@ -4645,7 +4651,7 @@ write_pipe_chunks(char *data, int len, int dest)
 		Assert(PIPE_HEADER_SIZE + len <= PIPE_CHUNK_SIZE);
 #endif
 	memcpy(p.data, data, len);
-	write(fd, &p, PIPE_HEADER_SIZE + len);
+	write_rc = write(fd, &p, PIPE_HEADER_SIZE + len);
 }
 
 


### PR DESCRIPTION
fixes
```
elog.c: In function ‘write_syslogger_in_csv’:
elog.c:4105:17: warning: ignoring return value of ‘write’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
 4105 |                 write(fileno(stderr), LOG_EOL, strlen(LOG_EOL));
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
elog.c: In function ‘write_syslogger_file_string’:
elog.c:3966:25: warning: ignoring return value of ‘write’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
 3966 |                         write(fileno(stderr), "\"", 1);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
elog.c:3968:25: warning: ignoring return value of ‘write’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
 3968 |                         write(fileno(stderr), "\"", 1);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
elog.c:3977:25: warning: ignoring return value of ‘write’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
 3977 |                         write(fileno(stderr), ",", 1);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
elog.c: In function ‘append_stacktrace’:
elog.c:3943:41: warning: ignoring return value of ‘write’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
 3943 |                                         write(fileno(stderr), symbol, symbol_len);
      |                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
elog.c: In function ‘write_pipe_chunks’:

```
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
