### PR TITLE
FIx compile-time issues with try convert

### DIFF
--- a/src/backend/utils/mb/conv.c
+++ b/src/backend/utils/mb/conv.c
@@ -340,8 +340,8 @@ UtfToLocal(const unsigned char *utf, unsigned char *iso,
 	uint32		iutf;
 	uint32		cutf[2];
 	uint32		code;
-	pg_utf_to_local *p;
-	pg_utf_to_local_combined *cp;
+	const pg_utf_to_local *p;
+	const pg_utf_to_local_combined *cp;
 	int			l;
 
 	for (; len > 0; len -= l)
@@ -510,8 +510,8 @@ LocalToUtf(const unsigned char *iso, unsigned char *utf,
 {
 	unsigned int iiso;
 	int			l;
-	pg_local_to_utf *p;
-	pg_local_to_utf_combined *cp;
+	const pg_local_to_utf *p;
+	const pg_local_to_utf_combined *cp;
 
 	if (!PG_VALID_ENCODING(encoding))
 		ereport(ERROR,


### PR DESCRIPTION
conv.c: In function ‘UtfToLocal’:
conv.c:415:43: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  415 |                                         p = bsearch(&cutf[0], map, size1,
      |                                           ^
conv.c:452:28: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  452 |                         cp = bsearch(cutf, cmap, size2,
      |                            ^
conv.c:459:35: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  459 |                                 p = bsearch(&cutf[0], map, size1,
      |                                   ^
conv.c:466:35: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  466 |                                 p = bsearch(&cutf[1], map, size1,
      |                                   ^
conv.c:476:27: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  476 |                         p = bsearch(&iutf, map, size1,
      |                           ^
conv.c: In function ‘LocalToUtf’:
conv.c:565:19: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  565 |                 p = bsearch(&iiso, map, size1,
      |                   ^
conv.c:576:36: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  576 |                                 cp = bsearch(&iiso, cmap, size2,
      |                                    ^  поправь пожалуйста

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
