### PR TITLE
Disable decorrelation for count() with no grouping columns.

### DIFF
--- a/src/backend/gporca/libgpopt/src/xforms/CDecorrelator.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CDecorrelator.cpp
@@ -426,6 +426,17 @@ CDecorrelator::FProcessGbAgg(CMemoryPool *mp, CExpression *pexpr,
 		return false;
 	}
 
+	// fail if agg has no grouping columns and a count() aggregate
+	// this is a temporary fix for the "count bug".
+	if (0 == popAggOriginal->Pdrgpcr()->Size())
+	{
+		CColRef *pcrCount = NULL;
+		if (CUtils::FHasCountAgg((*pexpr)[1], &pcrCount))
+		{
+			return false;
+		}
+	}
+
 	// TODO: 12/20/2012 - ; check for strictness of agg function
 
 	// decorrelate relational child, allow only equality predicates, see below for the reason
@@ -456,17 +467,19 @@ CDecorrelator::FProcessGbAgg(CMemoryPool *mp, CExpression *pexpr,
 	//   with the original subquery and group by expression.
 	// - Given that all the rows (and only the rows) in the surviving groups satisfy the
 	//   correlation predicate(s), the aggregate functions will have the correct values.
+	// - Note: this doesn't work for count(*)/count(Any) without grouping columns since
+	//   adding a GROUP BY clause changes behavior when count is 0. See "count bug".
 	// Example:
 	//
 	//   select *
 	//   from foo
-	//   where foo.a in (select count(*) from bar where bar.b=foo.b)
+	//   where foo.a in (select sum(1) from bar where bar.b=foo.b)
 	//
 	// gets transformed into
 	//
 	//   select *
-	//   from foo semijoin (select bar.b, count(*) from bar group by bar.b) subq(b, cnt)
-	//        on foo.a = subq.cnt and foo.b = subq.b
+	//   from foo semijoin (select bar.b, sum(1) from bar group by bar.b) subq(b, s)
+	//        on foo.a = subq.s and foo.b = subq.b
 	//
 	pcrs->Intersection(pcrsOutput);
 	pexprTemp->Release();

--- a/src/backend/gporca/libgpopt/src/xforms/CSubqueryHandler.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CSubqueryHandler.cpp
@@ -752,8 +752,7 @@ CSubqueryHandler::FCreateOuterApplyForScalarSubquery(
 	*ppexprNewOuter = pexprPrj;
 
 	BOOL fGeneratedByQuantified = popSubquery->FGeneratedByQuantified();
-	if (fGeneratedByQuantified ||
-		(fHasCountAggMatchingColumn && 0 == pgbAgg->Pdrgpcr()->Size()))
+	if (fGeneratedByQuantified)
 	{
 		CMDAccessor *md_accessor = COptCtxt::PoctxtFromTLS()->Pmda();
 		const IMDTypeInt8 *pmdtypeint8 = md_accessor->PtMDType<IMDTypeInt8>();
@@ -764,27 +763,17 @@ CSubqueryHandler::FCreateOuterApplyForScalarSubquery(
 						CUtils::PexprScalarIdent(mp, pcrComputed),
 						CUtils::PexprScalarConstInt8(mp, 0 /*val*/));
 
-		if (fGeneratedByQuantified)
-		{
-			// we produce Null if count(*) value is -1,
-			// this case can only occur when transforming quantified subquery to
-			// count(*) subquery using CXformSimplifySubquery
-			pmdidInt8->AddRef();
-			*ppexprResidualScalar = GPOS_NEW(mp) CExpression(
-				mp, GPOS_NEW(mp) CScalarIf(mp, pmdidInt8),
-				CUtils::PexprScalarEqCmp(
-					mp, pcrComputed,
-					CUtils::PexprScalarConstInt8(mp, -1 /*value*/)),
-				CUtils::PexprScalarConstInt8(mp, 0 /*value*/, true /*is_null*/),
-				pexprCoalesce);
-		}
-		else
-		{
-			// count(*) value can either be NULL (if produced by a lower outer join), or some value >= 0,
-			// we return coalesce(count(*), 0) in this case
-
-			*ppexprResidualScalar = pexprCoalesce;
-		}
+		// we produce Null if count(*) value is -1,
+		// this case can only occur when transforming quantified subquery to
+		// count(*) subquery using CXformSimplifySubquery
+		pmdidInt8->AddRef();
+		*ppexprResidualScalar = GPOS_NEW(mp) CExpression(
+			mp, GPOS_NEW(mp) CScalarIf(mp, pmdidInt8),
+			CUtils::PexprScalarEqCmp(
+				mp, pcrComputed,
+				CUtils::PexprScalarConstInt8(mp, -1 /*value*/)),
+			CUtils::PexprScalarConstInt8(mp, 0 /*value*/, true /*is_null*/),
+			pexprCoalesce);
 
 		return fSuccess;
 	}

--- a/src/test/regress/expected/eagerfree_optimizer.out
+++ b/src/test/regress/expected/eagerfree_optimizer.out
@@ -18,47 +18,47 @@ set optimizer_segments = 3;
 select d, count(*) from smallt group by d;
      d      | count 
 ------------+-------
- 01-19-2011 |     5
- 01-16-2011 |     5
- 01-13-2011 |     5
- 01-10-2011 |     5
- 01-15-2011 |     5
- 01-11-2011 |     5
- 01-09-2011 |     5
- 01-17-2011 |     5
- 01-05-2011 |     5
- 01-12-2011 |     5
- 01-18-2011 |     5
- 01-06-2011 |     5
+ 01-07-2011 |     5
  01-08-2011 |     5
- 01-14-2011 |     5
- 01-20-2011 |     5
+ 01-13-2011 |     5
+ 01-15-2011 |     5
+ 01-17-2011 |     5
+ 01-18-2011 |     5
+ 01-01-2011 |     5
  01-02-2011 |     5
  01-03-2011 |     5
- 01-01-2011 |     5
- 01-07-2011 |     5
  01-04-2011 |     5
+ 01-05-2011 |     5
+ 01-09-2011 |     5
+ 01-11-2011 |     5
+ 01-06-2011 |     5
+ 01-10-2011 |     5
+ 01-12-2011 |     5
+ 01-14-2011 |     5
+ 01-16-2011 |     5
+ 01-19-2011 |     5
+ 01-20-2011 |     5
 (20 rows)
 
 explain analyze select d, count(*) from smallt group by d;
                                                                     QUERY PLAN                                                                    
 --------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=20 width=12) (actual time=1.785..1.787 rows=20 loops=1)
-   ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=1.513..1.522 rows=7 loops=1)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=20 width=12) (actual time=2.276..2.677 rows=20 loops=1)
+   ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=2.287..2.294 rows=7 loops=1)
          Group Key: d
-         ->  Sort  (cost=0.00..431.01 rows=34 width=4) (actual time=1.510..1.513 rows=35 loops=1)
+         ->  Sort  (cost=0.00..431.01 rows=34 width=4) (actual time=2.282..2.285 rows=35 loops=1)
                Sort Key: d
                Sort Method:  quicksort  Memory: 99kB
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.342..1.481 rows=35 loops=1)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=1.353..2.268 rows=35 loops=1)
                      Hash Key: d
-                     ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.002..0.004 rows=50 loops=1)
- Planning time: 17.216 ms
+                     ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.003..0.009 rows=50 loops=1)
+ Planning time: 9.957 ms
    (slice0)    Executor memory: 63K bytes.
    (slice1)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
    (slice2)    Executor memory: 64K bytes avg x 3 workers, 64K bytes max (seg0).  Work_mem: 33K bytes max.
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
- Execution time: 2.061 ms
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 3.350 ms
 (16 rows)
 
 set statement_mem=2560;
@@ -71,21 +71,23 @@ select count(*) from (select i, t, d, count(*) from bigt group by i, t, d) tmp;
 explain analyze select count(*) from (select i, t, d, count(*) from bigt group by i, t, d) tmp;
                                                              QUERY PLAN                                                              
 -------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..571.36 rows=1 width=8) (actual time=362.957..362.957 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..571.36 rows=1 width=8) (actual time=265.826..362.941 rows=3 loops=1)
-         ->  Aggregate  (cost=0.00..571.36 rows=1 width=8) (actual time=265.338..265.338 rows=1 loops=1)
-               ->  HashAggregate  (cost=0.00..571.36 rows=333580 width=1) (actual time=338.390..356.986 rows=44572 loops=1)
+ Aggregate  (cost=0.00..571.26 rows=1 width=8) (actual time=373.383..373.383 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..571.26 rows=1 width=8) (actual time=315.632..373.371 rows=3 loops=1)
+         ->  Aggregate  (cost=0.00..571.26 rows=1 width=8) (actual time=317.803..317.804 rows=1 loops=1)
+               ->  HashAggregate  (cost=0.00..571.26 rows=333334 width=1) (actual time=332.487..366.514 rows=44538 loops=1)
                      Group Key: i, t, d
-                     (seg0)   44435 groups total in 32 batches; 1 overflows; 44435 spill groups.
-                     (seg0)   Hash chain length 2.8 avg, 10 max, using 30315 of 32768 buckets; total 9 expansions.
-                     ->  Seq Scan on bigt  (cost=0.00..439.81 rows=333580 width=18) (actual time=0.026..49.692 rows=333530 loops=1)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)  * Executor memory: 3180K bytes avg x 3 workers, 3180K bytes max (seg0).  Work_mem: 2461K bytes max, 4866K bytes wanted.
+                     Extra Text: (seg0)   44473 groups total in 32 batches; 1 overflows; 44473 spill groups.
+ (seg0)   Hash chain length 2.8 avg, 10 max, using 30386 of 32768 buckets; total 9 expansions.
+ 
+                     ->  Seq Scan on bigt  (cost=0.00..439.80 rows=333334 width=18) (actual time=0.010..60.930 rows=334620 loops=1)
+ Planning time: 37.952 ms
+   (slice0)    Executor memory: 90K bytes.
+ * (slice1)    Executor memory: 3669K bytes avg x 3 workers, 3669K bytes max (seg0).  Work_mem: 2461K bytes max, 4865K bytes wanted.
  Memory used:  2560kB
- Memory wanted:  5265kB
- Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
- Total runtime: 363.922 ms
-(14 rows)
+ Memory wanted:  5264kB
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 376.850 ms
+(16 rows)
 
 set statement_mem=128000;
 -- DQA
@@ -100,19 +102,19 @@ select count(distinct d) from smallt;
 explain analyze select count(distinct d) from smallt;
                                                                     QUERY PLAN                                                                    
 --------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=1.637..1.637 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=1.631..1.633 rows=3 loops=1)
-         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=1.408..1.408 rows=1 loops=1)
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=1.396..1.402 rows=35 loops=1)
+ Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=5.313..5.313 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=5.137..5.309 rows=3 loops=1)
+         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=5.447..5.448 rows=1 loops=1)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=2.486..5.545 rows=35 loops=1)
                      Hash Key: d
-                     ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.002..0.006 rows=50 loops=1)
- Planning time: 19.307 ms
+                     ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.003..0.011 rows=50 loops=1)
+ Planning time: 20.289 ms
    (slice0)    Executor memory: 59K bytes.
    (slice1)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
    (slice2)    Executor memory: 64K bytes avg x 3 workers, 64K bytes max (seg0).  Work_mem: 33K bytes max.
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
- Execution time: 1.904 ms
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 9.731 ms
 (13 rows)
 
 set statement_mem=2560;
@@ -125,20 +127,20 @@ select count(distinct d) from bigt;
 explain analyze select count(distinct d) from bigt;
                                                                          QUERY PLAN                                                                         
 ------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..446.60 rows=1 width=8) (actual time=394.139..394.139 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..446.60 rows=1 width=8) (actual time=388.126..394.130 rows=3 loops=1)
-         ->  Aggregate  (cost=0.00..446.60 rows=1 width=8) (actual time=393.902..393.903 rows=1 loops=1)
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..446.45 rows=333334 width=4) (actual time=0.670..118.334 rows=334920 loops=1)
+ Aggregate  (cost=0.00..446.60 rows=1 width=8) (actual time=1003.482..1003.482 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..446.60 rows=1 width=8) (actual time=978.614..1003.471 rows=3 loops=1)
+         ->  Aggregate  (cost=0.00..446.60 rows=1 width=8) (actual time=977.200..977.200 rows=1 loops=1)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..446.45 rows=333334 width=4) (actual time=2.732..396.243 rows=334920 loops=1)
                      Hash Key: d
-                     ->  Seq Scan on bigt  (cost=0.00..439.80 rows=333334 width=4) (actual time=0.013..46.779 rows=334620 loops=1)
- Planning time: 27.350 ms
+                     ->  Seq Scan on bigt  (cost=0.00..439.80 rows=333334 width=4) (actual time=0.011..114.538 rows=334620 loops=1)
+ Planning time: 27.186 ms
    (slice0)    Executor memory: 59K bytes.
-   (slice1)    Executor memory: 68K bytes avg x 3 workers, 68K bytes max (seg0).
+   (slice1)    Executor memory: 58K bytes avg x 3 workers, 58K bytes max (seg0).
  * (slice2)    Executor memory: 2768K bytes avg x 3 workers, 2768K bytes max (seg0).  Work_mem: 2617K bytes max, 7876K bytes wanted.
  Memory used:  2560kB
  Memory wanted:  8275kB
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
- Execution time: 394.389 ms
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 1004.372 ms
 (14 rows)
 
 set statement_mem=128000;
@@ -155,26 +157,26 @@ select t1.*, t2.* from
 where t1.d = t2.d;
      d      | count |     d      | sum 
 ------------+-------+------------+-----
- 01-19-2011 |     5 | 01-19-2011 |  40
- 01-16-2011 |     5 | 01-16-2011 |  25
- 01-13-2011 |     5 | 01-13-2011 |  10
- 01-10-2011 |     5 | 01-10-2011 |  45
- 01-15-2011 |     5 | 01-15-2011 |  20
- 01-17-2011 |     5 | 01-17-2011 |  30
- 01-11-2011 |     5 | 01-11-2011 |   0
- 01-09-2011 |     5 | 01-09-2011 |  40
- 01-05-2011 |     5 | 01-05-2011 |  20
- 01-12-2011 |     5 | 01-12-2011 |   5
- 01-18-2011 |     5 | 01-18-2011 |  35
  01-06-2011 |     5 | 01-06-2011 |  25
- 01-08-2011 |     5 | 01-08-2011 |  35
+ 01-10-2011 |     5 | 01-10-2011 |  45
+ 01-12-2011 |     5 | 01-12-2011 |   5
  01-14-2011 |     5 | 01-14-2011 |  15
+ 01-16-2011 |     5 | 01-16-2011 |  25
+ 01-19-2011 |     5 | 01-19-2011 |  40
  01-20-2011 |     5 | 01-20-2011 |  45
+ 01-01-2011 |     5 | 01-01-2011 |   0
  01-02-2011 |     5 | 01-02-2011 |   5
  01-03-2011 |     5 | 01-03-2011 |  10
- 01-01-2011 |     5 | 01-01-2011 |   0
- 01-07-2011 |     5 | 01-07-2011 |  30
  01-04-2011 |     5 | 01-04-2011 |  15
+ 01-05-2011 |     5 | 01-05-2011 |  20
+ 01-09-2011 |     5 | 01-09-2011 |  40
+ 01-11-2011 |     5 | 01-11-2011 |   0
+ 01-07-2011 |     5 | 01-07-2011 |  30
+ 01-08-2011 |     5 | 01-08-2011 |  35
+ 01-13-2011 |     5 | 01-13-2011 |  10
+ 01-15-2011 |     5 | 01-15-2011 |  20
+ 01-17-2011 |     5 | 01-17-2011 |  30
+ 01-18-2011 |     5 | 01-18-2011 |  35
 (20 rows)
 
 explain analyze select t1.*, t2.* from
@@ -182,35 +184,35 @@ explain analyze select t1.*, t2.* from
 where t1.d = t2.d;
                                                                               QUERY PLAN                                                                               
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.02 rows=20 width=24) (actual time=1.873..1.922 rows=20 loops=1)
-   ->  Hash Join  (cost=0.00..862.02 rows=7 width=24) (actual time=1.498..1.631 rows=7 loops=1)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.02 rows=20 width=24) (actual time=1.998..5.143 rows=20 loops=1)
+   ->  Hash Join  (cost=0.00..862.02 rows=7 width=24) (actual time=2.523..2.647 rows=7 loops=1)
          Hash Cond: (smallt.d = smallt_1.d)
          Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 7 of 131072 buckets.Hash chain length 1.2 avg, 2 max, using 6 of 32 buckets; total 0 expansions.
  
-         ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.032..0.038 rows=7 loops=1)
+         ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.044..0.050 rows=7 loops=1)
                Group Key: smallt.d
-               ->  Sort  (cost=0.00..431.01 rows=34 width=4) (actual time=0.029..0.032 rows=35 loops=1)
+               ->  Sort  (cost=0.00..431.01 rows=34 width=4) (actual time=0.041..0.044 rows=35 loops=1)
                      Sort Key: smallt.d
                      Sort Method:  quicksort  Memory: 99kB
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.004..0.011 rows=35 loops=1)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.003..0.021 rows=35 loops=1)
                            Hash Key: smallt.d
-                           ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.003..0.018 rows=50 loops=1)
-         ->  Hash  (cost=431.01..431.01 rows=7 width=12) (actual time=1.402..1.402 rows=7 loops=1)
-               ->  HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=1.388..1.398 rows=7 loops=1)
+                           ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.002..0.009 rows=50 loops=1)
+         ->  Hash  (cost=431.01..431.01 rows=7 width=12) (actual time=2.432..2.432 rows=7 loops=1)
+               ->  HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=2.421..2.428 rows=7 loops=1)
                      Group Key: smallt_1.d
                      Extra Text: (seg1)   Hash chain length 1.2 avg, 2 max, using 6 of 32 buckets; total 0 expansions.
  
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=34 width=8) (actual time=0.245..1.337 rows=35 loops=1)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=34 width=8) (actual time=1.632..2.403 rows=35 loops=1)
                            Hash Key: smallt_1.d
-                           ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=8) (actual time=0.003..0.018 rows=50 loops=1)
- Planning time: 64.498 ms
+                           ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=8) (actual time=0.002..0.008 rows=50 loops=1)
+ Planning time: 20.573 ms
    (slice0)    Executor memory: 127K bytes.
    (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
    (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
    (slice3)    Executor memory: 1192K bytes avg x 3 workers, 1192K bytes max (seg0).  Work_mem: 33K bytes max.
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
- Execution time: 2.226 ms
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 6.132 ms
 (29 rows)
 
 set enable_nestloop=off;
@@ -226,16 +228,16 @@ select t1.*, t2.* from
 where t1.i = t2.i;
  i | count | i | sum 
 ---+-------+---+-----
- 1 |    10 | 1 |  10
- 3 |    10 | 3 |  30
  0 |    10 | 0 |   0
- 4 |    10 | 4 |  40
- 7 |    10 | 7 |  70
- 8 |    10 | 8 |  80
- 2 |    10 | 2 |  20
+ 1 |    10 | 1 |  10
  5 |    10 | 5 |  50
  6 |    10 | 6 |  60
  9 |    10 | 9 |  90
+ 2 |    10 | 2 |  20
+ 3 |    10 | 3 |  30
+ 4 |    10 | 4 |  40
+ 7 |    10 | 7 |  70
+ 8 |    10 | 8 |  80
 (10 rows)
 
 explain analyze select t1.*, t2.* from
@@ -243,29 +245,29 @@ explain analyze select t1.*, t2.* from
 where t1.i = t2.i;
                                                                 QUERY PLAN                                                                 
 -------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.01 rows=10 width=24) (actual time=0.501..0.740 rows=5 loops=2)
-   ->  Hash Join  (cost=0.00..862.01 rows=4 width=24) (actual time=0.166..0.460 rows=2 loops=2)
-         Hash Cond: smallt.i = smallt_1.i
-         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 4 of 131072 buckets.
- 
-         ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12) (actual time=0.041..0.055 rows=2 loops=2)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.01 rows=10 width=24) (actual time=0.722..0.728 rows=10 loops=1)
+   ->  Hash Join  (cost=0.00..862.01 rows=4 width=24) (actual time=0.111..0.220 rows=5 loops=1)
+         Hash Cond: (smallt.i = smallt_1.i)
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 5 of 131072 buckets.
+         ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12) (actual time=0.020..0.028 rows=5 loops=1)
                Group Key: smallt.i
-               ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.036..0.042 rows=20 loops=2)
+               ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.017..0.019 rows=50 loops=1)
                      Sort Key: smallt.i
                      Sort Method:  quicksort  Memory: 99kB
-                     ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.004..0.013 rows=20 loops=2)
-         ->  Hash  (cost=431.01..431.01 rows=4 width=12) (actual time=0.072..0.072 rows=2 loops=2)
-               ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12) (actual time=0.053..0.069 rows=2 loops=2)
+                     ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.001..0.007 rows=50 loops=1)
+         ->  Hash  (cost=431.01..431.01 rows=4 width=12) (actual time=0.043..0.043 rows=5 loops=1)
+               ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12) (actual time=0.031..0.040 rows=5 loops=1)
                      Group Key: smallt_1.i
-                     ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.048..0.053 rows=20 loops=2)
+                     ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.027..0.032 rows=50 loops=1)
                            Sort Key: smallt_1.i
                            Sort Method:  quicksort  Memory: 99kB
-                           ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=4) (actual time=0.012..0.022 rows=20 loops=2)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 1238K bytes avg x 3 workers, 1238K bytes max (seg0).  Work_mem: 33K bytes max.
+                           ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=4) (actual time=0.003..0.010 rows=50 loops=1)
+ Planning time: 8.575 ms
+   (slice0)    Executor memory: 123K bytes.
+   (slice1)    Executor memory: 1196K bytes avg x 3 workers, 1196K bytes max (seg0).  Work_mem: 33K bytes max.
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
- Total runtime: 2.471 ms
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 1.576 ms
 (23 rows)
 
 set enable_nestloop=off;
@@ -274,34 +276,34 @@ set enable_hashjoin=on;
 select d, count(*) from smallt group by d limit 5; --ignore
      d      | count 
 ------------+-------
- 01-19-2011 |     5
- 01-16-2011 |     5
+ 01-07-2011 |     5
+ 01-08-2011 |     5
  01-13-2011 |     5
- 01-10-2011 |     5
  01-15-2011 |     5
+ 01-17-2011 |     5
 (5 rows)
 
 explain analyze select d, count(*) from smallt group by d limit 5;
                                                                           QUERY PLAN                                                                          
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=0.00..431.01 rows=2 width=12) (actual time=1.700..1.702 rows=5 loops=1)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=5 width=12) (actual time=1.698..1.700 rows=5 loops=1)
-         ->  Limit  (cost=0.00..431.01 rows=2 width=12) (actual time=1.456..1.464 rows=5 loops=1)
-               ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=1.455..1.460 rows=5 loops=1)
+ Limit  (cost=0.00..431.01 rows=2 width=12) (actual time=1.434..1.436 rows=5 loops=1)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=5 width=12) (actual time=1.433..1.434 rows=5 loops=1)
+         ->  Limit  (cost=0.00..431.01 rows=2 width=12) (actual time=1.391..1.396 rows=5 loops=1)
+               ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=1.390..1.394 rows=5 loops=1)
                      Group Key: d
-                     ->  Sort  (cost=0.00..431.01 rows=34 width=4) (actual time=1.449..1.453 rows=26 loops=1)
+                     ->  Sort  (cost=0.00..431.01 rows=34 width=4) (actual time=1.386..1.387 rows=26 loops=1)
                            Sort Key: d
                            Sort Method:  quicksort  Memory: 99kB
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.413..1.428 rows=35 loops=1)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.462..1.060 rows=35 loops=1)
                                  Hash Key: d
-                                 ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.003..0.006 rows=50 loops=1)
- Planning time: 16.802 ms
+                                 ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.002..0.007 rows=50 loops=1)
+ Planning time: 9.721 ms
    (slice0)    Executor memory: 59K bytes.
    (slice1)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
    (slice2)    Executor memory: 64K bytes avg x 3 workers, 64K bytes max (seg0).  Work_mem: 33K bytes max.
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
- Execution time: 2.024 ms
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 2.268 ms
 (18 rows)
 
 -- HashJoin
@@ -1313,19 +1315,19 @@ select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i order by 1,2,3;
 explain analyze select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i;
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.09 rows=1000 width=15) (actual time=0.788..1.687 rows=500 loops=2)
-   ->  Hash Join  (cost=0.00..862.03 rows=334 width=15) (actual time=0.402..1.244 rows=200 loops=2)
-         Hash Cond: smallt.i = smallt_1.i
-         Extra Text: (seg0)   Hash chain length 10.0 avg, 10 max, using 4 of 524288 buckets.
- 
-         ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=15) (actual time=0.002..0.008 rows=20 loops=2)
-         ->  Hash  (cost=431.00..431.00 rows=34 width=4) (actual time=0.034..0.034 rows=20 loops=2)
-               ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=4) (actual time=0.019..0.023 rows=20 loops=2)
-   (slice0)    Executor memory: 322K bytes.
-   (slice1)    Executor memory: 4198K bytes avg x 3 workers, 4206K bytes max (seg0).  Work_mem: 1K bytes max.
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.09 rows=1000 width=15) (actual time=2.566..5.471 rows=1000 loops=1)
+   ->  Hash Join  (cost=0.00..862.03 rows=334 width=15) (actual time=0.341..0.910 rows=500 loops=1)
+         Hash Cond: (smallt.i = smallt_1.i)
+         Extra Text: (seg0)   Hash chain length 10.0 avg, 10 max, using 5 of 524288 buckets.
+         ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=15) (actual time=0.001..0.006 rows=50 loops=1)
+         ->  Hash  (cost=431.00..431.00 rows=34 width=4) (actual time=0.016..0.016 rows=50 loops=1)
+               ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=4) (actual time=0.004..0.007 rows=50 loops=1)
+ Planning time: 10.713 ms
+   (slice0)    Executor memory: 87K bytes.
+   (slice1)    Executor memory: 4182K bytes avg x 3 workers, 4188K bytes max (seg0).  Work_mem: 2K bytes max.
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
- Total runtime: 4.129 ms
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 5.721 ms
 (13 rows)
 
 -- Rescan on HashJoin
@@ -1390,23 +1392,21 @@ where i < (select count(*) from smallt where smallt.i = smallt2.i) order by 1,2,
 
 explain select smallt2.* from smallt2
 where i < (select count(*) from smallt where smallt.i = smallt2.i);
-                                            QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.02 rows=50 width=15)
-   ->  Result  (cost=0.00..862.01 rows=17 width=15)
-         Filter: smallt2.i < COALESCE((count()), 0::bigint)
-         ->  Result  (cost=0.00..862.01 rows=17 width=24)
-               ->  Hash Left Join  (cost=0.00..862.01 rows=17 width=23)
-                     Hash Cond: smallt2.i = smallt.i
-                     ->  Seq Scan on smallt2  (cost=0.00..431.00 rows=17 width=15)
-                     ->  Hash  (cost=431.01..431.01 rows=4 width=12)
-                           ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12)
-                                 Group Key: smallt.i
-                                 ->  Sort  (cost=0.00..431.00 rows=34 width=4)
-                                       Sort Key: smallt.i
-                                       ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
-(14 rows)
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324412.64 rows=50 width=15)
+   ->  Result  (cost=0.00..1324412.64 rows=17 width=15)
+         Filter: (smallt2.i < (SubPlan 1))
+         ->  Seq Scan on smallt2  (cost=0.00..1324412.62 rows=334 width=24)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Aggregate  (cost=0.00..431.34 rows=1 width=8)
+                 ->  Result  (cost=0.00..431.34 rows=10 width=1)
+                       Filter: (smallt.i = smallt2.i)
+                       ->  Materialize  (cost=0.00..431.01 rows=100 width=4)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.01 rows=100 width=4)
+                                   ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
 
 -- Sort in MergeJoin
 -- start_ignore
@@ -1417,106 +1417,6 @@ set enable_mergejoin=on;
 select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i and t1.i < 2;
  i |    t    |     d      
 ---+---------+------------
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 11 | 01-12-2011
- 1 | text 11 | 01-12-2011
- 1 | text 11 | 01-12-2011
- 1 | text 11 | 01-12-2011
- 1 | text 11 | 01-12-2011
- 1 | text 11 | 01-12-2011
- 1 | text 11 | 01-12-2011
- 1 | text 11 | 01-12-2011
- 1 | text 11 | 01-12-2011
- 1 | text 11 | 01-12-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 1  | 01-12-2011
- 1 | text 1  | 01-12-2011
- 1 | text 1  | 01-12-2011
- 1 | text 1  | 01-12-2011
- 1 | text 1  | 01-12-2011
- 1 | text 1  | 01-12-2011
- 1 | text 1  | 01-12-2011
- 1 | text 1  | 01-12-2011
- 1 | text 1  | 01-12-2011
- 1 | text 1  | 01-12-2011
- 1 | text 11 | 01-02-2011
- 1 | text 11 | 01-02-2011
- 1 | text 11 | 01-02-2011
- 1 | text 11 | 01-02-2011
- 1 | text 11 | 01-02-2011
- 1 | text 11 | 01-02-2011
- 1 | text 11 | 01-02-2011
- 1 | text 11 | 01-02-2011
- 1 | text 11 | 01-02-2011
- 1 | text 11 | 01-02-2011
- 1 | text 6  | 01-12-2011
- 1 | text 6  | 01-12-2011
- 1 | text 6  | 01-12-2011
- 1 | text 6  | 01-12-2011
- 1 | text 6  | 01-12-2011
- 1 | text 6  | 01-12-2011
- 1 | text 6  | 01-12-2011
- 1 | text 6  | 01-12-2011
- 1 | text 6  | 01-12-2011
- 1 | text 6  | 01-12-2011
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 11 | 01-12-2011
- 1 | text 11 | 01-12-2011
- 1 | text 11 | 01-12-2011
- 1 | text 11 | 01-12-2011
- 1 | text 11 | 01-12-2011
- 1 | text 11 | 01-12-2011
- 1 | text 11 | 01-12-2011
- 1 | text 11 | 01-12-2011
- 1 | text 11 | 01-12-2011
- 1 | text 11 | 01-12-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 1  | 01-12-2011
- 1 | text 1  | 01-12-2011
- 1 | text 1  | 01-12-2011
- 1 | text 1  | 01-12-2011
- 1 | text 1  | 01-12-2011
- 1 | text 1  | 01-12-2011
- 1 | text 1  | 01-12-2011
- 1 | text 1  | 01-12-2011
- 1 | text 1  | 01-12-2011
- 1 | text 1  | 01-12-2011
  0 | text 0  | 01-01-2011
  0 | text 0  | 01-01-2011
  0 | text 0  | 01-01-2011
@@ -1527,6 +1427,16 @@ select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i and t1.i < 2;
  0 | text 0  | 01-01-2011
  0 | text 0  | 01-01-2011
  0 | text 0  | 01-01-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
  0 | text 10 | 01-11-2011
  0 | text 10 | 01-11-2011
  0 | text 10 | 01-11-2011
@@ -1537,6 +1447,16 @@ select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i and t1.i < 2;
  0 | text 10 | 01-11-2011
  0 | text 10 | 01-11-2011
  0 | text 10 | 01-11-2011
+ 1 | text 11 | 01-12-2011
+ 1 | text 11 | 01-12-2011
+ 1 | text 11 | 01-12-2011
+ 1 | text 11 | 01-12-2011
+ 1 | text 11 | 01-12-2011
+ 1 | text 11 | 01-12-2011
+ 1 | text 11 | 01-12-2011
+ 1 | text 11 | 01-12-2011
+ 1 | text 11 | 01-12-2011
+ 1 | text 11 | 01-12-2011
  0 | text 5  | 01-01-2011
  0 | text 5  | 01-01-2011
  0 | text 5  | 01-01-2011
@@ -1547,6 +1467,16 @@ select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i and t1.i < 2;
  0 | text 5  | 01-01-2011
  0 | text 5  | 01-01-2011
  0 | text 5  | 01-01-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
  0 | text 0  | 01-11-2011
  0 | text 0  | 01-11-2011
  0 | text 0  | 01-11-2011
@@ -1557,6 +1487,16 @@ select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i and t1.i < 2;
  0 | text 0  | 01-11-2011
  0 | text 0  | 01-11-2011
  0 | text 0  | 01-11-2011
+ 1 | text 1  | 01-12-2011
+ 1 | text 1  | 01-12-2011
+ 1 | text 1  | 01-12-2011
+ 1 | text 1  | 01-12-2011
+ 1 | text 1  | 01-12-2011
+ 1 | text 1  | 01-12-2011
+ 1 | text 1  | 01-12-2011
+ 1 | text 1  | 01-12-2011
+ 1 | text 1  | 01-12-2011
+ 1 | text 1  | 01-12-2011
  0 | text 10 | 01-01-2011
  0 | text 10 | 01-01-2011
  0 | text 10 | 01-01-2011
@@ -1567,6 +1507,16 @@ select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i and t1.i < 2;
  0 | text 10 | 01-01-2011
  0 | text 10 | 01-01-2011
  0 | text 10 | 01-01-2011
+ 1 | text 11 | 01-02-2011
+ 1 | text 11 | 01-02-2011
+ 1 | text 11 | 01-02-2011
+ 1 | text 11 | 01-02-2011
+ 1 | text 11 | 01-02-2011
+ 1 | text 11 | 01-02-2011
+ 1 | text 11 | 01-02-2011
+ 1 | text 11 | 01-02-2011
+ 1 | text 11 | 01-02-2011
+ 1 | text 11 | 01-02-2011
  0 | text 5  | 01-11-2011
  0 | text 5  | 01-11-2011
  0 | text 5  | 01-11-2011
@@ -1577,6 +1527,16 @@ select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i and t1.i < 2;
  0 | text 5  | 01-11-2011
  0 | text 5  | 01-11-2011
  0 | text 5  | 01-11-2011
+ 1 | text 6  | 01-12-2011
+ 1 | text 6  | 01-12-2011
+ 1 | text 6  | 01-12-2011
+ 1 | text 6  | 01-12-2011
+ 1 | text 6  | 01-12-2011
+ 1 | text 6  | 01-12-2011
+ 1 | text 6  | 01-12-2011
+ 1 | text 6  | 01-12-2011
+ 1 | text 6  | 01-12-2011
+ 1 | text 6  | 01-12-2011
  0 | text 0  | 01-01-2011
  0 | text 0  | 01-01-2011
  0 | text 0  | 01-01-2011
@@ -1587,6 +1547,16 @@ select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i and t1.i < 2;
  0 | text 0  | 01-01-2011
  0 | text 0  | 01-01-2011
  0 | text 0  | 01-01-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
  0 | text 10 | 01-11-2011
  0 | text 10 | 01-11-2011
  0 | text 10 | 01-11-2011
@@ -1597,6 +1567,16 @@ select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i and t1.i < 2;
  0 | text 10 | 01-11-2011
  0 | text 10 | 01-11-2011
  0 | text 10 | 01-11-2011
+ 1 | text 11 | 01-12-2011
+ 1 | text 11 | 01-12-2011
+ 1 | text 11 | 01-12-2011
+ 1 | text 11 | 01-12-2011
+ 1 | text 11 | 01-12-2011
+ 1 | text 11 | 01-12-2011
+ 1 | text 11 | 01-12-2011
+ 1 | text 11 | 01-12-2011
+ 1 | text 11 | 01-12-2011
+ 1 | text 11 | 01-12-2011
  0 | text 5  | 01-01-2011
  0 | text 5  | 01-01-2011
  0 | text 5  | 01-01-2011
@@ -1607,6 +1587,16 @@ select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i and t1.i < 2;
  0 | text 5  | 01-01-2011
  0 | text 5  | 01-01-2011
  0 | text 5  | 01-01-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
  0 | text 0  | 01-11-2011
  0 | text 0  | 01-11-2011
  0 | text 0  | 01-11-2011
@@ -1617,31 +1607,116 @@ select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i and t1.i < 2;
  0 | text 0  | 01-11-2011
  0 | text 0  | 01-11-2011
  0 | text 0  | 01-11-2011
+ 1 | text 1  | 01-12-2011
+ 1 | text 1  | 01-12-2011
+ 1 | text 1  | 01-12-2011
+ 1 | text 1  | 01-12-2011
+ 1 | text 1  | 01-12-2011
+ 1 | text 1  | 01-12-2011
+ 1 | text 1  | 01-12-2011
+ 1 | text 1  | 01-12-2011
+ 1 | text 1  | 01-12-2011
+ 1 | text 1  | 01-12-2011
 (200 rows)
 
 explain analyze select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i and t1.i < 2;
-                                                         QUERY PLAN                                                          
------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.02 rows=200 width=15) (actual time=1.423..1.484 rows=100 loops=2)
-   ->  Hash Join  (cost=0.00..862.01 rows=67 width=15) (actual time=0.289..1.208 rows=50 loops=2)
-         Hash Cond: smallt.i = smallt_1.i
-         Extra Text: (seg0)   Hash chain length 10.0 avg, 10 max, using 1 of 524288 buckets.
- 
-         ->  Seq Scan on smallt  (cost=0.00..431.00 rows=7 width=15) (actual time=0.002..0.007 rows=5 loops=2)
-               Filter: i < 2
-         ->  Hash  (cost=431.00..431.00 rows=7 width=4) (actual time=0.049..0.049 rows=5 loops=2)
-               ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=7 width=4) (actual time=0.037..0.044 rows=5 loops=2)
-                     Filter: i < 2
-   (slice0)    Executor memory: 322K bytes.
-   (slice1)    Executor memory: 4182K bytes avg x 3 workers, 4182K bytes max (seg0).  Work_mem: 1K bytes max.
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.02 rows=200 width=15) (actual time=0.508..0.514 rows=200 loops=1)
+   ->  Hash Join  (cost=0.00..862.01 rows=67 width=15) (actual time=0.215..0.715 rows=200 loops=1)
+         Hash Cond: (smallt.i = smallt_1.i)
+         Extra Text: (seg1)   Hash chain length 10.0 avg, 10 max, using 2 of 524288 buckets.
+         ->  Seq Scan on smallt  (cost=0.00..431.00 rows=7 width=15) (actual time=0.001..0.003 rows=20 loops=1)
+               Filter: (i < 2)
+         ->  Hash  (cost=431.00..431.00 rows=7 width=4) (actual time=0.015..0.015 rows=20 loops=1)
+               ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=7 width=4) (actual time=0.006..0.010 rows=20 loops=1)
+                     Filter: (i < 2)
+ Planning time: 3.361 ms
+   (slice0)    Executor memory: 87K bytes.
+   (slice1)    Executor memory: 4172K bytes avg x 3 workers, 4172K bytes max (seg0).  Work_mem: 1K bytes max.
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
- Total runtime: 3.631 ms
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 1.660 ms
 (15 rows)
 
 select t1.* from smallt as t1, smallt as t2 where t1.d = t2.d and t1.i < 2;
  i |    t    |     d      
 ---+---------+------------
+ 0 | text 0  | 01-01-2011
+ 0 | text 0  | 01-01-2011
+ 0 | text 0  | 01-01-2011
+ 0 | text 0  | 01-01-2011
+ 0 | text 0  | 01-01-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
+ 0 | text 10 | 01-11-2011
+ 0 | text 10 | 01-11-2011
+ 0 | text 10 | 01-11-2011
+ 0 | text 10 | 01-11-2011
+ 0 | text 10 | 01-11-2011
+ 0 | text 5  | 01-01-2011
+ 0 | text 5  | 01-01-2011
+ 0 | text 5  | 01-01-2011
+ 0 | text 5  | 01-01-2011
+ 0 | text 5  | 01-01-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
+ 0 | text 0  | 01-11-2011
+ 0 | text 0  | 01-11-2011
+ 0 | text 0  | 01-11-2011
+ 0 | text 0  | 01-11-2011
+ 0 | text 0  | 01-11-2011
+ 0 | text 10 | 01-01-2011
+ 0 | text 10 | 01-01-2011
+ 0 | text 10 | 01-01-2011
+ 0 | text 10 | 01-01-2011
+ 0 | text 10 | 01-01-2011
+ 1 | text 11 | 01-02-2011
+ 1 | text 11 | 01-02-2011
+ 1 | text 11 | 01-02-2011
+ 1 | text 11 | 01-02-2011
+ 1 | text 11 | 01-02-2011
+ 0 | text 5  | 01-11-2011
+ 0 | text 5  | 01-11-2011
+ 0 | text 5  | 01-11-2011
+ 0 | text 5  | 01-11-2011
+ 0 | text 5  | 01-11-2011
+ 0 | text 0  | 01-01-2011
+ 0 | text 0  | 01-01-2011
+ 0 | text 0  | 01-01-2011
+ 0 | text 0  | 01-01-2011
+ 0 | text 0  | 01-01-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
+ 1 | text 1  | 01-02-2011
+ 0 | text 10 | 01-11-2011
+ 0 | text 10 | 01-11-2011
+ 0 | text 10 | 01-11-2011
+ 0 | text 10 | 01-11-2011
+ 0 | text 10 | 01-11-2011
+ 0 | text 5  | 01-01-2011
+ 0 | text 5  | 01-01-2011
+ 0 | text 5  | 01-01-2011
+ 0 | text 5  | 01-01-2011
+ 0 | text 5  | 01-01-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
+ 1 | text 6  | 01-02-2011
+ 0 | text 0  | 01-11-2011
+ 0 | text 0  | 01-11-2011
+ 0 | text 0  | 01-11-2011
+ 0 | text 0  | 01-11-2011
+ 0 | text 0  | 01-11-2011
  1 | text 11 | 01-12-2011
  1 | text 11 | 01-12-2011
  1 | text 11 | 01-12-2011
@@ -1667,107 +1742,32 @@ select t1.* from smallt as t1, smallt as t2 where t1.d = t2.d and t1.i < 2;
  1 | text 1  | 01-12-2011
  1 | text 1  | 01-12-2011
  1 | text 1  | 01-12-2011
- 0 | text 10 | 01-11-2011
- 0 | text 10 | 01-11-2011
- 0 | text 10 | 01-11-2011
- 0 | text 10 | 01-11-2011
- 0 | text 10 | 01-11-2011
- 0 | text 0  | 01-11-2011
- 0 | text 0  | 01-11-2011
- 0 | text 0  | 01-11-2011
- 0 | text 0  | 01-11-2011
- 0 | text 0  | 01-11-2011
- 0 | text 5  | 01-11-2011
- 0 | text 5  | 01-11-2011
- 0 | text 5  | 01-11-2011
- 0 | text 5  | 01-11-2011
- 0 | text 5  | 01-11-2011
- 0 | text 10 | 01-11-2011
- 0 | text 10 | 01-11-2011
- 0 | text 10 | 01-11-2011
- 0 | text 10 | 01-11-2011
- 0 | text 10 | 01-11-2011
- 0 | text 0  | 01-11-2011
- 0 | text 0  | 01-11-2011
- 0 | text 0  | 01-11-2011
- 0 | text 0  | 01-11-2011
- 0 | text 0  | 01-11-2011
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 11 | 01-02-2011
- 1 | text 11 | 01-02-2011
- 1 | text 11 | 01-02-2011
- 1 | text 11 | 01-02-2011
- 1 | text 11 | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 1  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 1 | text 6  | 01-02-2011
- 0 | text 0  | 01-01-2011
- 0 | text 0  | 01-01-2011
- 0 | text 0  | 01-01-2011
- 0 | text 0  | 01-01-2011
- 0 | text 0  | 01-01-2011
- 0 | text 5  | 01-01-2011
- 0 | text 5  | 01-01-2011
- 0 | text 5  | 01-01-2011
- 0 | text 5  | 01-01-2011
- 0 | text 5  | 01-01-2011
- 0 | text 10 | 01-01-2011
- 0 | text 10 | 01-01-2011
- 0 | text 10 | 01-01-2011
- 0 | text 10 | 01-01-2011
- 0 | text 10 | 01-01-2011
- 0 | text 0  | 01-01-2011
- 0 | text 0  | 01-01-2011
- 0 | text 0  | 01-01-2011
- 0 | text 0  | 01-01-2011
- 0 | text 0  | 01-01-2011
- 0 | text 5  | 01-01-2011
- 0 | text 5  | 01-01-2011
- 0 | text 5  | 01-01-2011
- 0 | text 5  | 01-01-2011
- 0 | text 5  | 01-01-2011
 (100 rows)
 
 --start_ignore
 explain analyze select t1.* from smallt as t1, smallt as t2 where t1.d = t2.d and t1.i < 2;
                                                                     QUERY PLAN                                                                    
 --------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.02 rows=100 width=15) (actual time=1.917..2.300 rows=50 loops=2)
-   ->  Hash Join  (cost=0.00..862.01 rows=34 width=15) (actual time=0.611..2.052 rows=25 loops=2)
-         Hash Cond: smallt.d = smallt_1.d
-         Extra Text: (seg1)   Hash chain length 5.0 avg, 5 max, using 11 of 524288 buckets.
- 
-         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=15) (actual time=0.004..0.199 rows=5 loops=2)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.02 rows=100 width=15) (actual time=4.340..6.196 rows=100 loops=1)
+   ->  Hash Join  (cost=0.00..862.01 rows=34 width=15) (actual time=4.110..5.833 rows=75 loops=1)
+         Hash Cond: (smallt.d = smallt_1.d)
+         Extra Text: (seg1)   Hash chain length 5.0 avg, 5 max, using 7 of 524288 buckets.
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=15) (actual time=0.004..0.007 rows=15 loops=1)
                Hash Key: smallt.d
-               ->  Seq Scan on smallt  (cost=0.00..431.00 rows=7 width=15) (actual time=0.021..0.034 rows=5 loops=2)
-                     Filter: i < 2
-         ->  Hash  (cost=431.00..431.00 rows=34 width=4) (actual time=0.169..0.169 rows=28 loops=2)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.032..0.153 rows=28 loops=2)
+               ->  Seq Scan on smallt  (cost=0.00..431.00 rows=7 width=15) (actual time=0.003..0.007 rows=20 loops=1)
+                     Filter: (i < 2)
+         ->  Hash  (cost=431.00..431.00 rows=34 width=4) (actual time=3.958..3.958 rows=35 loops=1)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=3.948..3.953 rows=35 loops=1)
                      Hash Key: smallt_1.d
-                     ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=4) (actual time=0.022..0.036 rows=20 loops=2)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice3)    Executor memory: 4186K bytes avg x 3 workers, 4186K bytes max (seg0).  Work_mem: 2K bytes max.
+                     ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=4) (actual time=0.002..0.008 rows=50 loops=1)
+ Planning time: 6.368 ms
+   (slice0)    Executor memory: 71K bytes.
+   (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
+   (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
+   (slice3)    Executor memory: 4146K bytes avg x 3 workers, 4152K bytes max (seg1).  Work_mem: 1K bytes max.
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
- Total runtime: 5.688 ms
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 7.110 ms
 (20 rows)
 
 --end_ignore
@@ -1820,40 +1820,43 @@ explain analyze select smallt.* from smallt, smallt2 where smallt.i = smallt2.i 
 and smallt.d = '2011-01-04'::date;
                                                                QUERY PLAN                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..17.99 rows=2 width=15) (actual time=2.338..2.341 rows=20 loops=1)
-   ->  Hash Join  (cost=0.00..17.99 rows=1 width=15) (actual time=0.464..1.817 rows=20 loops=1)
-         Hash Cond: smallt.i = smallt2.i
-         (seg2)   Hash chain length 4.0 avg, 4 max, using 1 of 524288 buckets.
-         ->  Index Scan using smallt_d_idx on smallt  (cost=0.00..9.99 rows=2 width=15) (actual time=0.005..0.007 rows=5 loops=1)
-               Index Cond: d = '01-04-2011'::date
-         ->  Hash  (cost=8.00..8.00 rows=2 width=4) (actual time=0.034..0.034 rows=4 loops=1)
-               ->  Index Scan using smallt2_d_idx on smallt2  (cost=0.00..8.00 rows=2 width=4) (actual time=0.023..0.027 rows=4 loops=1)
-                     Index Cond: d = '01-04-2011'::date
-   (slice0)    Executor memory: 450K bytes.
-   (slice1)    Executor memory: 4234K bytes avg x 3 workers, 4234K bytes max (seg0).  Work_mem: 1K bytes max.
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..12.00 rows=4 width=15) (actual time=1.073..4.912 rows=20 loops=1)
+   ->  Hash Join  (cost=0.00..12.00 rows=2 width=15) (actual time=0.371..0.877 rows=20 loops=1)
+         Hash Cond: (smallt.i = smallt2.i)
+         Extra Text: (seg0)   Hash chain length 4.0 avg, 4 max, using 1 of 524288 buckets.
+         ->  Index Scan using smallt_d_idx on smallt  (cost=0.00..6.00 rows=2 width=15) (actual time=0.004..0.005 rows=5 loops=1)
+               Index Cond: (d = '01-04-2011'::date)
+         ->  Hash  (cost=6.00..6.00 rows=2 width=4) (actual time=0.013..0.013 rows=4 loops=1)
+               ->  Index Scan using smallt2_d_idx on smallt2  (cost=0.00..6.00 rows=2 width=4) (actual time=0.009..0.012 rows=4 loops=1)
+                     Index Cond: (d = '01-04-2011'::date)
+ Planning time: 18.368 ms
+   (slice0)    Executor memory: 128K bytes.
+   (slice1)    Executor memory: 4236K bytes avg x 3 workers, 4236K bytes max (seg0).  Work_mem: 1K bytes max.
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
- Total runtime: 3.325 ms
-(14 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 5.203 ms
+(15 rows)
 
 -- IndexOnlyScan
 explain analyze select *, exists(select 1 from pg_class where oid = c.oid) as dummy from pg_class c;
-                                                                            QUERY PLAN                                                                             
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Seq Scan on pg_class c  (cost=10000000000.00..10000277657.66 rows=1387 width=209) (actual time=0.465..0.708 rows=222 loops=2)
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Seq Scan on pg_class c  (cost=10000000000.00..10002313594.06 rows=11549 width=206) (actual time=5.949..9.191 rows=7195 loops=1)
    SubPlan 1
-     ->  Index Only Scan using pg_class_oid_index on pg_class  (cost=0.15..200.17 rows=1 width=0) (never executed)
-           Index Cond: oid = c.oid
+     ->  Index Only Scan using pg_class_oid_index on pg_class  (cost=0.29..200.30 rows=1 width=0) (never executed)
+           Index Cond: (oid = c.oid)
            Heap Fetches: 0
    SubPlan 2
-     ->  Materialize  (cost=0.15..1027.89 rows=1387 width=4) (actual time=0.327..0.345 rows=222 loops=2)
-           ->  Index Only Scan using pg_class_oid_index on pg_class pg_class_1  (cost=0.15..1020.96 rows=1387 width=4) (actual time=0.036..0.258 rows=222 loops=2)
-                 Heap Fetches: 1252
-   (slice0)    Executor memory: 382K bytes.
+     ->  Materialize  (cost=0.29..19631.26 rows=11549 width=4) (actual time=4.851..5.129 rows=7195 loops=1)
+           ->  Index Only Scan using pg_class_oid_index on pg_class pg_class_1  (cost=0.29..19573.52 rows=11549 width=4) (actual time=0.069..4.370 rows=7195 loops=1)
+                 Heap Fetches: 19944
+ Planning time: 2.282 ms
+ * (slice0)    Executor memory: 1033K bytes.  Work_mem: 96K bytes max, 64K bytes wanted.
  Memory used:  128000kB
+ Memory wanted:  364kB
  Optimizer: Postgres query optimizer
- Total runtime: 1.681 ms
-(13 rows)
+ Execution time: 9.561 ms
+(15 rows)
 
 -- BitmapScan
 -- start_ignore
@@ -1891,21 +1894,22 @@ explain analyze select smallt.* from smallt, smallt2 where smallt.i = smallt2.i 
 and smallt.d = '2011-01-04'::date;
                                                                QUERY PLAN                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..17.99 rows=2 width=15) (actual time=3.960..3.964 rows=20 loops=1)
-   ->  Hash Join  (cost=0.00..17.99 rows=1 width=15) (actual time=0.267..1.566 rows=20 loops=1)
-         Hash Cond: smallt.i = smallt2.i
-         (seg2)   Hash chain length 4.0 avg, 4 max, using 1 of 524288 buckets.
-         ->  Index Scan using smallt_d_idx on smallt  (cost=0.00..9.99 rows=2 width=15) (actual time=0.005..0.007 rows=5 loops=1)
-               Index Cond: d = '01-04-2011'::date
-         ->  Hash  (cost=8.00..8.00 rows=2 width=4) (actual time=0.031..0.031 rows=4 loops=1)
-               ->  Index Scan using smallt2_d_idx on smallt2  (cost=0.00..8.00 rows=2 width=4) (actual time=0.020..0.024 rows=4 loops=1)
-                     Index Cond: d = '01-04-2011'::date
-   (slice0)    Executor memory: 450K bytes.
-   (slice1)    Executor memory: 4234K bytes avg x 3 workers, 4234K bytes max (seg0).  Work_mem: 1K bytes max.
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..12.00 rows=4 width=15) (actual time=0.413..0.414 rows=20 loops=1)
+   ->  Hash Join  (cost=0.00..12.00 rows=2 width=15) (actual time=0.466..1.063 rows=20 loops=1)
+         Hash Cond: (smallt.i = smallt2.i)
+         Extra Text: (seg0)   Hash chain length 4.0 avg, 4 max, using 1 of 524288 buckets.
+         ->  Index Scan using smallt_d_idx on smallt  (cost=0.00..6.00 rows=2 width=15) (actual time=0.004..0.005 rows=5 loops=1)
+               Index Cond: (d = '01-04-2011'::date)
+         ->  Hash  (cost=6.00..6.00 rows=2 width=4) (actual time=0.012..0.012 rows=4 loops=1)
+               ->  Index Scan using smallt2_d_idx on smallt2  (cost=0.00..6.00 rows=2 width=4) (actual time=0.007..0.009 rows=4 loops=1)
+                     Index Cond: (d = '01-04-2011'::date)
+ Planning time: 4.367 ms
+   (slice0)    Executor memory: 128K bytes.
+   (slice1)    Executor memory: 4236K bytes avg x 3 workers, 4236K bytes max (seg0).  Work_mem: 1K bytes max.
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
- Total runtime: 5.131 ms
-(14 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution time: 1.521 ms
+(15 rows)
 
 set enable_hashjoin=on;
 set enable_nestloop=off;
@@ -1956,30 +1960,30 @@ insert into eager_free_t select generate_series(1, 30), generate_series(1, 6), g
 select * from eager_free_t where t1 > (select min(r1) from eager_free_r where r2<t2 and r3 > (Select min(s3) from eager_free_s where s1<r1));
  t1 | t2 | t3 
 ----+----+----
- 11 |  5 |  1
- 17 |  5 |  2
- 18 |  6 |  3
- 21 |  3 |  1
  20 |  2 |  5
- 29 |  5 |  4
  26 |  2 |  1
- 27 |  3 |  2
-  5 |  5 |  5
-  9 |  3 |  4
- 12 |  6 |  2
- 23 |  5 |  3
- 24 |  6 |  4
- 28 |  4 |  3
- 30 |  6 |  5
-  4 |  4 |  4
-  3 |  3 |  3
-  8 |  2 |  3
-  6 |  6 |  1
- 14 |  2 |  4
- 10 |  4 |  5
  15 |  3 |  5
+ 23 |  5 |  3
+ 12 |  6 |  2
+ 30 |  6 |  5
+  6 |  6 |  1
+  5 |  5 |  5
+ 10 |  4 |  5
+ 28 |  4 |  3
+  9 |  3 |  4
+ 14 |  2 |  4
+ 11 |  5 |  1
+ 21 |  3 |  1
+ 17 |  5 |  2
+  3 |  3 |  3
+ 27 |  3 |  2
+ 18 |  6 |  3
+ 24 |  6 |  4
  16 |  4 |  1
+  4 |  4 |  4
+ 29 |  5 |  4
  22 |  4 |  2
+  8 |  2 |  3
 (24 rows)
 
 reset optimizer_segments;

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -7,10 +7,14 @@ CREATE TABLE J1_TBL (
   j integer,
   t text
 );
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TABLE J2_TBL (
   i integer,
   k integer
 );
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO J1_TBL VALUES (1, 4, 'one');
 INSERT INTO J1_TBL VALUES (2, 3, 'two');
 INSERT INTO J1_TBL VALUES (3, 2, 'three');
@@ -41,14 +45,14 @@ SELECT '' AS "xxx", *
  xxx | i | j |   t   
 -----+---+---+-------
      | 1 | 4 | one
+     | 0 |   | zero
+     | 5 | 0 | five
+     | 6 | 6 | six
      | 2 | 3 | two
      | 3 | 2 | three
      | 4 | 1 | four
-     | 5 | 0 | five
-     | 6 | 6 | six
      | 7 | 7 | seven
      | 8 | 8 | eight
-     | 0 |   | zero
      |   |   | null
      |   | 0 | zero
 (11 rows)
@@ -58,14 +62,14 @@ SELECT '' AS "xxx", *
  xxx | i | j |   t   
 -----+---+---+-------
      | 1 | 4 | one
+     | 0 |   | zero
+     | 5 | 0 | five
+     | 6 | 6 | six
      | 2 | 3 | two
      | 3 | 2 | three
      | 4 | 1 | four
-     | 5 | 0 | five
-     | 6 | 6 | six
      | 7 | 7 | seven
      | 8 | 8 | eight
-     | 0 |   | zero
      |   |   | null
      |   | 0 | zero
 (11 rows)
@@ -74,139 +78,139 @@ SELECT '' AS "xxx", *
   FROM J1_TBL AS t1 (a, b, c);
  xxx | a | b |   c   
 -----+---+---+-------
-     | 1 | 4 | one
+     | 5 | 0 | five
+     | 6 | 6 | six
      | 2 | 3 | two
      | 3 | 2 | three
      | 4 | 1 | four
-     | 5 | 0 | five
-     | 6 | 6 | six
      | 7 | 7 | seven
      | 8 | 8 | eight
-     | 0 |   | zero
      |   |   | null
      |   | 0 | zero
+     | 1 | 4 | one
+     | 0 |   | zero
 (11 rows)
 
 SELECT '' AS "xxx", *
   FROM J1_TBL t1 (a, b, c);
  xxx | a | b |   c   
 -----+---+---+-------
-     | 1 | 4 | one
      | 2 | 3 | two
      | 3 | 2 | three
      | 4 | 1 | four
-     | 5 | 0 | five
-     | 6 | 6 | six
      | 7 | 7 | seven
      | 8 | 8 | eight
-     | 0 |   | zero
      |   |   | null
      |   | 0 | zero
+     | 1 | 4 | one
+     | 0 |   | zero
+     | 5 | 0 | five
+     | 6 | 6 | six
 (11 rows)
 
 SELECT '' AS "xxx", *
   FROM J1_TBL t1 (a, b, c), J2_TBL t2 (d, e);
  xxx | a | b |   c   | d | e  
 -----+---+---+-------+---+----
-     | 1 | 4 | one   | 1 | -1
-     | 2 | 3 | two   | 1 | -1
-     | 3 | 2 | three | 1 | -1
-     | 4 | 1 | four  | 1 | -1
+     | 5 | 0 | five  | 5 | -5
+     | 6 | 6 | six   | 5 | -5
+     | 5 | 0 | five  | 5 | -5
+     | 6 | 6 | six   | 5 | -5
+     | 5 | 0 | five  | 2 |  2
+     | 6 | 6 | six   | 2 |  2
+     | 5 | 0 | five  | 3 | -3
+     | 6 | 6 | six   | 3 | -3
+     | 5 | 0 | five  | 2 |  4
+     | 6 | 6 | six   | 2 |  4
+     | 5 | 0 | five  |   |   
+     | 6 | 6 | six   |   |   
+     | 5 | 0 | five  |   |  0
+     | 6 | 6 | six   |   |  0
      | 5 | 0 | five  | 1 | -1
      | 6 | 6 | six   | 1 | -1
-     | 7 | 7 | seven | 1 | -1
-     | 8 | 8 | eight | 1 | -1
-     | 0 |   | zero  | 1 | -1
-     |   |   | null  | 1 | -1
-     |   | 0 | zero  | 1 | -1
-     | 1 | 4 | one   | 2 |  2
+     | 5 | 0 | five  | 0 |   
+     | 6 | 6 | six   | 0 |   
+     | 2 | 3 | two   | 5 | -5
+     | 3 | 2 | three | 5 | -5
+     | 4 | 1 | four  | 5 | -5
+     | 7 | 7 | seven | 5 | -5
+     | 8 | 8 | eight | 5 | -5
+     |   |   | null  | 5 | -5
+     |   | 0 | zero  | 5 | -5
+     | 2 | 3 | two   | 5 | -5
+     | 3 | 2 | three | 5 | -5
+     | 4 | 1 | four  | 5 | -5
+     | 7 | 7 | seven | 5 | -5
+     | 8 | 8 | eight | 5 | -5
+     |   |   | null  | 5 | -5
+     |   | 0 | zero  | 5 | -5
      | 2 | 3 | two   | 2 |  2
      | 3 | 2 | three | 2 |  2
      | 4 | 1 | four  | 2 |  2
-     | 5 | 0 | five  | 2 |  2
-     | 6 | 6 | six   | 2 |  2
      | 7 | 7 | seven | 2 |  2
      | 8 | 8 | eight | 2 |  2
-     | 0 |   | zero  | 2 |  2
      |   |   | null  | 2 |  2
      |   | 0 | zero  | 2 |  2
-     | 1 | 4 | one   | 3 | -3
      | 2 | 3 | two   | 3 | -3
      | 3 | 2 | three | 3 | -3
      | 4 | 1 | four  | 3 | -3
-     | 5 | 0 | five  | 3 | -3
-     | 6 | 6 | six   | 3 | -3
      | 7 | 7 | seven | 3 | -3
      | 8 | 8 | eight | 3 | -3
-     | 0 |   | zero  | 3 | -3
      |   |   | null  | 3 | -3
      |   | 0 | zero  | 3 | -3
-     | 1 | 4 | one   | 2 |  4
      | 2 | 3 | two   | 2 |  4
      | 3 | 2 | three | 2 |  4
      | 4 | 1 | four  | 2 |  4
-     | 5 | 0 | five  | 2 |  4
-     | 6 | 6 | six   | 2 |  4
      | 7 | 7 | seven | 2 |  4
      | 8 | 8 | eight | 2 |  4
-     | 0 |   | zero  | 2 |  4
      |   |   | null  | 2 |  4
      |   | 0 | zero  | 2 |  4
-     | 1 | 4 | one   | 5 | -5
-     | 2 | 3 | two   | 5 | -5
-     | 3 | 2 | three | 5 | -5
-     | 4 | 1 | four  | 5 | -5
-     | 5 | 0 | five  | 5 | -5
-     | 6 | 6 | six   | 5 | -5
-     | 7 | 7 | seven | 5 | -5
-     | 8 | 8 | eight | 5 | -5
-     | 0 |   | zero  | 5 | -5
-     |   |   | null  | 5 | -5
-     |   | 0 | zero  | 5 | -5
-     | 1 | 4 | one   | 5 | -5
-     | 2 | 3 | two   | 5 | -5
-     | 3 | 2 | three | 5 | -5
-     | 4 | 1 | four  | 5 | -5
-     | 5 | 0 | five  | 5 | -5
-     | 6 | 6 | six   | 5 | -5
-     | 7 | 7 | seven | 5 | -5
-     | 8 | 8 | eight | 5 | -5
-     | 0 |   | zero  | 5 | -5
-     |   |   | null  | 5 | -5
-     |   | 0 | zero  | 5 | -5
-     | 1 | 4 | one   | 0 |   
-     | 2 | 3 | two   | 0 |   
-     | 3 | 2 | three | 0 |   
-     | 4 | 1 | four  | 0 |   
-     | 5 | 0 | five  | 0 |   
-     | 6 | 6 | six   | 0 |   
-     | 7 | 7 | seven | 0 |   
-     | 8 | 8 | eight | 0 |   
-     | 0 |   | zero  | 0 |   
-     |   |   | null  | 0 |   
-     |   | 0 | zero  | 0 |   
-     | 1 | 4 | one   |   |   
      | 2 | 3 | two   |   |   
      | 3 | 2 | three |   |   
      | 4 | 1 | four  |   |   
-     | 5 | 0 | five  |   |   
-     | 6 | 6 | six   |   |   
      | 7 | 7 | seven |   |   
      | 8 | 8 | eight |   |   
-     | 0 |   | zero  |   |   
      |   |   | null  |   |   
      |   | 0 | zero  |   |   
-     | 1 | 4 | one   |   |  0
      | 2 | 3 | two   |   |  0
      | 3 | 2 | three |   |  0
      | 4 | 1 | four  |   |  0
-     | 5 | 0 | five  |   |  0
-     | 6 | 6 | six   |   |  0
      | 7 | 7 | seven |   |  0
      | 8 | 8 | eight |   |  0
-     | 0 |   | zero  |   |  0
      |   |   | null  |   |  0
      |   | 0 | zero  |   |  0
+     | 2 | 3 | two   | 1 | -1
+     | 3 | 2 | three | 1 | -1
+     | 4 | 1 | four  | 1 | -1
+     | 7 | 7 | seven | 1 | -1
+     | 8 | 8 | eight | 1 | -1
+     |   |   | null  | 1 | -1
+     |   | 0 | zero  | 1 | -1
+     | 2 | 3 | two   | 0 |   
+     | 3 | 2 | three | 0 |   
+     | 4 | 1 | four  | 0 |   
+     | 7 | 7 | seven | 0 |   
+     | 8 | 8 | eight | 0 |   
+     |   |   | null  | 0 |   
+     |   | 0 | zero  | 0 |   
+     | 1 | 4 | one   | 2 |  2
+     | 0 |   | zero  | 2 |  2
+     | 1 | 4 | one   | 3 | -3
+     | 0 |   | zero  | 3 | -3
+     | 1 | 4 | one   | 2 |  4
+     | 0 |   | zero  | 2 |  4
+     | 1 | 4 | one   |   |   
+     | 0 |   | zero  |   |   
+     | 1 | 4 | one   |   |  0
+     | 0 |   | zero  |   |  0
+     | 1 | 4 | one   | 5 | -5
+     | 0 |   | zero  | 5 | -5
+     | 1 | 4 | one   | 5 | -5
+     | 0 |   | zero  | 5 | -5
+     | 1 | 4 | one   | 1 | -1
+     | 0 |   | zero  | 1 | -1
+     | 1 | 4 | one   | 0 |   
+     | 0 |   | zero  | 0 |   
 (99 rows)
 
 SELECT '' AS "xxx", t1.a, t2.e
@@ -214,13 +218,13 @@ SELECT '' AS "xxx", t1.a, t2.e
   WHERE t1.a = t2.d;
  xxx | a | e  
 -----+---+----
-     | 0 |   
+     | 5 | -5
+     | 5 | -5
      | 1 | -1
+     | 0 |   
      | 2 |  2
-     | 2 |  4
      | 3 | -3
-     | 5 | -5
-     | 5 | -5
+     | 2 |  4
 (7 rows)
 
 --
@@ -232,105 +236,105 @@ SELECT '' AS "xxx", *
   FROM J1_TBL CROSS JOIN J2_TBL;
  xxx | i | j |   t   | i | k  
 -----+---+---+-------+---+----
-     | 1 | 4 | one   | 1 | -1
+     | 5 | 0 | five  | 1 | -1
+     | 6 | 6 | six   | 1 | -1
+     | 5 | 0 | five  | 0 |   
+     | 6 | 6 | six   | 0 |   
+     | 5 | 0 | five  | 5 | -5
+     | 6 | 6 | six   | 5 | -5
+     | 5 | 0 | five  | 5 | -5
+     | 6 | 6 | six   | 5 | -5
+     | 5 | 0 | five  | 2 |  2
+     | 6 | 6 | six   | 2 |  2
+     | 5 | 0 | five  | 3 | -3
+     | 6 | 6 | six   | 3 | -3
+     | 5 | 0 | five  | 2 |  4
+     | 6 | 6 | six   | 2 |  4
+     | 5 | 0 | five  |   |   
+     | 6 | 6 | six   |   |   
+     | 5 | 0 | five  |   |  0
+     | 6 | 6 | six   |   |  0
      | 2 | 3 | two   | 1 | -1
      | 3 | 2 | three | 1 | -1
      | 4 | 1 | four  | 1 | -1
-     | 5 | 0 | five  | 1 | -1
-     | 6 | 6 | six   | 1 | -1
      | 7 | 7 | seven | 1 | -1
      | 8 | 8 | eight | 1 | -1
-     | 0 |   | zero  | 1 | -1
      |   |   | null  | 1 | -1
      |   | 0 | zero  | 1 | -1
-     | 1 | 4 | one   | 2 |  2
-     | 2 | 3 | two   | 2 |  2
-     | 3 | 2 | three | 2 |  2
-     | 4 | 1 | four  | 2 |  2
-     | 5 | 0 | five  | 2 |  2
-     | 6 | 6 | six   | 2 |  2
-     | 7 | 7 | seven | 2 |  2
-     | 8 | 8 | eight | 2 |  2
-     | 0 |   | zero  | 2 |  2
-     |   |   | null  | 2 |  2
-     |   | 0 | zero  | 2 |  2
-     | 1 | 4 | one   | 3 | -3
-     | 2 | 3 | two   | 3 | -3
-     | 3 | 2 | three | 3 | -3
-     | 4 | 1 | four  | 3 | -3
-     | 5 | 0 | five  | 3 | -3
-     | 6 | 6 | six   | 3 | -3
-     | 7 | 7 | seven | 3 | -3
-     | 8 | 8 | eight | 3 | -3
-     | 0 |   | zero  | 3 | -3
-     |   |   | null  | 3 | -3
-     |   | 0 | zero  | 3 | -3
-     | 1 | 4 | one   | 2 |  4
-     | 2 | 3 | two   | 2 |  4
-     | 3 | 2 | three | 2 |  4
-     | 4 | 1 | four  | 2 |  4
-     | 5 | 0 | five  | 2 |  4
-     | 6 | 6 | six   | 2 |  4
-     | 7 | 7 | seven | 2 |  4
-     | 8 | 8 | eight | 2 |  4
-     | 0 |   | zero  | 2 |  4
-     |   |   | null  | 2 |  4
-     |   | 0 | zero  | 2 |  4
-     | 1 | 4 | one   | 5 | -5
-     | 2 | 3 | two   | 5 | -5
-     | 3 | 2 | three | 5 | -5
-     | 4 | 1 | four  | 5 | -5
-     | 5 | 0 | five  | 5 | -5
-     | 6 | 6 | six   | 5 | -5
-     | 7 | 7 | seven | 5 | -5
-     | 8 | 8 | eight | 5 | -5
-     | 0 |   | zero  | 5 | -5
-     |   |   | null  | 5 | -5
-     |   | 0 | zero  | 5 | -5
-     | 1 | 4 | one   | 5 | -5
-     | 2 | 3 | two   | 5 | -5
-     | 3 | 2 | three | 5 | -5
-     | 4 | 1 | four  | 5 | -5
-     | 5 | 0 | five  | 5 | -5
-     | 6 | 6 | six   | 5 | -5
-     | 7 | 7 | seven | 5 | -5
-     | 8 | 8 | eight | 5 | -5
-     | 0 |   | zero  | 5 | -5
-     |   |   | null  | 5 | -5
-     |   | 0 | zero  | 5 | -5
-     | 1 | 4 | one   | 0 |   
      | 2 | 3 | two   | 0 |   
      | 3 | 2 | three | 0 |   
      | 4 | 1 | four  | 0 |   
-     | 5 | 0 | five  | 0 |   
-     | 6 | 6 | six   | 0 |   
      | 7 | 7 | seven | 0 |   
      | 8 | 8 | eight | 0 |   
-     | 0 |   | zero  | 0 |   
      |   |   | null  | 0 |   
      |   | 0 | zero  | 0 |   
-     | 1 | 4 | one   |   |   
+     | 2 | 3 | two   | 5 | -5
+     | 3 | 2 | three | 5 | -5
+     | 4 | 1 | four  | 5 | -5
+     | 7 | 7 | seven | 5 | -5
+     | 8 | 8 | eight | 5 | -5
+     |   |   | null  | 5 | -5
+     |   | 0 | zero  | 5 | -5
+     | 2 | 3 | two   | 5 | -5
+     | 3 | 2 | three | 5 | -5
+     | 4 | 1 | four  | 5 | -5
+     | 7 | 7 | seven | 5 | -5
+     | 8 | 8 | eight | 5 | -5
+     |   |   | null  | 5 | -5
+     |   | 0 | zero  | 5 | -5
+     | 2 | 3 | two   | 2 |  2
+     | 3 | 2 | three | 2 |  2
+     | 4 | 1 | four  | 2 |  2
+     | 7 | 7 | seven | 2 |  2
+     | 8 | 8 | eight | 2 |  2
+     |   |   | null  | 2 |  2
+     |   | 0 | zero  | 2 |  2
+     | 2 | 3 | two   | 3 | -3
+     | 3 | 2 | three | 3 | -3
+     | 4 | 1 | four  | 3 | -3
+     | 7 | 7 | seven | 3 | -3
+     | 8 | 8 | eight | 3 | -3
+     |   |   | null  | 3 | -3
+     |   | 0 | zero  | 3 | -3
+     | 2 | 3 | two   | 2 |  4
+     | 3 | 2 | three | 2 |  4
+     | 4 | 1 | four  | 2 |  4
+     | 7 | 7 | seven | 2 |  4
+     | 8 | 8 | eight | 2 |  4
+     |   |   | null  | 2 |  4
+     |   | 0 | zero  | 2 |  4
      | 2 | 3 | two   |   |   
      | 3 | 2 | three |   |   
      | 4 | 1 | four  |   |   
-     | 5 | 0 | five  |   |   
-     | 6 | 6 | six   |   |   
      | 7 | 7 | seven |   |   
      | 8 | 8 | eight |   |   
-     | 0 |   | zero  |   |   
      |   |   | null  |   |   
      |   | 0 | zero  |   |   
-     | 1 | 4 | one   |   |  0
      | 2 | 3 | two   |   |  0
      | 3 | 2 | three |   |  0
      | 4 | 1 | four  |   |  0
-     | 5 | 0 | five  |   |  0
-     | 6 | 6 | six   |   |  0
      | 7 | 7 | seven |   |  0
      | 8 | 8 | eight |   |  0
-     | 0 |   | zero  |   |  0
      |   |   | null  |   |  0
      |   | 0 | zero  |   |  0
+     | 1 | 4 | one   | 1 | -1
+     | 0 |   | zero  | 1 | -1
+     | 1 | 4 | one   | 0 |   
+     | 0 |   | zero  | 0 |   
+     | 1 | 4 | one   | 5 | -5
+     | 0 |   | zero  | 5 | -5
+     | 1 | 4 | one   | 5 | -5
+     | 0 |   | zero  | 5 | -5
+     | 1 | 4 | one   | 2 |  2
+     | 0 |   | zero  | 2 |  2
+     | 1 | 4 | one   | 3 | -3
+     | 0 |   | zero  | 3 | -3
+     | 1 | 4 | one   | 2 |  4
+     | 0 |   | zero  | 2 |  4
+     | 1 | 4 | one   |   |   
+     | 0 |   | zero  |   |   
+     | 1 | 4 | one   |   |  0
+     | 0 |   | zero  |   |  0
 (99 rows)
 
 -- ambiguous column
@@ -344,105 +348,105 @@ SELECT '' AS "xxx", t1.i, k, t
   FROM J1_TBL t1 CROSS JOIN J2_TBL t2;
  xxx | i | k  |   t   
 -----+---+----+-------
-     | 1 | -1 | one
-     | 2 | -1 | two
-     | 3 | -1 | three
-     | 4 | -1 | four
-     | 5 | -1 | five
-     | 6 | -1 | six
-     | 7 | -1 | seven
-     | 8 | -1 | eight
-     | 0 | -1 | zero
-     |   | -1 | null
-     |   | -1 | zero
-     | 1 |  2 | one
+     | 2 | -5 | two
+     | 2 | -5 | two
      | 2 |  2 | two
-     | 3 |  2 | three
-     | 4 |  2 | four
-     | 5 |  2 | five
-     | 6 |  2 | six
-     | 7 |  2 | seven
-     | 8 |  2 | eight
-     | 0 |  2 | zero
-     |   |  2 | null
-     |   |  2 | zero
-     | 1 | -3 | one
      | 2 | -3 | two
-     | 3 | -3 | three
-     | 4 | -3 | four
-     | 5 | -3 | five
-     | 6 | -3 | six
-     | 7 | -3 | seven
-     | 8 | -3 | eight
-     | 0 | -3 | zero
-     |   | -3 | null
-     |   | -3 | zero
-     | 1 |  4 | one
      | 2 |  4 | two
-     | 3 |  4 | three
-     | 4 |  4 | four
-     | 5 |  4 | five
-     | 6 |  4 | six
-     | 7 |  4 | seven
-     | 8 |  4 | eight
-     | 0 |  4 | zero
-     |   |  4 | null
-     |   |  4 | zero
-     | 1 | -5 | one
-     | 2 | -5 | two
-     | 3 | -5 | three
-     | 4 | -5 | four
-     | 5 | -5 | five
-     | 6 | -5 | six
-     | 7 | -5 | seven
-     | 8 | -5 | eight
-     | 0 | -5 | zero
-     |   | -5 | null
-     |   | -5 | zero
-     | 1 | -5 | one
-     | 2 | -5 | two
-     | 3 | -5 | three
-     | 4 | -5 | four
-     | 5 | -5 | five
-     | 6 | -5 | six
-     | 7 | -5 | seven
-     | 8 | -5 | eight
-     | 0 | -5 | zero
-     |   | -5 | null
-     |   | -5 | zero
-     | 1 |    | one
      | 2 |    | two
-     | 3 |    | three
-     | 4 |    | four
-     | 5 |    | five
-     | 6 |    | six
-     | 7 |    | seven
-     | 8 |    | eight
-     | 0 |    | zero
-     |   |    | null
-     |   |    | zero
-     | 1 |    | one
-     | 2 |    | two
-     | 3 |    | three
-     | 4 |    | four
-     | 5 |    | five
-     | 6 |    | six
-     | 7 |    | seven
-     | 8 |    | eight
-     | 0 |    | zero
-     |   |    | null
-     |   |    | zero
-     | 1 |  0 | one
      | 2 |  0 | two
+     | 2 | -1 | two
+     | 2 |    | two
+     | 3 | -5 | three
+     | 3 | -5 | three
+     | 3 |  2 | three
+     | 3 | -3 | three
+     | 3 |  4 | three
+     | 3 |    | three
      | 3 |  0 | three
+     | 3 | -1 | three
+     | 3 |    | three
+     | 4 | -5 | four
+     | 4 | -5 | four
+     | 4 |  2 | four
+     | 4 | -3 | four
+     | 4 |  4 | four
+     | 4 |    | four
      | 4 |  0 | four
-     | 5 |  0 | five
-     | 6 |  0 | six
+     | 4 | -1 | four
+     | 4 |    | four
+     | 7 | -5 | seven
+     | 7 | -5 | seven
+     | 7 |  2 | seven
+     | 7 | -3 | seven
+     | 7 |  4 | seven
+     | 7 |    | seven
      | 7 |  0 | seven
+     | 7 | -1 | seven
+     | 7 |    | seven
+     | 8 | -5 | eight
+     | 8 | -5 | eight
+     | 8 |  2 | eight
+     | 8 | -3 | eight
+     | 8 |  4 | eight
+     | 8 |    | eight
      | 8 |  0 | eight
-     | 0 |  0 | zero
+     | 8 | -1 | eight
+     | 8 |    | eight
+     |   | -5 | null
+     |   | -5 | null
+     |   |  2 | null
+     |   | -3 | null
+     |   |  4 | null
+     |   |    | null
      |   |  0 | null
+     |   | -1 | null
+     |   |    | null
+     |   | -5 | zero
+     |   | -5 | zero
+     |   |  2 | zero
+     |   | -3 | zero
+     |   |  4 | zero
+     |   |    | zero
      |   |  0 | zero
+     |   | -1 | zero
+     |   |    | zero
+     | 1 | -5 | one
+     | 1 | -5 | one
+     | 1 |  2 | one
+     | 1 | -3 | one
+     | 1 |  4 | one
+     | 1 |    | one
+     | 1 |  0 | one
+     | 1 | -1 | one
+     | 1 |    | one
+     | 0 | -5 | zero
+     | 0 | -5 | zero
+     | 0 |  2 | zero
+     | 0 | -3 | zero
+     | 0 |  4 | zero
+     | 0 |    | zero
+     | 0 |  0 | zero
+     | 0 | -1 | zero
+     | 0 |    | zero
+     | 5 | -5 | five
+     | 5 | -5 | five
+     | 5 |  2 | five
+     | 5 | -3 | five
+     | 5 |  4 | five
+     | 5 |    | five
+     | 5 |  0 | five
+     | 5 | -1 | five
+     | 5 |    | five
+     | 6 | -5 | six
+     | 6 | -5 | six
+     | 6 |  2 | six
+     | 6 | -3 | six
+     | 6 |  4 | six
+     | 6 |    | six
+     | 6 |  0 | six
+     | 6 | -1 | six
+     | 6 |    | six
 (99 rows)
 
 SELECT '' AS "xxx", ii, tt, kk
@@ -450,105 +454,105 @@ SELECT '' AS "xxx", ii, tt, kk
     AS tx (ii, jj, tt, ii2, kk);
  xxx | ii |  tt   | kk 
 -----+----+-------+----
-     |  1 | one   | -1
-     |  2 | two   | -1
-     |  3 | three | -1
-     |  4 | four  | -1
-     |  5 | five  | -1
-     |  6 | six   | -1
-     |  7 | seven | -1
-     |  8 | eight | -1
-     |  0 | zero  | -1
-     |    | null  | -1
-     |    | zero  | -1
-     |  1 | one   |  2
-     |  2 | two   |  2
-     |  3 | three |  2
-     |  4 | four  |  2
      |  5 | five  |  2
-     |  6 | six   |  2
-     |  7 | seven |  2
-     |  8 | eight |  2
-     |  0 | zero  |  2
-     |    | null  |  2
-     |    | zero  |  2
-     |  1 | one   | -3
-     |  2 | two   | -3
-     |  3 | three | -3
-     |  4 | four  | -3
      |  5 | five  | -3
-     |  6 | six   | -3
-     |  7 | seven | -3
-     |  8 | eight | -3
-     |  0 | zero  | -3
-     |    | null  | -3
-     |    | zero  | -3
-     |  1 | one   |  4
-     |  2 | two   |  4
-     |  3 | three |  4
-     |  4 | four  |  4
      |  5 | five  |  4
-     |  6 | six   |  4
-     |  7 | seven |  4
-     |  8 | eight |  4
-     |  0 | zero  |  4
-     |    | null  |  4
-     |    | zero  |  4
-     |  1 | one   | -5
-     |  2 | two   | -5
-     |  3 | three | -5
-     |  4 | four  | -5
-     |  5 | five  | -5
-     |  6 | six   | -5
-     |  7 | seven | -5
-     |  8 | eight | -5
-     |  0 | zero  | -5
-     |    | null  | -5
-     |    | zero  | -5
-     |  1 | one   | -5
-     |  2 | two   | -5
-     |  3 | three | -5
-     |  4 | four  | -5
-     |  5 | five  | -5
-     |  6 | six   | -5
-     |  7 | seven | -5
-     |  8 | eight | -5
-     |  0 | zero  | -5
-     |    | null  | -5
-     |    | zero  | -5
-     |  1 | one   |   
-     |  2 | two   |   
-     |  3 | three |   
-     |  4 | four  |   
      |  5 | five  |   
-     |  6 | six   |   
-     |  7 | seven |   
-     |  8 | eight |   
-     |  0 | zero  |   
-     |    | null  |   
-     |    | zero  |   
-     |  1 | one   |   
-     |  2 | two   |   
-     |  3 | three |   
-     |  4 | four  |   
-     |  5 | five  |   
-     |  6 | six   |   
-     |  7 | seven |   
-     |  8 | eight |   
-     |  0 | zero  |   
-     |    | null  |   
-     |    | zero  |   
-     |  1 | one   |  0
-     |  2 | two   |  0
-     |  3 | three |  0
-     |  4 | four  |  0
      |  5 | five  |  0
+     |  5 | five  | -1
+     |  5 | five  |   
+     |  5 | five  | -5
+     |  5 | five  | -5
+     |  6 | six   |  2
+     |  6 | six   | -3
+     |  6 | six   |  4
+     |  6 | six   |   
      |  6 | six   |  0
-     |  7 | seven |  0
-     |  8 | eight |  0
+     |  6 | six   | -1
+     |  6 | six   |   
+     |  6 | six   | -5
+     |  6 | six   | -5
+     |  1 | one   |  2
+     |  1 | one   | -3
+     |  1 | one   |  4
+     |  1 | one   |   
+     |  1 | one   |  0
+     |  1 | one   | -5
+     |  1 | one   | -5
+     |  1 | one   | -1
+     |  1 | one   |   
+     |  0 | zero  |  2
+     |  0 | zero  | -3
+     |  0 | zero  |  4
+     |  0 | zero  |   
      |  0 | zero  |  0
+     |  0 | zero  | -5
+     |  0 | zero  | -5
+     |  0 | zero  | -1
+     |  0 | zero  |   
+     |  2 | two   |  2
+     |  2 | two   | -3
+     |  2 | two   |  4
+     |  2 | two   |   
+     |  2 | two   |  0
+     |  2 | two   | -5
+     |  2 | two   | -5
+     |  2 | two   | -1
+     |  2 | two   |   
+     |  3 | three |  2
+     |  3 | three | -3
+     |  3 | three |  4
+     |  3 | three |   
+     |  3 | three |  0
+     |  3 | three | -5
+     |  3 | three | -5
+     |  3 | three | -1
+     |  3 | three |   
+     |  4 | four  |  2
+     |  4 | four  | -3
+     |  4 | four  |  4
+     |  4 | four  |   
+     |  4 | four  |  0
+     |  4 | four  | -5
+     |  4 | four  | -5
+     |  4 | four  | -1
+     |  4 | four  |   
+     |  7 | seven |  2
+     |  7 | seven | -3
+     |  7 | seven |  4
+     |  7 | seven |   
+     |  7 | seven |  0
+     |  7 | seven | -5
+     |  7 | seven | -5
+     |  7 | seven | -1
+     |  7 | seven |   
+     |  8 | eight |  2
+     |  8 | eight | -3
+     |  8 | eight |  4
+     |  8 | eight |   
+     |  8 | eight |  0
+     |  8 | eight | -5
+     |  8 | eight | -5
+     |  8 | eight | -1
+     |  8 | eight |   
+     |    | null  |  2
+     |    | null  | -3
+     |    | null  |  4
+     |    | null  |   
      |    | null  |  0
+     |    | null  | -5
+     |    | null  | -5
+     |    | null  | -1
+     |    | null  |   
+     |    | zero  |  2
+     |    | zero  | -3
+     |    | zero  |  4
+     |    | zero  |   
      |    | zero  |  0
+     |    | zero  | -5
+     |    | zero  | -5
+     |    | zero  | -1
+     |    | zero  |   
 (99 rows)
 
 SELECT '' AS "xxx", tx.ii, tx.jj, tx.kk
@@ -556,1002 +560,1002 @@ SELECT '' AS "xxx", tx.ii, tx.jj, tx.kk
     AS tx (ii, jj, tt, ii2, kk);
  xxx | ii | jj | kk 
 -----+----+----+----
-     |  1 |  4 | -1
-     |  2 |  3 | -1
-     |  3 |  2 | -1
-     |  4 |  1 | -1
-     |  5 |  0 | -1
-     |  6 |  6 | -1
-     |  7 |  7 | -1
-     |  8 |  8 | -1
-     |  0 |    | -1
-     |    |    | -1
-     |    |  0 | -1
-     |  1 |  4 |  2
-     |  2 |  3 |  2
-     |  3 |  2 |  2
-     |  4 |  1 |  2
      |  5 |  0 |  2
-     |  6 |  6 |  2
-     |  7 |  7 |  2
-     |  8 |  8 |  2
-     |  0 |    |  2
-     |    |    |  2
-     |    |  0 |  2
-     |  1 |  4 | -3
-     |  2 |  3 | -3
-     |  3 |  2 | -3
-     |  4 |  1 | -3
      |  5 |  0 | -3
-     |  6 |  6 | -3
-     |  7 |  7 | -3
-     |  8 |  8 | -3
-     |  0 |    | -3
-     |    |    | -3
-     |    |  0 | -3
-     |  1 |  4 |  4
-     |  2 |  3 |  4
-     |  3 |  2 |  4
-     |  4 |  1 |  4
      |  5 |  0 |  4
-     |  6 |  6 |  4
-     |  7 |  7 |  4
-     |  8 |  8 |  4
-     |  0 |    |  4
-     |    |    |  4
-     |    |  0 |  4
-     |  1 |  4 | -5
-     |  2 |  3 | -5
-     |  3 |  2 | -5
-     |  4 |  1 | -5
-     |  5 |  0 | -5
-     |  6 |  6 | -5
-     |  7 |  7 | -5
-     |  8 |  8 | -5
-     |  0 |    | -5
-     |    |    | -5
-     |    |  0 | -5
-     |  1 |  4 | -5
-     |  2 |  3 | -5
-     |  3 |  2 | -5
-     |  4 |  1 | -5
-     |  5 |  0 | -5
-     |  6 |  6 | -5
-     |  7 |  7 | -5
-     |  8 |  8 | -5
-     |  0 |    | -5
-     |    |    | -5
-     |    |  0 | -5
-     |  1 |  4 |   
-     |  2 |  3 |   
-     |  3 |  2 |   
-     |  4 |  1 |   
      |  5 |  0 |   
-     |  6 |  6 |   
-     |  7 |  7 |   
-     |  8 |  8 |   
-     |  0 |    |   
-     |    |    |   
-     |    |  0 |   
-     |  1 |  4 |   
-     |  2 |  3 |   
-     |  3 |  2 |   
-     |  4 |  1 |   
-     |  5 |  0 |   
-     |  6 |  6 |   
-     |  7 |  7 |   
-     |  8 |  8 |   
-     |  0 |    |   
-     |    |    |   
-     |    |  0 |   
-     |  1 |  4 |  0
-     |  2 |  3 |  0
-     |  3 |  2 |  0
-     |  4 |  1 |  0
      |  5 |  0 |  0
+     |  5 |  0 | -1
+     |  5 |  0 |   
+     |  5 |  0 | -5
+     |  5 |  0 | -5
+     |  6 |  6 |  2
+     |  6 |  6 | -3
+     |  6 |  6 |  4
+     |  6 |  6 |   
      |  6 |  6 |  0
+     |  6 |  6 | -1
+     |  6 |  6 |   
+     |  6 |  6 | -5
+     |  6 |  6 | -5
+     |  2 |  3 |  2
+     |  2 |  3 | -3
+     |  2 |  3 |  4
+     |  2 |  3 |   
+     |  2 |  3 |  0
+     |  2 |  3 | -1
+     |  2 |  3 |   
+     |  2 |  3 | -5
+     |  2 |  3 | -5
+     |  3 |  2 |  2
+     |  3 |  2 | -3
+     |  3 |  2 |  4
+     |  3 |  2 |   
+     |  3 |  2 |  0
+     |  3 |  2 | -1
+     |  3 |  2 |   
+     |  3 |  2 | -5
+     |  3 |  2 | -5
+     |  4 |  1 |  2
+     |  4 |  1 | -3
+     |  4 |  1 |  4
+     |  4 |  1 |   
+     |  4 |  1 |  0
+     |  4 |  1 | -1
+     |  4 |  1 |   
+     |  4 |  1 | -5
+     |  4 |  1 | -5
+     |  7 |  7 |  2
+     |  7 |  7 | -3
+     |  7 |  7 |  4
+     |  7 |  7 |   
      |  7 |  7 |  0
+     |  7 |  7 | -1
+     |  7 |  7 |   
+     |  7 |  7 | -5
+     |  7 |  7 | -5
+     |  8 |  8 |  2
+     |  8 |  8 | -3
+     |  8 |  8 |  4
+     |  8 |  8 |   
      |  8 |  8 |  0
-     |  0 |    |  0
+     |  8 |  8 | -1
+     |  8 |  8 |   
+     |  8 |  8 | -5
+     |  8 |  8 | -5
+     |    |    |  2
+     |    |    | -3
+     |    |    |  4
+     |    |    |   
      |    |    |  0
+     |    |    | -1
+     |    |    |   
+     |    |    | -5
+     |    |    | -5
+     |    |  0 |  2
+     |    |  0 | -3
+     |    |  0 |  4
+     |    |  0 |   
      |    |  0 |  0
+     |    |  0 | -1
+     |    |  0 |   
+     |    |  0 | -5
+     |    |  0 | -5
+     |  1 |  4 |  2
+     |  1 |  4 | -3
+     |  1 |  4 |  4
+     |  1 |  4 |   
+     |  1 |  4 |  0
+     |  1 |  4 | -1
+     |  1 |  4 |   
+     |  1 |  4 | -5
+     |  1 |  4 | -5
+     |  0 |    |  2
+     |  0 |    | -3
+     |  0 |    |  4
+     |  0 |    |   
+     |  0 |    |  0
+     |  0 |    | -1
+     |  0 |    |   
+     |  0 |    | -5
+     |  0 |    | -5
 (99 rows)
 
 SELECT '' AS "xxx", *
   FROM J1_TBL CROSS JOIN J2_TBL a CROSS JOIN J2_TBL b;
  xxx | i | j |   t   | i | k  | i | k  
 -----+---+---+-------+---+----+---+----
-     | 1 | 4 | one   | 1 | -1 | 1 | -1
-     | 1 | 4 | one   | 1 | -1 | 2 |  2
-     | 1 | 4 | one   | 1 | -1 | 3 | -3
-     | 1 | 4 | one   | 1 | -1 | 2 |  4
-     | 1 | 4 | one   | 1 | -1 | 5 | -5
-     | 1 | 4 | one   | 1 | -1 | 5 | -5
-     | 1 | 4 | one   | 1 | -1 | 0 |   
-     | 1 | 4 | one   | 1 | -1 |   |   
-     | 1 | 4 | one   | 1 | -1 |   |  0
-     | 2 | 3 | two   | 1 | -1 | 1 | -1
-     | 2 | 3 | two   | 1 | -1 | 2 |  2
-     | 2 | 3 | two   | 1 | -1 | 3 | -3
-     | 2 | 3 | two   | 1 | -1 | 2 |  4
-     | 2 | 3 | two   | 1 | -1 | 5 | -5
-     | 2 | 3 | two   | 1 | -1 | 5 | -5
-     | 2 | 3 | two   | 1 | -1 | 0 |   
-     | 2 | 3 | two   | 1 | -1 |   |   
-     | 2 | 3 | two   | 1 | -1 |   |  0
-     | 3 | 2 | three | 1 | -1 | 1 | -1
-     | 3 | 2 | three | 1 | -1 | 2 |  2
-     | 3 | 2 | three | 1 | -1 | 3 | -3
-     | 3 | 2 | three | 1 | -1 | 2 |  4
-     | 3 | 2 | three | 1 | -1 | 5 | -5
-     | 3 | 2 | three | 1 | -1 | 5 | -5
-     | 3 | 2 | three | 1 | -1 | 0 |   
-     | 3 | 2 | three | 1 | -1 |   |   
-     | 3 | 2 | three | 1 | -1 |   |  0
-     | 4 | 1 | four  | 1 | -1 | 1 | -1
-     | 4 | 1 | four  | 1 | -1 | 2 |  2
-     | 4 | 1 | four  | 1 | -1 | 3 | -3
-     | 4 | 1 | four  | 1 | -1 | 2 |  4
-     | 4 | 1 | four  | 1 | -1 | 5 | -5
-     | 4 | 1 | four  | 1 | -1 | 5 | -5
-     | 4 | 1 | four  | 1 | -1 | 0 |   
-     | 4 | 1 | four  | 1 | -1 |   |   
-     | 4 | 1 | four  | 1 | -1 |   |  0
-     | 5 | 0 | five  | 1 | -1 | 1 | -1
-     | 5 | 0 | five  | 1 | -1 | 2 |  2
-     | 5 | 0 | five  | 1 | -1 | 3 | -3
-     | 5 | 0 | five  | 1 | -1 | 2 |  4
-     | 5 | 0 | five  | 1 | -1 | 5 | -5
-     | 5 | 0 | five  | 1 | -1 | 5 | -5
-     | 5 | 0 | five  | 1 | -1 | 0 |   
-     | 5 | 0 | five  | 1 | -1 |   |   
-     | 5 | 0 | five  | 1 | -1 |   |  0
-     | 6 | 6 | six   | 1 | -1 | 1 | -1
-     | 6 | 6 | six   | 1 | -1 | 2 |  2
-     | 6 | 6 | six   | 1 | -1 | 3 | -3
-     | 6 | 6 | six   | 1 | -1 | 2 |  4
-     | 6 | 6 | six   | 1 | -1 | 5 | -5
-     | 6 | 6 | six   | 1 | -1 | 5 | -5
-     | 6 | 6 | six   | 1 | -1 | 0 |   
-     | 6 | 6 | six   | 1 | -1 |   |   
-     | 6 | 6 | six   | 1 | -1 |   |  0
-     | 7 | 7 | seven | 1 | -1 | 1 | -1
-     | 7 | 7 | seven | 1 | -1 | 2 |  2
-     | 7 | 7 | seven | 1 | -1 | 3 | -3
-     | 7 | 7 | seven | 1 | -1 | 2 |  4
-     | 7 | 7 | seven | 1 | -1 | 5 | -5
-     | 7 | 7 | seven | 1 | -1 | 5 | -5
-     | 7 | 7 | seven | 1 | -1 | 0 |   
-     | 7 | 7 | seven | 1 | -1 |   |   
-     | 7 | 7 | seven | 1 | -1 |   |  0
-     | 8 | 8 | eight | 1 | -1 | 1 | -1
-     | 8 | 8 | eight | 1 | -1 | 2 |  2
-     | 8 | 8 | eight | 1 | -1 | 3 | -3
-     | 8 | 8 | eight | 1 | -1 | 2 |  4
-     | 8 | 8 | eight | 1 | -1 | 5 | -5
-     | 8 | 8 | eight | 1 | -1 | 5 | -5
-     | 8 | 8 | eight | 1 | -1 | 0 |   
-     | 8 | 8 | eight | 1 | -1 |   |   
-     | 8 | 8 | eight | 1 | -1 |   |  0
-     | 0 |   | zero  | 1 | -1 | 1 | -1
-     | 0 |   | zero  | 1 | -1 | 2 |  2
-     | 0 |   | zero  | 1 | -1 | 3 | -3
-     | 0 |   | zero  | 1 | -1 | 2 |  4
-     | 0 |   | zero  | 1 | -1 | 5 | -5
-     | 0 |   | zero  | 1 | -1 | 5 | -5
-     | 0 |   | zero  | 1 | -1 | 0 |   
-     | 0 |   | zero  | 1 | -1 |   |   
-     | 0 |   | zero  | 1 | -1 |   |  0
-     |   |   | null  | 1 | -1 | 1 | -1
-     |   |   | null  | 1 | -1 | 2 |  2
-     |   |   | null  | 1 | -1 | 3 | -3
-     |   |   | null  | 1 | -1 | 2 |  4
-     |   |   | null  | 1 | -1 | 5 | -5
-     |   |   | null  | 1 | -1 | 5 | -5
-     |   |   | null  | 1 | -1 | 0 |   
-     |   |   | null  | 1 | -1 |   |   
-     |   |   | null  | 1 | -1 |   |  0
-     |   | 0 | zero  | 1 | -1 | 1 | -1
-     |   | 0 | zero  | 1 | -1 | 2 |  2
-     |   | 0 | zero  | 1 | -1 | 3 | -3
-     |   | 0 | zero  | 1 | -1 | 2 |  4
-     |   | 0 | zero  | 1 | -1 | 5 | -5
-     |   | 0 | zero  | 1 | -1 | 5 | -5
-     |   | 0 | zero  | 1 | -1 | 0 |   
-     |   | 0 | zero  | 1 | -1 |   |   
-     |   | 0 | zero  | 1 | -1 |   |  0
-     | 1 | 4 | one   | 2 |  2 | 1 | -1
-     | 1 | 4 | one   | 2 |  2 | 2 |  2
-     | 1 | 4 | one   | 2 |  2 | 3 | -3
-     | 1 | 4 | one   | 2 |  2 | 2 |  4
-     | 1 | 4 | one   | 2 |  2 | 5 | -5
-     | 1 | 4 | one   | 2 |  2 | 5 | -5
-     | 1 | 4 | one   | 2 |  2 | 0 |   
-     | 1 | 4 | one   | 2 |  2 |   |   
-     | 1 | 4 | one   | 2 |  2 |   |  0
      | 2 | 3 | two   | 2 |  2 | 1 | -1
+     | 2 | 3 | two   | 2 |  2 | 0 |   
+     | 2 | 3 | two   | 2 |  2 | 5 | -5
+     | 2 | 3 | two   | 2 |  2 | 5 | -5
      | 2 | 3 | two   | 2 |  2 | 2 |  2
      | 2 | 3 | two   | 2 |  2 | 3 | -3
      | 2 | 3 | two   | 2 |  2 | 2 |  4
-     | 2 | 3 | two   | 2 |  2 | 5 | -5
-     | 2 | 3 | two   | 2 |  2 | 5 | -5
-     | 2 | 3 | two   | 2 |  2 | 0 |   
      | 2 | 3 | two   | 2 |  2 |   |   
      | 2 | 3 | two   | 2 |  2 |   |  0
      | 3 | 2 | three | 2 |  2 | 1 | -1
+     | 3 | 2 | three | 2 |  2 | 0 |   
+     | 3 | 2 | three | 2 |  2 | 5 | -5
+     | 3 | 2 | three | 2 |  2 | 5 | -5
      | 3 | 2 | three | 2 |  2 | 2 |  2
      | 3 | 2 | three | 2 |  2 | 3 | -3
      | 3 | 2 | three | 2 |  2 | 2 |  4
-     | 3 | 2 | three | 2 |  2 | 5 | -5
-     | 3 | 2 | three | 2 |  2 | 5 | -5
-     | 3 | 2 | three | 2 |  2 | 0 |   
      | 3 | 2 | three | 2 |  2 |   |   
      | 3 | 2 | three | 2 |  2 |   |  0
      | 4 | 1 | four  | 2 |  2 | 1 | -1
+     | 4 | 1 | four  | 2 |  2 | 0 |   
+     | 4 | 1 | four  | 2 |  2 | 5 | -5
+     | 4 | 1 | four  | 2 |  2 | 5 | -5
      | 4 | 1 | four  | 2 |  2 | 2 |  2
      | 4 | 1 | four  | 2 |  2 | 3 | -3
      | 4 | 1 | four  | 2 |  2 | 2 |  4
-     | 4 | 1 | four  | 2 |  2 | 5 | -5
-     | 4 | 1 | four  | 2 |  2 | 5 | -5
-     | 4 | 1 | four  | 2 |  2 | 0 |   
      | 4 | 1 | four  | 2 |  2 |   |   
      | 4 | 1 | four  | 2 |  2 |   |  0
-     | 5 | 0 | five  | 2 |  2 | 1 | -1
-     | 5 | 0 | five  | 2 |  2 | 2 |  2
-     | 5 | 0 | five  | 2 |  2 | 3 | -3
-     | 5 | 0 | five  | 2 |  2 | 2 |  4
-     | 5 | 0 | five  | 2 |  2 | 5 | -5
-     | 5 | 0 | five  | 2 |  2 | 5 | -5
-     | 5 | 0 | five  | 2 |  2 | 0 |   
-     | 5 | 0 | five  | 2 |  2 |   |   
-     | 5 | 0 | five  | 2 |  2 |   |  0
-     | 6 | 6 | six   | 2 |  2 | 1 | -1
-     | 6 | 6 | six   | 2 |  2 | 2 |  2
-     | 6 | 6 | six   | 2 |  2 | 3 | -3
-     | 6 | 6 | six   | 2 |  2 | 2 |  4
-     | 6 | 6 | six   | 2 |  2 | 5 | -5
-     | 6 | 6 | six   | 2 |  2 | 5 | -5
-     | 6 | 6 | six   | 2 |  2 | 0 |   
-     | 6 | 6 | six   | 2 |  2 |   |   
-     | 6 | 6 | six   | 2 |  2 |   |  0
      | 7 | 7 | seven | 2 |  2 | 1 | -1
+     | 7 | 7 | seven | 2 |  2 | 0 |   
+     | 7 | 7 | seven | 2 |  2 | 5 | -5
+     | 7 | 7 | seven | 2 |  2 | 5 | -5
      | 7 | 7 | seven | 2 |  2 | 2 |  2
      | 7 | 7 | seven | 2 |  2 | 3 | -3
      | 7 | 7 | seven | 2 |  2 | 2 |  4
-     | 7 | 7 | seven | 2 |  2 | 5 | -5
-     | 7 | 7 | seven | 2 |  2 | 5 | -5
-     | 7 | 7 | seven | 2 |  2 | 0 |   
      | 7 | 7 | seven | 2 |  2 |   |   
      | 7 | 7 | seven | 2 |  2 |   |  0
      | 8 | 8 | eight | 2 |  2 | 1 | -1
+     | 8 | 8 | eight | 2 |  2 | 0 |   
+     | 8 | 8 | eight | 2 |  2 | 5 | -5
+     | 8 | 8 | eight | 2 |  2 | 5 | -5
      | 8 | 8 | eight | 2 |  2 | 2 |  2
      | 8 | 8 | eight | 2 |  2 | 3 | -3
      | 8 | 8 | eight | 2 |  2 | 2 |  4
-     | 8 | 8 | eight | 2 |  2 | 5 | -5
-     | 8 | 8 | eight | 2 |  2 | 5 | -5
-     | 8 | 8 | eight | 2 |  2 | 0 |   
      | 8 | 8 | eight | 2 |  2 |   |   
      | 8 | 8 | eight | 2 |  2 |   |  0
-     | 0 |   | zero  | 2 |  2 | 1 | -1
-     | 0 |   | zero  | 2 |  2 | 2 |  2
-     | 0 |   | zero  | 2 |  2 | 3 | -3
-     | 0 |   | zero  | 2 |  2 | 2 |  4
-     | 0 |   | zero  | 2 |  2 | 5 | -5
-     | 0 |   | zero  | 2 |  2 | 5 | -5
-     | 0 |   | zero  | 2 |  2 | 0 |   
-     | 0 |   | zero  | 2 |  2 |   |   
-     | 0 |   | zero  | 2 |  2 |   |  0
      |   |   | null  | 2 |  2 | 1 | -1
+     |   |   | null  | 2 |  2 | 0 |   
+     |   |   | null  | 2 |  2 | 5 | -5
+     |   |   | null  | 2 |  2 | 5 | -5
      |   |   | null  | 2 |  2 | 2 |  2
      |   |   | null  | 2 |  2 | 3 | -3
      |   |   | null  | 2 |  2 | 2 |  4
-     |   |   | null  | 2 |  2 | 5 | -5
-     |   |   | null  | 2 |  2 | 5 | -5
-     |   |   | null  | 2 |  2 | 0 |   
      |   |   | null  | 2 |  2 |   |   
      |   |   | null  | 2 |  2 |   |  0
      |   | 0 | zero  | 2 |  2 | 1 | -1
+     |   | 0 | zero  | 2 |  2 | 0 |   
+     |   | 0 | zero  | 2 |  2 | 5 | -5
+     |   | 0 | zero  | 2 |  2 | 5 | -5
      |   | 0 | zero  | 2 |  2 | 2 |  2
      |   | 0 | zero  | 2 |  2 | 3 | -3
      |   | 0 | zero  | 2 |  2 | 2 |  4
-     |   | 0 | zero  | 2 |  2 | 5 | -5
-     |   | 0 | zero  | 2 |  2 | 5 | -5
-     |   | 0 | zero  | 2 |  2 | 0 |   
      |   | 0 | zero  | 2 |  2 |   |   
      |   | 0 | zero  | 2 |  2 |   |  0
-     | 1 | 4 | one   | 3 | -3 | 1 | -1
-     | 1 | 4 | one   | 3 | -3 | 2 |  2
-     | 1 | 4 | one   | 3 | -3 | 3 | -3
-     | 1 | 4 | one   | 3 | -3 | 2 |  4
-     | 1 | 4 | one   | 3 | -3 | 5 | -5
-     | 1 | 4 | one   | 3 | -3 | 5 | -5
-     | 1 | 4 | one   | 3 | -3 | 0 |   
-     | 1 | 4 | one   | 3 | -3 |   |   
-     | 1 | 4 | one   | 3 | -3 |   |  0
      | 2 | 3 | two   | 3 | -3 | 1 | -1
+     | 2 | 3 | two   | 3 | -3 | 0 |   
+     | 2 | 3 | two   | 3 | -3 | 5 | -5
+     | 2 | 3 | two   | 3 | -3 | 5 | -5
      | 2 | 3 | two   | 3 | -3 | 2 |  2
      | 2 | 3 | two   | 3 | -3 | 3 | -3
      | 2 | 3 | two   | 3 | -3 | 2 |  4
-     | 2 | 3 | two   | 3 | -3 | 5 | -5
-     | 2 | 3 | two   | 3 | -3 | 5 | -5
-     | 2 | 3 | two   | 3 | -3 | 0 |   
      | 2 | 3 | two   | 3 | -3 |   |   
      | 2 | 3 | two   | 3 | -3 |   |  0
      | 3 | 2 | three | 3 | -3 | 1 | -1
+     | 3 | 2 | three | 3 | -3 | 0 |   
+     | 3 | 2 | three | 3 | -3 | 5 | -5
+     | 3 | 2 | three | 3 | -3 | 5 | -5
      | 3 | 2 | three | 3 | -3 | 2 |  2
      | 3 | 2 | three | 3 | -3 | 3 | -3
      | 3 | 2 | three | 3 | -3 | 2 |  4
-     | 3 | 2 | three | 3 | -3 | 5 | -5
-     | 3 | 2 | three | 3 | -3 | 5 | -5
-     | 3 | 2 | three | 3 | -3 | 0 |   
      | 3 | 2 | three | 3 | -3 |   |   
      | 3 | 2 | three | 3 | -3 |   |  0
      | 4 | 1 | four  | 3 | -3 | 1 | -1
+     | 4 | 1 | four  | 3 | -3 | 0 |   
+     | 4 | 1 | four  | 3 | -3 | 5 | -5
+     | 4 | 1 | four  | 3 | -3 | 5 | -5
      | 4 | 1 | four  | 3 | -3 | 2 |  2
      | 4 | 1 | four  | 3 | -3 | 3 | -3
      | 4 | 1 | four  | 3 | -3 | 2 |  4
-     | 4 | 1 | four  | 3 | -3 | 5 | -5
-     | 4 | 1 | four  | 3 | -3 | 5 | -5
-     | 4 | 1 | four  | 3 | -3 | 0 |   
      | 4 | 1 | four  | 3 | -3 |   |   
      | 4 | 1 | four  | 3 | -3 |   |  0
-     | 5 | 0 | five  | 3 | -3 | 1 | -1
-     | 5 | 0 | five  | 3 | -3 | 2 |  2
-     | 5 | 0 | five  | 3 | -3 | 3 | -3
-     | 5 | 0 | five  | 3 | -3 | 2 |  4
-     | 5 | 0 | five  | 3 | -3 | 5 | -5
-     | 5 | 0 | five  | 3 | -3 | 5 | -5
-     | 5 | 0 | five  | 3 | -3 | 0 |   
-     | 5 | 0 | five  | 3 | -3 |   |   
-     | 5 | 0 | five  | 3 | -3 |   |  0
-     | 6 | 6 | six   | 3 | -3 | 1 | -1
-     | 6 | 6 | six   | 3 | -3 | 2 |  2
-     | 6 | 6 | six   | 3 | -3 | 3 | -3
-     | 6 | 6 | six   | 3 | -3 | 2 |  4
-     | 6 | 6 | six   | 3 | -3 | 5 | -5
-     | 6 | 6 | six   | 3 | -3 | 5 | -5
-     | 6 | 6 | six   | 3 | -3 | 0 |   
-     | 6 | 6 | six   | 3 | -3 |   |   
-     | 6 | 6 | six   | 3 | -3 |   |  0
      | 7 | 7 | seven | 3 | -3 | 1 | -1
+     | 7 | 7 | seven | 3 | -3 | 0 |   
+     | 7 | 7 | seven | 3 | -3 | 5 | -5
+     | 7 | 7 | seven | 3 | -3 | 5 | -5
      | 7 | 7 | seven | 3 | -3 | 2 |  2
      | 7 | 7 | seven | 3 | -3 | 3 | -3
      | 7 | 7 | seven | 3 | -3 | 2 |  4
-     | 7 | 7 | seven | 3 | -3 | 5 | -5
-     | 7 | 7 | seven | 3 | -3 | 5 | -5
-     | 7 | 7 | seven | 3 | -3 | 0 |   
      | 7 | 7 | seven | 3 | -3 |   |   
      | 7 | 7 | seven | 3 | -3 |   |  0
      | 8 | 8 | eight | 3 | -3 | 1 | -1
+     | 8 | 8 | eight | 3 | -3 | 0 |   
+     | 8 | 8 | eight | 3 | -3 | 5 | -5
+     | 8 | 8 | eight | 3 | -3 | 5 | -5
      | 8 | 8 | eight | 3 | -3 | 2 |  2
      | 8 | 8 | eight | 3 | -3 | 3 | -3
      | 8 | 8 | eight | 3 | -3 | 2 |  4
-     | 8 | 8 | eight | 3 | -3 | 5 | -5
-     | 8 | 8 | eight | 3 | -3 | 5 | -5
-     | 8 | 8 | eight | 3 | -3 | 0 |   
      | 8 | 8 | eight | 3 | -3 |   |   
      | 8 | 8 | eight | 3 | -3 |   |  0
-     | 0 |   | zero  | 3 | -3 | 1 | -1
-     | 0 |   | zero  | 3 | -3 | 2 |  2
-     | 0 |   | zero  | 3 | -3 | 3 | -3
-     | 0 |   | zero  | 3 | -3 | 2 |  4
-     | 0 |   | zero  | 3 | -3 | 5 | -5
-     | 0 |   | zero  | 3 | -3 | 5 | -5
-     | 0 |   | zero  | 3 | -3 | 0 |   
-     | 0 |   | zero  | 3 | -3 |   |   
-     | 0 |   | zero  | 3 | -3 |   |  0
      |   |   | null  | 3 | -3 | 1 | -1
+     |   |   | null  | 3 | -3 | 0 |   
+     |   |   | null  | 3 | -3 | 5 | -5
+     |   |   | null  | 3 | -3 | 5 | -5
      |   |   | null  | 3 | -3 | 2 |  2
      |   |   | null  | 3 | -3 | 3 | -3
      |   |   | null  | 3 | -3 | 2 |  4
-     |   |   | null  | 3 | -3 | 5 | -5
-     |   |   | null  | 3 | -3 | 5 | -5
-     |   |   | null  | 3 | -3 | 0 |   
      |   |   | null  | 3 | -3 |   |   
      |   |   | null  | 3 | -3 |   |  0
      |   | 0 | zero  | 3 | -3 | 1 | -1
+     |   | 0 | zero  | 3 | -3 | 0 |   
+     |   | 0 | zero  | 3 | -3 | 5 | -5
+     |   | 0 | zero  | 3 | -3 | 5 | -5
      |   | 0 | zero  | 3 | -3 | 2 |  2
      |   | 0 | zero  | 3 | -3 | 3 | -3
      |   | 0 | zero  | 3 | -3 | 2 |  4
-     |   | 0 | zero  | 3 | -3 | 5 | -5
-     |   | 0 | zero  | 3 | -3 | 5 | -5
-     |   | 0 | zero  | 3 | -3 | 0 |   
      |   | 0 | zero  | 3 | -3 |   |   
      |   | 0 | zero  | 3 | -3 |   |  0
-     | 1 | 4 | one   | 2 |  4 | 1 | -1
-     | 1 | 4 | one   | 2 |  4 | 2 |  2
-     | 1 | 4 | one   | 2 |  4 | 3 | -3
-     | 1 | 4 | one   | 2 |  4 | 2 |  4
-     | 1 | 4 | one   | 2 |  4 | 5 | -5
-     | 1 | 4 | one   | 2 |  4 | 5 | -5
-     | 1 | 4 | one   | 2 |  4 | 0 |   
-     | 1 | 4 | one   | 2 |  4 |   |   
-     | 1 | 4 | one   | 2 |  4 |   |  0
      | 2 | 3 | two   | 2 |  4 | 1 | -1
+     | 2 | 3 | two   | 2 |  4 | 0 |   
+     | 2 | 3 | two   | 2 |  4 | 5 | -5
+     | 2 | 3 | two   | 2 |  4 | 5 | -5
      | 2 | 3 | two   | 2 |  4 | 2 |  2
      | 2 | 3 | two   | 2 |  4 | 3 | -3
      | 2 | 3 | two   | 2 |  4 | 2 |  4
-     | 2 | 3 | two   | 2 |  4 | 5 | -5
-     | 2 | 3 | two   | 2 |  4 | 5 | -5
-     | 2 | 3 | two   | 2 |  4 | 0 |   
      | 2 | 3 | two   | 2 |  4 |   |   
      | 2 | 3 | two   | 2 |  4 |   |  0
      | 3 | 2 | three | 2 |  4 | 1 | -1
+     | 3 | 2 | three | 2 |  4 | 0 |   
+     | 3 | 2 | three | 2 |  4 | 5 | -5
+     | 3 | 2 | three | 2 |  4 | 5 | -5
      | 3 | 2 | three | 2 |  4 | 2 |  2
      | 3 | 2 | three | 2 |  4 | 3 | -3
      | 3 | 2 | three | 2 |  4 | 2 |  4
-     | 3 | 2 | three | 2 |  4 | 5 | -5
-     | 3 | 2 | three | 2 |  4 | 5 | -5
-     | 3 | 2 | three | 2 |  4 | 0 |   
      | 3 | 2 | three | 2 |  4 |   |   
      | 3 | 2 | three | 2 |  4 |   |  0
      | 4 | 1 | four  | 2 |  4 | 1 | -1
+     | 4 | 1 | four  | 2 |  4 | 0 |   
+     | 4 | 1 | four  | 2 |  4 | 5 | -5
+     | 4 | 1 | four  | 2 |  4 | 5 | -5
      | 4 | 1 | four  | 2 |  4 | 2 |  2
      | 4 | 1 | four  | 2 |  4 | 3 | -3
      | 4 | 1 | four  | 2 |  4 | 2 |  4
-     | 4 | 1 | four  | 2 |  4 | 5 | -5
-     | 4 | 1 | four  | 2 |  4 | 5 | -5
-     | 4 | 1 | four  | 2 |  4 | 0 |   
      | 4 | 1 | four  | 2 |  4 |   |   
      | 4 | 1 | four  | 2 |  4 |   |  0
-     | 5 | 0 | five  | 2 |  4 | 1 | -1
-     | 5 | 0 | five  | 2 |  4 | 2 |  2
-     | 5 | 0 | five  | 2 |  4 | 3 | -3
-     | 5 | 0 | five  | 2 |  4 | 2 |  4
-     | 5 | 0 | five  | 2 |  4 | 5 | -5
-     | 5 | 0 | five  | 2 |  4 | 5 | -5
-     | 5 | 0 | five  | 2 |  4 | 0 |   
-     | 5 | 0 | five  | 2 |  4 |   |   
-     | 5 | 0 | five  | 2 |  4 |   |  0
-     | 6 | 6 | six   | 2 |  4 | 1 | -1
-     | 6 | 6 | six   | 2 |  4 | 2 |  2
-     | 6 | 6 | six   | 2 |  4 | 3 | -3
-     | 6 | 6 | six   | 2 |  4 | 2 |  4
-     | 6 | 6 | six   | 2 |  4 | 5 | -5
-     | 6 | 6 | six   | 2 |  4 | 5 | -5
-     | 6 | 6 | six   | 2 |  4 | 0 |   
-     | 6 | 6 | six   | 2 |  4 |   |   
-     | 6 | 6 | six   | 2 |  4 |   |  0
      | 7 | 7 | seven | 2 |  4 | 1 | -1
+     | 7 | 7 | seven | 2 |  4 | 0 |   
+     | 7 | 7 | seven | 2 |  4 | 5 | -5
+     | 7 | 7 | seven | 2 |  4 | 5 | -5
      | 7 | 7 | seven | 2 |  4 | 2 |  2
      | 7 | 7 | seven | 2 |  4 | 3 | -3
      | 7 | 7 | seven | 2 |  4 | 2 |  4
-     | 7 | 7 | seven | 2 |  4 | 5 | -5
-     | 7 | 7 | seven | 2 |  4 | 5 | -5
-     | 7 | 7 | seven | 2 |  4 | 0 |   
      | 7 | 7 | seven | 2 |  4 |   |   
      | 7 | 7 | seven | 2 |  4 |   |  0
      | 8 | 8 | eight | 2 |  4 | 1 | -1
+     | 8 | 8 | eight | 2 |  4 | 0 |   
+     | 8 | 8 | eight | 2 |  4 | 5 | -5
+     | 8 | 8 | eight | 2 |  4 | 5 | -5
      | 8 | 8 | eight | 2 |  4 | 2 |  2
      | 8 | 8 | eight | 2 |  4 | 3 | -3
      | 8 | 8 | eight | 2 |  4 | 2 |  4
-     | 8 | 8 | eight | 2 |  4 | 5 | -5
-     | 8 | 8 | eight | 2 |  4 | 5 | -5
-     | 8 | 8 | eight | 2 |  4 | 0 |   
      | 8 | 8 | eight | 2 |  4 |   |   
      | 8 | 8 | eight | 2 |  4 |   |  0
-     | 0 |   | zero  | 2 |  4 | 1 | -1
-     | 0 |   | zero  | 2 |  4 | 2 |  2
-     | 0 |   | zero  | 2 |  4 | 3 | -3
-     | 0 |   | zero  | 2 |  4 | 2 |  4
-     | 0 |   | zero  | 2 |  4 | 5 | -5
-     | 0 |   | zero  | 2 |  4 | 5 | -5
-     | 0 |   | zero  | 2 |  4 | 0 |   
-     | 0 |   | zero  | 2 |  4 |   |   
-     | 0 |   | zero  | 2 |  4 |   |  0
      |   |   | null  | 2 |  4 | 1 | -1
+     |   |   | null  | 2 |  4 | 0 |   
+     |   |   | null  | 2 |  4 | 5 | -5
+     |   |   | null  | 2 |  4 | 5 | -5
      |   |   | null  | 2 |  4 | 2 |  2
      |   |   | null  | 2 |  4 | 3 | -3
      |   |   | null  | 2 |  4 | 2 |  4
-     |   |   | null  | 2 |  4 | 5 | -5
-     |   |   | null  | 2 |  4 | 5 | -5
-     |   |   | null  | 2 |  4 | 0 |   
      |   |   | null  | 2 |  4 |   |   
      |   |   | null  | 2 |  4 |   |  0
      |   | 0 | zero  | 2 |  4 | 1 | -1
+     |   | 0 | zero  | 2 |  4 | 0 |   
+     |   | 0 | zero  | 2 |  4 | 5 | -5
+     |   | 0 | zero  | 2 |  4 | 5 | -5
      |   | 0 | zero  | 2 |  4 | 2 |  2
      |   | 0 | zero  | 2 |  4 | 3 | -3
      |   | 0 | zero  | 2 |  4 | 2 |  4
-     |   | 0 | zero  | 2 |  4 | 5 | -5
-     |   | 0 | zero  | 2 |  4 | 5 | -5
-     |   | 0 | zero  | 2 |  4 | 0 |   
      |   | 0 | zero  | 2 |  4 |   |   
      |   | 0 | zero  | 2 |  4 |   |  0
-     | 1 | 4 | one   | 5 | -5 | 1 | -1
-     | 1 | 4 | one   | 5 | -5 | 2 |  2
-     | 1 | 4 | one   | 5 | -5 | 3 | -3
-     | 1 | 4 | one   | 5 | -5 | 2 |  4
-     | 1 | 4 | one   | 5 | -5 | 5 | -5
-     | 1 | 4 | one   | 5 | -5 | 5 | -5
-     | 1 | 4 | one   | 5 | -5 | 0 |   
-     | 1 | 4 | one   | 5 | -5 |   |   
-     | 1 | 4 | one   | 5 | -5 |   |  0
-     | 2 | 3 | two   | 5 | -5 | 1 | -1
-     | 2 | 3 | two   | 5 | -5 | 2 |  2
-     | 2 | 3 | two   | 5 | -5 | 3 | -3
-     | 2 | 3 | two   | 5 | -5 | 2 |  4
-     | 2 | 3 | two   | 5 | -5 | 5 | -5
-     | 2 | 3 | two   | 5 | -5 | 5 | -5
-     | 2 | 3 | two   | 5 | -5 | 0 |   
-     | 2 | 3 | two   | 5 | -5 |   |   
-     | 2 | 3 | two   | 5 | -5 |   |  0
-     | 3 | 2 | three | 5 | -5 | 1 | -1
-     | 3 | 2 | three | 5 | -5 | 2 |  2
-     | 3 | 2 | three | 5 | -5 | 3 | -3
-     | 3 | 2 | three | 5 | -5 | 2 |  4
-     | 3 | 2 | three | 5 | -5 | 5 | -5
-     | 3 | 2 | three | 5 | -5 | 5 | -5
-     | 3 | 2 | three | 5 | -5 | 0 |   
-     | 3 | 2 | three | 5 | -5 |   |   
-     | 3 | 2 | three | 5 | -5 |   |  0
-     | 4 | 1 | four  | 5 | -5 | 1 | -1
-     | 4 | 1 | four  | 5 | -5 | 2 |  2
-     | 4 | 1 | four  | 5 | -5 | 3 | -3
-     | 4 | 1 | four  | 5 | -5 | 2 |  4
-     | 4 | 1 | four  | 5 | -5 | 5 | -5
-     | 4 | 1 | four  | 5 | -5 | 5 | -5
-     | 4 | 1 | four  | 5 | -5 | 0 |   
-     | 4 | 1 | four  | 5 | -5 |   |   
-     | 4 | 1 | four  | 5 | -5 |   |  0
-     | 5 | 0 | five  | 5 | -5 | 1 | -1
-     | 5 | 0 | five  | 5 | -5 | 2 |  2
-     | 5 | 0 | five  | 5 | -5 | 3 | -3
-     | 5 | 0 | five  | 5 | -5 | 2 |  4
-     | 5 | 0 | five  | 5 | -5 | 5 | -5
-     | 5 | 0 | five  | 5 | -5 | 5 | -5
-     | 5 | 0 | five  | 5 | -5 | 0 |   
-     | 5 | 0 | five  | 5 | -5 |   |   
-     | 5 | 0 | five  | 5 | -5 |   |  0
-     | 6 | 6 | six   | 5 | -5 | 1 | -1
-     | 6 | 6 | six   | 5 | -5 | 2 |  2
-     | 6 | 6 | six   | 5 | -5 | 3 | -3
-     | 6 | 6 | six   | 5 | -5 | 2 |  4
-     | 6 | 6 | six   | 5 | -5 | 5 | -5
-     | 6 | 6 | six   | 5 | -5 | 5 | -5
-     | 6 | 6 | six   | 5 | -5 | 0 |   
-     | 6 | 6 | six   | 5 | -5 |   |   
-     | 6 | 6 | six   | 5 | -5 |   |  0
-     | 7 | 7 | seven | 5 | -5 | 1 | -1
-     | 7 | 7 | seven | 5 | -5 | 2 |  2
-     | 7 | 7 | seven | 5 | -5 | 3 | -3
-     | 7 | 7 | seven | 5 | -5 | 2 |  4
-     | 7 | 7 | seven | 5 | -5 | 5 | -5
-     | 7 | 7 | seven | 5 | -5 | 5 | -5
-     | 7 | 7 | seven | 5 | -5 | 0 |   
-     | 7 | 7 | seven | 5 | -5 |   |   
-     | 7 | 7 | seven | 5 | -5 |   |  0
-     | 8 | 8 | eight | 5 | -5 | 1 | -1
-     | 8 | 8 | eight | 5 | -5 | 2 |  2
-     | 8 | 8 | eight | 5 | -5 | 3 | -3
-     | 8 | 8 | eight | 5 | -5 | 2 |  4
-     | 8 | 8 | eight | 5 | -5 | 5 | -5
-     | 8 | 8 | eight | 5 | -5 | 5 | -5
-     | 8 | 8 | eight | 5 | -5 | 0 |   
-     | 8 | 8 | eight | 5 | -5 |   |   
-     | 8 | 8 | eight | 5 | -5 |   |  0
-     | 0 |   | zero  | 5 | -5 | 1 | -1
-     | 0 |   | zero  | 5 | -5 | 2 |  2
-     | 0 |   | zero  | 5 | -5 | 3 | -3
-     | 0 |   | zero  | 5 | -5 | 2 |  4
-     | 0 |   | zero  | 5 | -5 | 5 | -5
-     | 0 |   | zero  | 5 | -5 | 5 | -5
-     | 0 |   | zero  | 5 | -5 | 0 |   
-     | 0 |   | zero  | 5 | -5 |   |   
-     | 0 |   | zero  | 5 | -5 |   |  0
-     |   |   | null  | 5 | -5 | 1 | -1
-     |   |   | null  | 5 | -5 | 2 |  2
-     |   |   | null  | 5 | -5 | 3 | -3
-     |   |   | null  | 5 | -5 | 2 |  4
-     |   |   | null  | 5 | -5 | 5 | -5
-     |   |   | null  | 5 | -5 | 5 | -5
-     |   |   | null  | 5 | -5 | 0 |   
-     |   |   | null  | 5 | -5 |   |   
-     |   |   | null  | 5 | -5 |   |  0
-     |   | 0 | zero  | 5 | -5 | 1 | -1
-     |   | 0 | zero  | 5 | -5 | 2 |  2
-     |   | 0 | zero  | 5 | -5 | 3 | -3
-     |   | 0 | zero  | 5 | -5 | 2 |  4
-     |   | 0 | zero  | 5 | -5 | 5 | -5
-     |   | 0 | zero  | 5 | -5 | 5 | -5
-     |   | 0 | zero  | 5 | -5 | 0 |   
-     |   | 0 | zero  | 5 | -5 |   |   
-     |   | 0 | zero  | 5 | -5 |   |  0
-     | 1 | 4 | one   | 5 | -5 | 1 | -1
-     | 1 | 4 | one   | 5 | -5 | 2 |  2
-     | 1 | 4 | one   | 5 | -5 | 3 | -3
-     | 1 | 4 | one   | 5 | -5 | 2 |  4
-     | 1 | 4 | one   | 5 | -5 | 5 | -5
-     | 1 | 4 | one   | 5 | -5 | 5 | -5
-     | 1 | 4 | one   | 5 | -5 | 0 |   
-     | 1 | 4 | one   | 5 | -5 |   |   
-     | 1 | 4 | one   | 5 | -5 |   |  0
-     | 2 | 3 | two   | 5 | -5 | 1 | -1
-     | 2 | 3 | two   | 5 | -5 | 2 |  2
-     | 2 | 3 | two   | 5 | -5 | 3 | -3
-     | 2 | 3 | two   | 5 | -5 | 2 |  4
-     | 2 | 3 | two   | 5 | -5 | 5 | -5
-     | 2 | 3 | two   | 5 | -5 | 5 | -5
-     | 2 | 3 | two   | 5 | -5 | 0 |   
-     | 2 | 3 | two   | 5 | -5 |   |   
-     | 2 | 3 | two   | 5 | -5 |   |  0
-     | 3 | 2 | three | 5 | -5 | 1 | -1
-     | 3 | 2 | three | 5 | -5 | 2 |  2
-     | 3 | 2 | three | 5 | -5 | 3 | -3
-     | 3 | 2 | three | 5 | -5 | 2 |  4
-     | 3 | 2 | three | 5 | -5 | 5 | -5
-     | 3 | 2 | three | 5 | -5 | 5 | -5
-     | 3 | 2 | three | 5 | -5 | 0 |   
-     | 3 | 2 | three | 5 | -5 |   |   
-     | 3 | 2 | three | 5 | -5 |   |  0
-     | 4 | 1 | four  | 5 | -5 | 1 | -1
-     | 4 | 1 | four  | 5 | -5 | 2 |  2
-     | 4 | 1 | four  | 5 | -5 | 3 | -3
-     | 4 | 1 | four  | 5 | -5 | 2 |  4
-     | 4 | 1 | four  | 5 | -5 | 5 | -5
-     | 4 | 1 | four  | 5 | -5 | 5 | -5
-     | 4 | 1 | four  | 5 | -5 | 0 |   
-     | 4 | 1 | four  | 5 | -5 |   |   
-     | 4 | 1 | four  | 5 | -5 |   |  0
-     | 5 | 0 | five  | 5 | -5 | 1 | -1
-     | 5 | 0 | five  | 5 | -5 | 2 |  2
-     | 5 | 0 | five  | 5 | -5 | 3 | -3
-     | 5 | 0 | five  | 5 | -5 | 2 |  4
-     | 5 | 0 | five  | 5 | -5 | 5 | -5
-     | 5 | 0 | five  | 5 | -5 | 5 | -5
-     | 5 | 0 | five  | 5 | -5 | 0 |   
-     | 5 | 0 | five  | 5 | -5 |   |   
-     | 5 | 0 | five  | 5 | -5 |   |  0
-     | 6 | 6 | six   | 5 | -5 | 1 | -1
-     | 6 | 6 | six   | 5 | -5 | 2 |  2
-     | 6 | 6 | six   | 5 | -5 | 3 | -3
-     | 6 | 6 | six   | 5 | -5 | 2 |  4
-     | 6 | 6 | six   | 5 | -5 | 5 | -5
-     | 6 | 6 | six   | 5 | -5 | 5 | -5
-     | 6 | 6 | six   | 5 | -5 | 0 |   
-     | 6 | 6 | six   | 5 | -5 |   |   
-     | 6 | 6 | six   | 5 | -5 |   |  0
-     | 7 | 7 | seven | 5 | -5 | 1 | -1
-     | 7 | 7 | seven | 5 | -5 | 2 |  2
-     | 7 | 7 | seven | 5 | -5 | 3 | -3
-     | 7 | 7 | seven | 5 | -5 | 2 |  4
-     | 7 | 7 | seven | 5 | -5 | 5 | -5
-     | 7 | 7 | seven | 5 | -5 | 5 | -5
-     | 7 | 7 | seven | 5 | -5 | 0 |   
-     | 7 | 7 | seven | 5 | -5 |   |   
-     | 7 | 7 | seven | 5 | -5 |   |  0
-     | 8 | 8 | eight | 5 | -5 | 1 | -1
-     | 8 | 8 | eight | 5 | -5 | 2 |  2
-     | 8 | 8 | eight | 5 | -5 | 3 | -3
-     | 8 | 8 | eight | 5 | -5 | 2 |  4
-     | 8 | 8 | eight | 5 | -5 | 5 | -5
-     | 8 | 8 | eight | 5 | -5 | 5 | -5
-     | 8 | 8 | eight | 5 | -5 | 0 |   
-     | 8 | 8 | eight | 5 | -5 |   |   
-     | 8 | 8 | eight | 5 | -5 |   |  0
-     | 0 |   | zero  | 5 | -5 | 1 | -1
-     | 0 |   | zero  | 5 | -5 | 2 |  2
-     | 0 |   | zero  | 5 | -5 | 3 | -3
-     | 0 |   | zero  | 5 | -5 | 2 |  4
-     | 0 |   | zero  | 5 | -5 | 5 | -5
-     | 0 |   | zero  | 5 | -5 | 5 | -5
-     | 0 |   | zero  | 5 | -5 | 0 |   
-     | 0 |   | zero  | 5 | -5 |   |   
-     | 0 |   | zero  | 5 | -5 |   |  0
-     |   |   | null  | 5 | -5 | 1 | -1
-     |   |   | null  | 5 | -5 | 2 |  2
-     |   |   | null  | 5 | -5 | 3 | -3
-     |   |   | null  | 5 | -5 | 2 |  4
-     |   |   | null  | 5 | -5 | 5 | -5
-     |   |   | null  | 5 | -5 | 5 | -5
-     |   |   | null  | 5 | -5 | 0 |   
-     |   |   | null  | 5 | -5 |   |   
-     |   |   | null  | 5 | -5 |   |  0
-     |   | 0 | zero  | 5 | -5 | 1 | -1
-     |   | 0 | zero  | 5 | -5 | 2 |  2
-     |   | 0 | zero  | 5 | -5 | 3 | -3
-     |   | 0 | zero  | 5 | -5 | 2 |  4
-     |   | 0 | zero  | 5 | -5 | 5 | -5
-     |   | 0 | zero  | 5 | -5 | 5 | -5
-     |   | 0 | zero  | 5 | -5 | 0 |   
-     |   | 0 | zero  | 5 | -5 |   |   
-     |   | 0 | zero  | 5 | -5 |   |  0
-     | 1 | 4 | one   | 0 |    | 1 | -1
-     | 1 | 4 | one   | 0 |    | 2 |  2
-     | 1 | 4 | one   | 0 |    | 3 | -3
-     | 1 | 4 | one   | 0 |    | 2 |  4
-     | 1 | 4 | one   | 0 |    | 5 | -5
-     | 1 | 4 | one   | 0 |    | 5 | -5
-     | 1 | 4 | one   | 0 |    | 0 |   
-     | 1 | 4 | one   | 0 |    |   |   
-     | 1 | 4 | one   | 0 |    |   |  0
-     | 2 | 3 | two   | 0 |    | 1 | -1
-     | 2 | 3 | two   | 0 |    | 2 |  2
-     | 2 | 3 | two   | 0 |    | 3 | -3
-     | 2 | 3 | two   | 0 |    | 2 |  4
-     | 2 | 3 | two   | 0 |    | 5 | -5
-     | 2 | 3 | two   | 0 |    | 5 | -5
-     | 2 | 3 | two   | 0 |    | 0 |   
-     | 2 | 3 | two   | 0 |    |   |   
-     | 2 | 3 | two   | 0 |    |   |  0
-     | 3 | 2 | three | 0 |    | 1 | -1
-     | 3 | 2 | three | 0 |    | 2 |  2
-     | 3 | 2 | three | 0 |    | 3 | -3
-     | 3 | 2 | three | 0 |    | 2 |  4
-     | 3 | 2 | three | 0 |    | 5 | -5
-     | 3 | 2 | three | 0 |    | 5 | -5
-     | 3 | 2 | three | 0 |    | 0 |   
-     | 3 | 2 | three | 0 |    |   |   
-     | 3 | 2 | three | 0 |    |   |  0
-     | 4 | 1 | four  | 0 |    | 1 | -1
-     | 4 | 1 | four  | 0 |    | 2 |  2
-     | 4 | 1 | four  | 0 |    | 3 | -3
-     | 4 | 1 | four  | 0 |    | 2 |  4
-     | 4 | 1 | four  | 0 |    | 5 | -5
-     | 4 | 1 | four  | 0 |    | 5 | -5
-     | 4 | 1 | four  | 0 |    | 0 |   
-     | 4 | 1 | four  | 0 |    |   |   
-     | 4 | 1 | four  | 0 |    |   |  0
-     | 5 | 0 | five  | 0 |    | 1 | -1
-     | 5 | 0 | five  | 0 |    | 2 |  2
-     | 5 | 0 | five  | 0 |    | 3 | -3
-     | 5 | 0 | five  | 0 |    | 2 |  4
-     | 5 | 0 | five  | 0 |    | 5 | -5
-     | 5 | 0 | five  | 0 |    | 5 | -5
-     | 5 | 0 | five  | 0 |    | 0 |   
-     | 5 | 0 | five  | 0 |    |   |   
-     | 5 | 0 | five  | 0 |    |   |  0
-     | 6 | 6 | six   | 0 |    | 1 | -1
-     | 6 | 6 | six   | 0 |    | 2 |  2
-     | 6 | 6 | six   | 0 |    | 3 | -3
-     | 6 | 6 | six   | 0 |    | 2 |  4
-     | 6 | 6 | six   | 0 |    | 5 | -5
-     | 6 | 6 | six   | 0 |    | 5 | -5
-     | 6 | 6 | six   | 0 |    | 0 |   
-     | 6 | 6 | six   | 0 |    |   |   
-     | 6 | 6 | six   | 0 |    |   |  0
-     | 7 | 7 | seven | 0 |    | 1 | -1
-     | 7 | 7 | seven | 0 |    | 2 |  2
-     | 7 | 7 | seven | 0 |    | 3 | -3
-     | 7 | 7 | seven | 0 |    | 2 |  4
-     | 7 | 7 | seven | 0 |    | 5 | -5
-     | 7 | 7 | seven | 0 |    | 5 | -5
-     | 7 | 7 | seven | 0 |    | 0 |   
-     | 7 | 7 | seven | 0 |    |   |   
-     | 7 | 7 | seven | 0 |    |   |  0
-     | 8 | 8 | eight | 0 |    | 1 | -1
-     | 8 | 8 | eight | 0 |    | 2 |  2
-     | 8 | 8 | eight | 0 |    | 3 | -3
-     | 8 | 8 | eight | 0 |    | 2 |  4
-     | 8 | 8 | eight | 0 |    | 5 | -5
-     | 8 | 8 | eight | 0 |    | 5 | -5
-     | 8 | 8 | eight | 0 |    | 0 |   
-     | 8 | 8 | eight | 0 |    |   |   
-     | 8 | 8 | eight | 0 |    |   |  0
-     | 0 |   | zero  | 0 |    | 1 | -1
-     | 0 |   | zero  | 0 |    | 2 |  2
-     | 0 |   | zero  | 0 |    | 3 | -3
-     | 0 |   | zero  | 0 |    | 2 |  4
-     | 0 |   | zero  | 0 |    | 5 | -5
-     | 0 |   | zero  | 0 |    | 5 | -5
-     | 0 |   | zero  | 0 |    | 0 |   
-     | 0 |   | zero  | 0 |    |   |   
-     | 0 |   | zero  | 0 |    |   |  0
-     |   |   | null  | 0 |    | 1 | -1
-     |   |   | null  | 0 |    | 2 |  2
-     |   |   | null  | 0 |    | 3 | -3
-     |   |   | null  | 0 |    | 2 |  4
-     |   |   | null  | 0 |    | 5 | -5
-     |   |   | null  | 0 |    | 5 | -5
-     |   |   | null  | 0 |    | 0 |   
-     |   |   | null  | 0 |    |   |   
-     |   |   | null  | 0 |    |   |  0
-     |   | 0 | zero  | 0 |    | 1 | -1
-     |   | 0 | zero  | 0 |    | 2 |  2
-     |   | 0 | zero  | 0 |    | 3 | -3
-     |   | 0 | zero  | 0 |    | 2 |  4
-     |   | 0 | zero  | 0 |    | 5 | -5
-     |   | 0 | zero  | 0 |    | 5 | -5
-     |   | 0 | zero  | 0 |    | 0 |   
-     |   | 0 | zero  | 0 |    |   |   
-     |   | 0 | zero  | 0 |    |   |  0
+     | 2 | 3 | two   |   |    | 1 | -1
+     | 2 | 3 | two   |   |    | 0 |   
+     | 2 | 3 | two   |   |    | 5 | -5
+     | 2 | 3 | two   |   |    | 5 | -5
+     | 2 | 3 | two   |   |    | 2 |  2
+     | 2 | 3 | two   |   |    | 3 | -3
+     | 1 | 4 | one   | 2 |  2 | 1 | -1
+     | 1 | 4 | one   | 2 |  2 | 0 |   
+     | 1 | 4 | one   | 2 |  2 | 5 | -5
+     | 1 | 4 | one   | 2 |  2 | 5 | -5
+     | 1 | 4 | one   | 2 |  2 | 2 |  2
+     | 1 | 4 | one   | 2 |  2 | 3 | -3
+     | 1 | 4 | one   | 2 |  2 | 2 |  4
+     | 1 | 4 | one   | 2 |  2 |   |   
+     | 1 | 4 | one   | 2 |  2 |   |  0
+     | 0 |   | zero  | 2 |  2 | 1 | -1
+     | 0 |   | zero  | 2 |  2 | 0 |   
+     | 0 |   | zero  | 2 |  2 | 5 | -5
+     | 0 |   | zero  | 2 |  2 | 5 | -5
+     | 0 |   | zero  | 2 |  2 | 2 |  2
+     | 0 |   | zero  | 2 |  2 | 3 | -3
+     | 0 |   | zero  | 2 |  2 | 2 |  4
+     | 0 |   | zero  | 2 |  2 |   |   
+     | 0 |   | zero  | 2 |  2 |   |  0
+     | 1 | 4 | one   | 3 | -3 | 1 | -1
+     | 1 | 4 | one   | 3 | -3 | 0 |   
+     | 1 | 4 | one   | 3 | -3 | 5 | -5
+     | 1 | 4 | one   | 3 | -3 | 5 | -5
+     | 1 | 4 | one   | 3 | -3 | 2 |  2
+     | 1 | 4 | one   | 3 | -3 | 3 | -3
+     | 1 | 4 | one   | 3 | -3 | 2 |  4
+     | 1 | 4 | one   | 3 | -3 |   |   
+     | 1 | 4 | one   | 3 | -3 |   |  0
+     | 0 |   | zero  | 3 | -3 | 1 | -1
+     | 0 |   | zero  | 3 | -3 | 0 |   
+     | 0 |   | zero  | 3 | -3 | 5 | -5
+     | 0 |   | zero  | 3 | -3 | 5 | -5
+     | 0 |   | zero  | 3 | -3 | 2 |  2
+     | 0 |   | zero  | 3 | -3 | 3 | -3
+     | 0 |   | zero  | 3 | -3 | 2 |  4
+     | 0 |   | zero  | 3 | -3 |   |   
+     | 0 |   | zero  | 3 | -3 |   |  0
+     | 1 | 4 | one   | 2 |  4 | 1 | -1
+     | 1 | 4 | one   | 2 |  4 | 0 |   
+     | 1 | 4 | one   | 2 |  4 | 5 | -5
+     | 1 | 4 | one   | 2 |  4 | 5 | -5
+     | 1 | 4 | one   | 2 |  4 | 2 |  2
+     | 1 | 4 | one   | 2 |  4 | 3 | -3
+     | 1 | 4 | one   | 2 |  4 | 2 |  4
+     | 1 | 4 | one   | 2 |  4 |   |   
+     | 1 | 4 | one   | 2 |  4 |   |  0
+     | 0 |   | zero  | 2 |  4 | 1 | -1
+     | 0 |   | zero  | 2 |  4 | 0 |   
+     | 0 |   | zero  | 2 |  4 | 5 | -5
+     | 0 |   | zero  | 2 |  4 | 5 | -5
+     | 0 |   | zero  | 2 |  4 | 2 |  2
+     | 0 |   | zero  | 2 |  4 | 3 | -3
+     | 0 |   | zero  | 2 |  4 | 2 |  4
+     | 0 |   | zero  | 2 |  4 |   |   
+     | 0 |   | zero  | 2 |  4 |   |  0
      | 1 | 4 | one   |   |    | 1 | -1
+     | 1 | 4 | one   |   |    | 0 |   
+     | 1 | 4 | one   |   |    | 5 | -5
+     | 1 | 4 | one   |   |    | 5 | -5
      | 1 | 4 | one   |   |    | 2 |  2
      | 1 | 4 | one   |   |    | 3 | -3
      | 1 | 4 | one   |   |    | 2 |  4
-     | 1 | 4 | one   |   |    | 5 | -5
-     | 1 | 4 | one   |   |    | 5 | -5
-     | 1 | 4 | one   |   |    | 0 |   
      | 1 | 4 | one   |   |    |   |   
      | 1 | 4 | one   |   |    |   |  0
-     | 2 | 3 | two   |   |    | 1 | -1
-     | 2 | 3 | two   |   |    | 2 |  2
-     | 2 | 3 | two   |   |    | 3 | -3
-     | 2 | 3 | two   |   |    | 2 |  4
-     | 2 | 3 | two   |   |    | 5 | -5
-     | 2 | 3 | two   |   |    | 5 | -5
-     | 2 | 3 | two   |   |    | 0 |   
-     | 2 | 3 | two   |   |    |   |   
-     | 2 | 3 | two   |   |    |   |  0
-     | 3 | 2 | three |   |    | 1 | -1
-     | 3 | 2 | three |   |    | 2 |  2
-     | 3 | 2 | three |   |    | 3 | -3
-     | 3 | 2 | three |   |    | 2 |  4
-     | 3 | 2 | three |   |    | 5 | -5
-     | 3 | 2 | three |   |    | 5 | -5
-     | 3 | 2 | three |   |    | 0 |   
-     | 3 | 2 | three |   |    |   |   
-     | 3 | 2 | three |   |    |   |  0
-     | 4 | 1 | four  |   |    | 1 | -1
-     | 4 | 1 | four  |   |    | 2 |  2
-     | 4 | 1 | four  |   |    | 3 | -3
-     | 4 | 1 | four  |   |    | 2 |  4
-     | 4 | 1 | four  |   |    | 5 | -5
-     | 4 | 1 | four  |   |    | 5 | -5
-     | 4 | 1 | four  |   |    | 0 |   
-     | 4 | 1 | four  |   |    |   |   
-     | 4 | 1 | four  |   |    |   |  0
-     | 5 | 0 | five  |   |    | 1 | -1
-     | 5 | 0 | five  |   |    | 2 |  2
-     | 5 | 0 | five  |   |    | 3 | -3
-     | 5 | 0 | five  |   |    | 2 |  4
-     | 5 | 0 | five  |   |    | 5 | -5
-     | 5 | 0 | five  |   |    | 5 | -5
-     | 5 | 0 | five  |   |    | 0 |   
-     | 5 | 0 | five  |   |    |   |   
-     | 5 | 0 | five  |   |    |   |  0
-     | 6 | 6 | six   |   |    | 1 | -1
-     | 6 | 6 | six   |   |    | 2 |  2
-     | 6 | 6 | six   |   |    | 3 | -3
-     | 6 | 6 | six   |   |    | 2 |  4
-     | 6 | 6 | six   |   |    | 5 | -5
-     | 6 | 6 | six   |   |    | 5 | -5
-     | 6 | 6 | six   |   |    | 0 |   
-     | 6 | 6 | six   |   |    |   |   
-     | 6 | 6 | six   |   |    |   |  0
-     | 7 | 7 | seven |   |    | 1 | -1
-     | 7 | 7 | seven |   |    | 2 |  2
-     | 7 | 7 | seven |   |    | 3 | -3
-     | 7 | 7 | seven |   |    | 2 |  4
-     | 7 | 7 | seven |   |    | 5 | -5
-     | 7 | 7 | seven |   |    | 5 | -5
-     | 7 | 7 | seven |   |    | 0 |   
-     | 7 | 7 | seven |   |    |   |   
-     | 7 | 7 | seven |   |    |   |  0
-     | 8 | 8 | eight |   |    | 1 | -1
-     | 8 | 8 | eight |   |    | 2 |  2
-     | 8 | 8 | eight |   |    | 3 | -3
-     | 8 | 8 | eight |   |    | 2 |  4
-     | 8 | 8 | eight |   |    | 5 | -5
-     | 8 | 8 | eight |   |    | 5 | -5
-     | 8 | 8 | eight |   |    | 0 |   
-     | 8 | 8 | eight |   |    |   |   
-     | 8 | 8 | eight |   |    |   |  0
      | 0 |   | zero  |   |    | 1 | -1
+     | 0 |   | zero  |   |    | 0 |   
+     | 0 |   | zero  |   |    | 5 | -5
+     | 0 |   | zero  |   |    | 5 | -5
      | 0 |   | zero  |   |    | 2 |  2
      | 0 |   | zero  |   |    | 3 | -3
      | 0 |   | zero  |   |    | 2 |  4
-     | 0 |   | zero  |   |    | 5 | -5
-     | 0 |   | zero  |   |    | 5 | -5
-     | 0 |   | zero  |   |    | 0 |   
      | 0 |   | zero  |   |    |   |   
      | 0 |   | zero  |   |    |   |  0
-     |   |   | null  |   |    | 1 | -1
-     |   |   | null  |   |    | 2 |  2
-     |   |   | null  |   |    | 3 | -3
-     |   |   | null  |   |    | 2 |  4
-     |   |   | null  |   |    | 5 | -5
-     |   |   | null  |   |    | 5 | -5
-     |   |   | null  |   |    | 0 |   
-     |   |   | null  |   |    |   |   
-     |   |   | null  |   |    |   |  0
-     |   | 0 | zero  |   |    | 1 | -1
-     |   | 0 | zero  |   |    | 2 |  2
-     |   | 0 | zero  |   |    | 3 | -3
-     |   | 0 | zero  |   |    | 2 |  4
-     |   | 0 | zero  |   |    | 5 | -5
-     |   | 0 | zero  |   |    | 5 | -5
-     |   | 0 | zero  |   |    | 0 |   
-     |   | 0 | zero  |   |    |   |   
-     |   | 0 | zero  |   |    |   |  0
      | 1 | 4 | one   |   |  0 | 1 | -1
+     | 1 | 4 | one   |   |  0 | 0 |   
+     | 1 | 4 | one   |   |  0 | 5 | -5
+     | 1 | 4 | one   |   |  0 | 5 | -5
      | 1 | 4 | one   |   |  0 | 2 |  2
      | 1 | 4 | one   |   |  0 | 3 | -3
      | 1 | 4 | one   |   |  0 | 2 |  4
-     | 1 | 4 | one   |   |  0 | 5 | -5
-     | 1 | 4 | one   |   |  0 | 5 | -5
-     | 1 | 4 | one   |   |  0 | 0 |   
      | 1 | 4 | one   |   |  0 |   |   
      | 1 | 4 | one   |   |  0 |   |  0
-     | 2 | 3 | two   |   |  0 | 1 | -1
-     | 2 | 3 | two   |   |  0 | 2 |  2
-     | 2 | 3 | two   |   |  0 | 3 | -3
-     | 2 | 3 | two   |   |  0 | 2 |  4
-     | 2 | 3 | two   |   |  0 | 5 | -5
-     | 2 | 3 | two   |   |  0 | 5 | -5
-     | 2 | 3 | two   |   |  0 | 0 |   
-     | 2 | 3 | two   |   |  0 |   |   
-     | 2 | 3 | two   |   |  0 |   |  0
-     | 3 | 2 | three |   |  0 | 1 | -1
-     | 3 | 2 | three |   |  0 | 2 |  2
-     | 3 | 2 | three |   |  0 | 3 | -3
-     | 3 | 2 | three |   |  0 | 2 |  4
-     | 3 | 2 | three |   |  0 | 5 | -5
-     | 3 | 2 | three |   |  0 | 5 | -5
-     | 3 | 2 | three |   |  0 | 0 |   
-     | 3 | 2 | three |   |  0 |   |   
-     | 3 | 2 | three |   |  0 |   |  0
-     | 4 | 1 | four  |   |  0 | 1 | -1
-     | 4 | 1 | four  |   |  0 | 2 |  2
-     | 4 | 1 | four  |   |  0 | 3 | -3
-     | 4 | 1 | four  |   |  0 | 2 |  4
-     | 4 | 1 | four  |   |  0 | 5 | -5
-     | 4 | 1 | four  |   |  0 | 5 | -5
-     | 4 | 1 | four  |   |  0 | 0 |   
-     | 4 | 1 | four  |   |  0 |   |   
-     | 4 | 1 | four  |   |  0 |   |  0
-     | 5 | 0 | five  |   |  0 | 1 | -1
-     | 5 | 0 | five  |   |  0 | 2 |  2
-     | 5 | 0 | five  |   |  0 | 3 | -3
-     | 5 | 0 | five  |   |  0 | 2 |  4
-     | 5 | 0 | five  |   |  0 | 5 | -5
-     | 5 | 0 | five  |   |  0 | 5 | -5
-     | 5 | 0 | five  |   |  0 | 0 |   
-     | 5 | 0 | five  |   |  0 |   |   
-     | 5 | 0 | five  |   |  0 |   |  0
-     | 6 | 6 | six   |   |  0 | 1 | -1
-     | 6 | 6 | six   |   |  0 | 2 |  2
-     | 6 | 6 | six   |   |  0 | 3 | -3
-     | 6 | 6 | six   |   |  0 | 2 |  4
-     | 6 | 6 | six   |   |  0 | 5 | -5
-     | 6 | 6 | six   |   |  0 | 5 | -5
-     | 6 | 6 | six   |   |  0 | 0 |   
-     | 6 | 6 | six   |   |  0 |   |   
-     | 6 | 6 | six   |   |  0 |   |  0
-     | 7 | 7 | seven |   |  0 | 1 | -1
-     | 7 | 7 | seven |   |  0 | 2 |  2
-     | 7 | 7 | seven |   |  0 | 3 | -3
-     | 7 | 7 | seven |   |  0 | 2 |  4
-     | 7 | 7 | seven |   |  0 | 5 | -5
-     | 7 | 7 | seven |   |  0 | 5 | -5
-     | 7 | 7 | seven |   |  0 | 0 |   
-     | 7 | 7 | seven |   |  0 |   |   
-     | 7 | 7 | seven |   |  0 |   |  0
-     | 8 | 8 | eight |   |  0 | 1 | -1
-     | 8 | 8 | eight |   |  0 | 2 |  2
-     | 8 | 8 | eight |   |  0 | 3 | -3
-     | 8 | 8 | eight |   |  0 | 2 |  4
-     | 8 | 8 | eight |   |  0 | 5 | -5
-     | 8 | 8 | eight |   |  0 | 5 | -5
-     | 8 | 8 | eight |   |  0 | 0 |   
-     | 8 | 8 | eight |   |  0 |   |   
-     | 8 | 8 | eight |   |  0 |   |  0
      | 0 |   | zero  |   |  0 | 1 | -1
+     | 0 |   | zero  |   |  0 | 0 |   
+     | 0 |   | zero  |   |  0 | 5 | -5
+     | 0 |   | zero  |   |  0 | 5 | -5
      | 0 |   | zero  |   |  0 | 2 |  2
      | 0 |   | zero  |   |  0 | 3 | -3
      | 0 |   | zero  |   |  0 | 2 |  4
-     | 0 |   | zero  |   |  0 | 5 | -5
-     | 0 |   | zero  |   |  0 | 5 | -5
-     | 0 |   | zero  |   |  0 | 0 |   
      | 0 |   | zero  |   |  0 |   |   
      | 0 |   | zero  |   |  0 |   |  0
+     | 1 | 4 | one   | 1 | -1 | 1 | -1
+     | 1 | 4 | one   | 1 | -1 | 0 |   
+     | 1 | 4 | one   | 1 | -1 | 5 | -5
+     | 1 | 4 | one   | 1 | -1 | 5 | -5
+     | 1 | 4 | one   | 1 | -1 | 2 |  2
+     | 1 | 4 | one   | 1 | -1 | 3 | -3
+     | 1 | 4 | one   | 1 | -1 | 2 |  4
+     | 1 | 4 | one   | 1 | -1 |   |   
+     | 1 | 4 | one   | 1 | -1 |   |  0
+     | 0 |   | zero  | 1 | -1 | 1 | -1
+     | 0 |   | zero  | 1 | -1 | 0 |   
+     | 0 |   | zero  | 1 | -1 | 5 | -5
+     | 0 |   | zero  | 1 | -1 | 5 | -5
+     | 0 |   | zero  | 1 | -1 | 2 |  2
+     | 0 |   | zero  | 1 | -1 | 3 | -3
+     | 0 |   | zero  | 1 | -1 | 2 |  4
+     | 0 |   | zero  | 1 | -1 |   |   
+     | 0 |   | zero  | 1 | -1 |   |  0
+     | 1 | 4 | one   | 0 |    | 1 | -1
+     | 1 | 4 | one   | 0 |    | 0 |   
+     | 1 | 4 | one   | 0 |    | 5 | -5
+     | 1 | 4 | one   | 0 |    | 5 | -5
+     | 1 | 4 | one   | 0 |    | 2 |  2
+     | 1 | 4 | one   | 0 |    | 3 | -3
+     | 1 | 4 | one   | 0 |    | 2 |  4
+     | 1 | 4 | one   | 0 |    |   |   
+     | 1 | 4 | one   | 0 |    |   |  0
+     | 0 |   | zero  | 0 |    | 1 | -1
+     | 0 |   | zero  | 0 |    | 0 |   
+     | 0 |   | zero  | 0 |    | 5 | -5
+     | 0 |   | zero  | 0 |    | 5 | -5
+     | 0 |   | zero  | 0 |    | 2 |  2
+     | 0 |   | zero  | 0 |    | 3 | -3
+     | 0 |   | zero  | 0 |    | 2 |  4
+     | 0 |   | zero  | 0 |    |   |   
+     | 0 |   | zero  | 0 |    |   |  0
+     | 1 | 4 | one   | 5 | -5 | 1 | -1
+     | 1 | 4 | one   | 5 | -5 | 0 |   
+     | 1 | 4 | one   | 5 | -5 | 5 | -5
+     | 1 | 4 | one   | 5 | -5 | 5 | -5
+     | 1 | 4 | one   | 5 | -5 | 2 |  2
+     | 1 | 4 | one   | 5 | -5 | 3 | -3
+     | 1 | 4 | one   | 5 | -5 | 2 |  4
+     | 1 | 4 | one   | 5 | -5 |   |   
+     | 1 | 4 | one   | 5 | -5 |   |  0
+     | 0 |   | zero  | 5 | -5 | 1 | -1
+     | 0 |   | zero  | 5 | -5 | 0 |   
+     | 0 |   | zero  | 5 | -5 | 5 | -5
+     | 0 |   | zero  | 5 | -5 | 5 | -5
+     | 0 |   | zero  | 5 | -5 | 2 |  2
+     | 0 |   | zero  | 5 | -5 | 3 | -3
+     | 0 |   | zero  | 5 | -5 | 2 |  4
+     | 0 |   | zero  | 5 | -5 |   |   
+     | 0 |   | zero  | 5 | -5 |   |  0
+     | 1 | 4 | one   | 5 | -5 | 1 | -1
+     | 1 | 4 | one   | 5 | -5 | 0 |   
+     | 1 | 4 | one   | 5 | -5 | 5 | -5
+     | 1 | 4 | one   | 5 | -5 | 5 | -5
+     | 1 | 4 | one   | 5 | -5 | 2 |  2
+     | 1 | 4 | one   | 5 | -5 | 3 | -3
+     | 1 | 4 | one   | 5 | -5 | 2 |  4
+     | 1 | 4 | one   | 5 | -5 |   |   
+     | 1 | 4 | one   | 5 | -5 |   |  0
+     | 0 |   | zero  | 5 | -5 | 1 | -1
+     | 0 |   | zero  | 5 | -5 | 0 |   
+     | 0 |   | zero  | 5 | -5 | 5 | -5
+     | 0 |   | zero  | 5 | -5 | 5 | -5
+     | 0 |   | zero  | 5 | -5 | 2 |  2
+     | 0 |   | zero  | 5 | -5 | 3 | -3
+     | 0 |   | zero  | 5 | -5 | 2 |  4
+     | 0 |   | zero  | 5 | -5 |   |   
+     | 0 |   | zero  | 5 | -5 |   |  0
+     | 5 | 0 | five  | 2 |  2 | 1 | -1
+     | 5 | 0 | five  | 2 |  2 | 0 |   
+     | 5 | 0 | five  | 2 |  2 | 5 | -5
+     | 5 | 0 | five  | 2 |  2 | 5 | -5
+     | 5 | 0 | five  | 2 |  2 | 2 |  2
+     | 5 | 0 | five  | 2 |  2 | 3 | -3
+     | 5 | 0 | five  | 2 |  2 | 2 |  4
+     | 5 | 0 | five  | 2 |  2 |   |   
+     | 5 | 0 | five  | 2 |  2 |   |  0
+     | 6 | 6 | six   | 2 |  2 | 1 | -1
+     | 6 | 6 | six   | 2 |  2 | 0 |   
+     | 6 | 6 | six   | 2 |  2 | 5 | -5
+     | 6 | 6 | six   | 2 |  2 | 5 | -5
+     | 6 | 6 | six   | 2 |  2 | 2 |  2
+     | 6 | 6 | six   | 2 |  2 | 3 | -3
+     | 6 | 6 | six   | 2 |  2 | 2 |  4
+     | 6 | 6 | six   | 2 |  2 |   |   
+     | 6 | 6 | six   | 2 |  2 |   |  0
+     | 5 | 0 | five  | 3 | -3 | 1 | -1
+     | 5 | 0 | five  | 3 | -3 | 0 |   
+     | 5 | 0 | five  | 3 | -3 | 5 | -5
+     | 5 | 0 | five  | 3 | -3 | 5 | -5
+     | 5 | 0 | five  | 3 | -3 | 2 |  2
+     | 5 | 0 | five  | 3 | -3 | 3 | -3
+     | 5 | 0 | five  | 3 | -3 | 2 |  4
+     | 5 | 0 | five  | 3 | -3 |   |   
+     | 5 | 0 | five  | 3 | -3 |   |  0
+     | 6 | 6 | six   | 3 | -3 | 1 | -1
+     | 6 | 6 | six   | 3 | -3 | 0 |   
+     | 6 | 6 | six   | 3 | -3 | 5 | -5
+     | 6 | 6 | six   | 3 | -3 | 5 | -5
+     | 6 | 6 | six   | 3 | -3 | 2 |  2
+     | 6 | 6 | six   | 3 | -3 | 3 | -3
+     | 6 | 6 | six   | 3 | -3 | 2 |  4
+     | 6 | 6 | six   | 3 | -3 |   |   
+     | 6 | 6 | six   | 3 | -3 |   |  0
+     | 5 | 0 | five  | 2 |  4 | 1 | -1
+     | 5 | 0 | five  | 2 |  4 | 0 |   
+     | 5 | 0 | five  | 2 |  4 | 5 | -5
+     | 5 | 0 | five  | 2 |  4 | 5 | -5
+     | 5 | 0 | five  | 2 |  4 | 2 |  2
+     | 5 | 0 | five  | 2 |  4 | 3 | -3
+     | 5 | 0 | five  | 2 |  4 | 2 |  4
+     | 5 | 0 | five  | 2 |  4 |   |   
+     | 5 | 0 | five  | 2 |  4 |   |  0
+     | 6 | 6 | six   | 2 |  4 | 1 | -1
+     | 6 | 6 | six   | 2 |  4 | 0 |   
+     | 6 | 6 | six   | 2 |  4 | 5 | -5
+     | 6 | 6 | six   | 2 |  4 | 5 | -5
+     | 6 | 6 | six   | 2 |  4 | 2 |  2
+     | 6 | 6 | six   | 2 |  4 | 3 | -3
+     | 6 | 6 | six   | 2 |  4 | 2 |  4
+     | 6 | 6 | six   | 2 |  4 |   |   
+     | 6 | 6 | six   | 2 |  4 |   |  0
+     | 5 | 0 | five  |   |    | 1 | -1
+     | 5 | 0 | five  |   |    | 0 |   
+     | 5 | 0 | five  |   |    | 5 | -5
+     | 5 | 0 | five  |   |    | 5 | -5
+     | 5 | 0 | five  |   |    | 2 |  2
+     | 5 | 0 | five  |   |    | 3 | -3
+     | 5 | 0 | five  |   |    | 2 |  4
+     | 5 | 0 | five  |   |    |   |   
+     | 5 | 0 | five  |   |    |   |  0
+     | 6 | 6 | six   |   |    | 1 | -1
+     | 6 | 6 | six   |   |    | 0 |   
+     | 6 | 6 | six   |   |    | 5 | -5
+     | 6 | 6 | six   |   |    | 5 | -5
+     | 6 | 6 | six   |   |    | 2 |  2
+     | 6 | 6 | six   |   |    | 3 | -3
+     | 6 | 6 | six   |   |    | 2 |  4
+     | 6 | 6 | six   |   |    |   |   
+     | 6 | 6 | six   |   |    |   |  0
+     | 5 | 0 | five  |   |  0 | 1 | -1
+     | 5 | 0 | five  |   |  0 | 0 |   
+     | 5 | 0 | five  |   |  0 | 5 | -5
+     | 5 | 0 | five  |   |  0 | 5 | -5
+     | 5 | 0 | five  |   |  0 | 2 |  2
+     | 5 | 0 | five  |   |  0 | 3 | -3
+     | 5 | 0 | five  |   |  0 | 2 |  4
+     | 5 | 0 | five  |   |  0 |   |   
+     | 5 | 0 | five  |   |  0 |   |  0
+     | 6 | 6 | six   |   |  0 | 1 | -1
+     | 6 | 6 | six   |   |  0 | 0 |   
+     | 6 | 6 | six   |   |  0 | 5 | -5
+     | 6 | 6 | six   |   |  0 | 5 | -5
+     | 6 | 6 | six   |   |  0 | 2 |  2
+     | 6 | 6 | six   |   |  0 | 3 | -3
+     | 6 | 6 | six   |   |  0 | 2 |  4
+     | 6 | 6 | six   |   |  0 |   |   
+     | 6 | 6 | six   |   |  0 |   |  0
+     | 5 | 0 | five  | 1 | -1 | 1 | -1
+     | 5 | 0 | five  | 1 | -1 | 0 |   
+     | 5 | 0 | five  | 1 | -1 | 5 | -5
+     | 5 | 0 | five  | 1 | -1 | 5 | -5
+     | 5 | 0 | five  | 1 | -1 | 2 |  2
+     | 5 | 0 | five  | 1 | -1 | 3 | -3
+     | 5 | 0 | five  | 1 | -1 | 2 |  4
+     | 5 | 0 | five  | 1 | -1 |   |   
+     | 5 | 0 | five  | 1 | -1 |   |  0
+     | 6 | 6 | six   | 1 | -1 | 1 | -1
+     | 6 | 6 | six   | 1 | -1 | 0 |   
+     | 6 | 6 | six   | 1 | -1 | 5 | -5
+     | 6 | 6 | six   | 1 | -1 | 5 | -5
+     | 6 | 6 | six   | 1 | -1 | 2 |  2
+     | 6 | 6 | six   | 1 | -1 | 3 | -3
+     | 6 | 6 | six   | 1 | -1 | 2 |  4
+     | 6 | 6 | six   | 1 | -1 |   |   
+     | 6 | 6 | six   | 1 | -1 |   |  0
+     | 5 | 0 | five  | 0 |    | 1 | -1
+     | 5 | 0 | five  | 0 |    | 0 |   
+     | 5 | 0 | five  | 0 |    | 5 | -5
+     | 5 | 0 | five  | 0 |    | 5 | -5
+     | 5 | 0 | five  | 0 |    | 2 |  2
+     | 5 | 0 | five  | 0 |    | 3 | -3
+     | 5 | 0 | five  | 0 |    | 2 |  4
+     | 5 | 0 | five  | 0 |    |   |   
+     | 5 | 0 | five  | 0 |    |   |  0
+     | 6 | 6 | six   | 0 |    | 1 | -1
+     | 6 | 6 | six   | 0 |    | 0 |   
+     | 6 | 6 | six   | 0 |    | 5 | -5
+     | 6 | 6 | six   | 0 |    | 5 | -5
+     | 6 | 6 | six   | 0 |    | 2 |  2
+     | 6 | 6 | six   | 0 |    | 3 | -3
+     | 6 | 6 | six   | 0 |    | 2 |  4
+     | 6 | 6 | six   | 0 |    |   |   
+     | 6 | 6 | six   | 0 |    |   |  0
+     | 5 | 0 | five  | 5 | -5 | 1 | -1
+     | 5 | 0 | five  | 5 | -5 | 0 |   
+     | 5 | 0 | five  | 5 | -5 | 5 | -5
+     | 5 | 0 | five  | 5 | -5 | 5 | -5
+     | 5 | 0 | five  | 5 | -5 | 2 |  2
+     | 5 | 0 | five  | 5 | -5 | 3 | -3
+     | 5 | 0 | five  | 5 | -5 | 2 |  4
+     | 5 | 0 | five  | 5 | -5 |   |   
+     | 5 | 0 | five  | 5 | -5 |   |  0
+     | 6 | 6 | six   | 5 | -5 | 1 | -1
+     | 6 | 6 | six   | 5 | -5 | 0 |   
+     | 6 | 6 | six   | 5 | -5 | 5 | -5
+     | 6 | 6 | six   | 5 | -5 | 5 | -5
+     | 6 | 6 | six   | 5 | -5 | 2 |  2
+     | 6 | 6 | six   | 5 | -5 | 3 | -3
+     | 6 | 6 | six   | 5 | -5 | 2 |  4
+     | 6 | 6 | six   | 5 | -5 |   |   
+     | 6 | 6 | six   | 5 | -5 |   |  0
+     | 5 | 0 | five  | 5 | -5 | 1 | -1
+     | 5 | 0 | five  | 5 | -5 | 0 |   
+     | 5 | 0 | five  | 5 | -5 | 5 | -5
+     | 5 | 0 | five  | 5 | -5 | 5 | -5
+     | 5 | 0 | five  | 5 | -5 | 2 |  2
+     | 5 | 0 | five  | 5 | -5 | 3 | -3
+     | 5 | 0 | five  | 5 | -5 | 2 |  4
+     | 5 | 0 | five  | 5 | -5 |   |   
+     | 5 | 0 | five  | 5 | -5 |   |  0
+     | 6 | 6 | six   | 5 | -5 | 1 | -1
+     | 6 | 6 | six   | 5 | -5 | 0 |   
+     | 6 | 6 | six   | 5 | -5 | 5 | -5
+     | 6 | 6 | six   | 5 | -5 | 5 | -5
+     | 6 | 6 | six   | 5 | -5 | 2 |  2
+     | 6 | 6 | six   | 5 | -5 | 3 | -3
+     | 6 | 6 | six   | 5 | -5 | 2 |  4
+     | 6 | 6 | six   | 5 | -5 |   |   
+     | 6 | 6 | six   | 5 | -5 |   |  0
+     | 2 | 3 | two   |   |    | 2 |  4
+     | 2 | 3 | two   |   |    |   |   
+     | 2 | 3 | two   |   |    |   |  0
+     | 3 | 2 | three |   |    | 1 | -1
+     | 3 | 2 | three |   |    | 0 |   
+     | 3 | 2 | three |   |    | 5 | -5
+     | 3 | 2 | three |   |    | 5 | -5
+     | 3 | 2 | three |   |    | 2 |  2
+     | 3 | 2 | three |   |    | 3 | -3
+     | 3 | 2 | three |   |    | 2 |  4
+     | 3 | 2 | three |   |    |   |   
+     | 3 | 2 | three |   |    |   |  0
+     | 4 | 1 | four  |   |    | 1 | -1
+     | 4 | 1 | four  |   |    | 0 |   
+     | 4 | 1 | four  |   |    | 5 | -5
+     | 4 | 1 | four  |   |    | 5 | -5
+     | 4 | 1 | four  |   |    | 2 |  2
+     | 4 | 1 | four  |   |    | 3 | -3
+     | 4 | 1 | four  |   |    | 2 |  4
+     | 4 | 1 | four  |   |    |   |   
+     | 4 | 1 | four  |   |    |   |  0
+     | 7 | 7 | seven |   |    | 1 | -1
+     | 7 | 7 | seven |   |    | 0 |   
+     | 7 | 7 | seven |   |    | 5 | -5
+     | 7 | 7 | seven |   |    | 5 | -5
+     | 7 | 7 | seven |   |    | 2 |  2
+     | 7 | 7 | seven |   |    | 3 | -3
+     | 7 | 7 | seven |   |    | 2 |  4
+     | 7 | 7 | seven |   |    |   |   
+     | 7 | 7 | seven |   |    |   |  0
+     | 8 | 8 | eight |   |    | 1 | -1
+     | 8 | 8 | eight |   |    | 0 |   
+     | 8 | 8 | eight |   |    | 5 | -5
+     | 8 | 8 | eight |   |    | 5 | -5
+     | 8 | 8 | eight |   |    | 2 |  2
+     | 8 | 8 | eight |   |    | 3 | -3
+     | 8 | 8 | eight |   |    | 2 |  4
+     | 8 | 8 | eight |   |    |   |   
+     | 8 | 8 | eight |   |    |   |  0
+     |   |   | null  |   |    | 1 | -1
+     |   |   | null  |   |    | 0 |   
+     |   |   | null  |   |    | 5 | -5
+     |   |   | null  |   |    | 5 | -5
+     |   |   | null  |   |    | 2 |  2
+     |   |   | null  |   |    | 3 | -3
+     |   |   | null  |   |    | 2 |  4
+     |   |   | null  |   |    |   |   
+     |   |   | null  |   |    |   |  0
+     |   | 0 | zero  |   |    | 1 | -1
+     |   | 0 | zero  |   |    | 0 |   
+     |   | 0 | zero  |   |    | 5 | -5
+     |   | 0 | zero  |   |    | 5 | -5
+     |   | 0 | zero  |   |    | 2 |  2
+     |   | 0 | zero  |   |    | 3 | -3
+     |   | 0 | zero  |   |    | 2 |  4
+     |   | 0 | zero  |   |    |   |   
+     |   | 0 | zero  |   |    |   |  0
+     | 2 | 3 | two   |   |  0 | 1 | -1
+     | 2 | 3 | two   |   |  0 | 0 |   
+     | 2 | 3 | two   |   |  0 | 5 | -5
+     | 2 | 3 | two   |   |  0 | 5 | -5
+     | 2 | 3 | two   |   |  0 | 2 |  2
+     | 2 | 3 | two   |   |  0 | 3 | -3
+     | 2 | 3 | two   |   |  0 | 2 |  4
+     | 2 | 3 | two   |   |  0 |   |   
+     | 2 | 3 | two   |   |  0 |   |  0
+     | 3 | 2 | three |   |  0 | 1 | -1
+     | 3 | 2 | three |   |  0 | 0 |   
+     | 3 | 2 | three |   |  0 | 5 | -5
+     | 3 | 2 | three |   |  0 | 5 | -5
+     | 3 | 2 | three |   |  0 | 2 |  2
+     | 3 | 2 | three |   |  0 | 3 | -3
+     | 3 | 2 | three |   |  0 | 2 |  4
+     | 3 | 2 | three |   |  0 |   |   
+     | 3 | 2 | three |   |  0 |   |  0
+     | 4 | 1 | four  |   |  0 | 1 | -1
+     | 4 | 1 | four  |   |  0 | 0 |   
+     | 4 | 1 | four  |   |  0 | 5 | -5
+     | 4 | 1 | four  |   |  0 | 5 | -5
+     | 4 | 1 | four  |   |  0 | 2 |  2
+     | 4 | 1 | four  |   |  0 | 3 | -3
+     | 4 | 1 | four  |   |  0 | 2 |  4
+     | 4 | 1 | four  |   |  0 |   |   
+     | 4 | 1 | four  |   |  0 |   |  0
+     | 7 | 7 | seven |   |  0 | 1 | -1
+     | 7 | 7 | seven |   |  0 | 0 |   
+     | 7 | 7 | seven |   |  0 | 5 | -5
+     | 7 | 7 | seven |   |  0 | 5 | -5
+     | 7 | 7 | seven |   |  0 | 2 |  2
+     | 7 | 7 | seven |   |  0 | 3 | -3
+     | 7 | 7 | seven |   |  0 | 2 |  4
+     | 7 | 7 | seven |   |  0 |   |   
+     | 7 | 7 | seven |   |  0 |   |  0
+     | 8 | 8 | eight |   |  0 | 1 | -1
+     | 8 | 8 | eight |   |  0 | 0 |   
+     | 8 | 8 | eight |   |  0 | 5 | -5
+     | 8 | 8 | eight |   |  0 | 5 | -5
+     | 8 | 8 | eight |   |  0 | 2 |  2
+     | 8 | 8 | eight |   |  0 | 3 | -3
+     | 8 | 8 | eight |   |  0 | 2 |  4
+     | 8 | 8 | eight |   |  0 |   |   
+     | 8 | 8 | eight |   |  0 |   |  0
      |   |   | null  |   |  0 | 1 | -1
+     |   |   | null  |   |  0 | 0 |   
+     |   |   | null  |   |  0 | 5 | -5
+     |   |   | null  |   |  0 | 5 | -5
      |   |   | null  |   |  0 | 2 |  2
      |   |   | null  |   |  0 | 3 | -3
      |   |   | null  |   |  0 | 2 |  4
-     |   |   | null  |   |  0 | 5 | -5
-     |   |   | null  |   |  0 | 5 | -5
-     |   |   | null  |   |  0 | 0 |   
      |   |   | null  |   |  0 |   |   
      |   |   | null  |   |  0 |   |  0
      |   | 0 | zero  |   |  0 | 1 | -1
+     |   | 0 | zero  |   |  0 | 0 |   
+     |   | 0 | zero  |   |  0 | 5 | -5
+     |   | 0 | zero  |   |  0 | 5 | -5
      |   | 0 | zero  |   |  0 | 2 |  2
      |   | 0 | zero  |   |  0 | 3 | -3
      |   | 0 | zero  |   |  0 | 2 |  4
-     |   | 0 | zero  |   |  0 | 5 | -5
-     |   | 0 | zero  |   |  0 | 5 | -5
-     |   | 0 | zero  |   |  0 | 0 |   
      |   | 0 | zero  |   |  0 |   |   
      |   | 0 | zero  |   |  0 |   |  0
+     | 2 | 3 | two   | 1 | -1 | 1 | -1
+     | 2 | 3 | two   | 1 | -1 | 0 |   
+     | 2 | 3 | two   | 1 | -1 | 5 | -5
+     | 2 | 3 | two   | 1 | -1 | 5 | -5
+     | 2 | 3 | two   | 1 | -1 | 2 |  2
+     | 2 | 3 | two   | 1 | -1 | 3 | -3
+     | 2 | 3 | two   | 1 | -1 | 2 |  4
+     | 2 | 3 | two   | 1 | -1 |   |   
+     | 2 | 3 | two   | 1 | -1 |   |  0
+     | 3 | 2 | three | 1 | -1 | 1 | -1
+     | 3 | 2 | three | 1 | -1 | 0 |   
+     | 3 | 2 | three | 1 | -1 | 5 | -5
+     | 3 | 2 | three | 1 | -1 | 5 | -5
+     | 3 | 2 | three | 1 | -1 | 2 |  2
+     | 3 | 2 | three | 1 | -1 | 3 | -3
+     | 3 | 2 | three | 1 | -1 | 2 |  4
+     | 3 | 2 | three | 1 | -1 |   |   
+     | 3 | 2 | three | 1 | -1 |   |  0
+     | 4 | 1 | four  | 1 | -1 | 1 | -1
+     | 4 | 1 | four  | 1 | -1 | 0 |   
+     | 4 | 1 | four  | 1 | -1 | 5 | -5
+     | 4 | 1 | four  | 1 | -1 | 5 | -5
+     | 4 | 1 | four  | 1 | -1 | 2 |  2
+     | 4 | 1 | four  | 1 | -1 | 3 | -3
+     | 4 | 1 | four  | 1 | -1 | 2 |  4
+     | 4 | 1 | four  | 1 | -1 |   |   
+     | 4 | 1 | four  | 1 | -1 |   |  0
+     | 7 | 7 | seven | 1 | -1 | 1 | -1
+     | 7 | 7 | seven | 1 | -1 | 0 |   
+     | 7 | 7 | seven | 1 | -1 | 5 | -5
+     | 7 | 7 | seven | 1 | -1 | 5 | -5
+     | 7 | 7 | seven | 1 | -1 | 2 |  2
+     | 7 | 7 | seven | 1 | -1 | 3 | -3
+     | 7 | 7 | seven | 1 | -1 | 2 |  4
+     | 7 | 7 | seven | 1 | -1 |   |   
+     | 7 | 7 | seven | 1 | -1 |   |  0
+     | 8 | 8 | eight | 1 | -1 | 1 | -1
+     | 8 | 8 | eight | 1 | -1 | 0 |   
+     | 8 | 8 | eight | 1 | -1 | 5 | -5
+     | 8 | 8 | eight | 1 | -1 | 5 | -5
+     | 8 | 8 | eight | 1 | -1 | 2 |  2
+     | 8 | 8 | eight | 1 | -1 | 3 | -3
+     | 8 | 8 | eight | 1 | -1 | 2 |  4
+     | 8 | 8 | eight | 1 | -1 |   |   
+     | 8 | 8 | eight | 1 | -1 |   |  0
+     |   |   | null  | 1 | -1 | 1 | -1
+     |   |   | null  | 1 | -1 | 0 |   
+     |   |   | null  | 1 | -1 | 5 | -5
+     |   |   | null  | 1 | -1 | 5 | -5
+     |   |   | null  | 1 | -1 | 2 |  2
+     |   |   | null  | 1 | -1 | 3 | -3
+     |   |   | null  | 1 | -1 | 2 |  4
+     |   |   | null  | 1 | -1 |   |   
+     |   |   | null  | 1 | -1 |   |  0
+     |   | 0 | zero  | 1 | -1 | 1 | -1
+     |   | 0 | zero  | 1 | -1 | 0 |   
+     |   | 0 | zero  | 1 | -1 | 5 | -5
+     |   | 0 | zero  | 1 | -1 | 5 | -5
+     |   | 0 | zero  | 1 | -1 | 2 |  2
+     |   | 0 | zero  | 1 | -1 | 3 | -3
+     |   | 0 | zero  | 1 | -1 | 2 |  4
+     |   | 0 | zero  | 1 | -1 |   |   
+     |   | 0 | zero  | 1 | -1 |   |  0
+     | 2 | 3 | two   | 0 |    | 1 | -1
+     | 2 | 3 | two   | 0 |    | 0 |   
+     | 2 | 3 | two   | 0 |    | 5 | -5
+     | 2 | 3 | two   | 0 |    | 5 | -5
+     | 2 | 3 | two   | 0 |    | 2 |  2
+     | 2 | 3 | two   | 0 |    | 3 | -3
+     | 2 | 3 | two   | 0 |    | 2 |  4
+     | 2 | 3 | two   | 0 |    |   |   
+     | 2 | 3 | two   | 0 |    |   |  0
+     | 3 | 2 | three | 0 |    | 1 | -1
+     | 3 | 2 | three | 0 |    | 0 |   
+     | 3 | 2 | three | 0 |    | 5 | -5
+     | 3 | 2 | three | 0 |    | 5 | -5
+     | 3 | 2 | three | 0 |    | 2 |  2
+     | 3 | 2 | three | 0 |    | 3 | -3
+     | 3 | 2 | three | 0 |    | 2 |  4
+     | 3 | 2 | three | 0 |    |   |   
+     | 3 | 2 | three | 0 |    |   |  0
+     | 4 | 1 | four  | 0 |    | 1 | -1
+     | 4 | 1 | four  | 0 |    | 0 |   
+     | 4 | 1 | four  | 0 |    | 5 | -5
+     | 4 | 1 | four  | 0 |    | 5 | -5
+     | 4 | 1 | four  | 0 |    | 2 |  2
+     | 4 | 1 | four  | 0 |    | 3 | -3
+     | 4 | 1 | four  | 0 |    | 2 |  4
+     | 4 | 1 | four  | 0 |    |   |   
+     | 4 | 1 | four  | 0 |    |   |  0
+     | 7 | 7 | seven | 0 |    | 1 | -1
+     | 7 | 7 | seven | 0 |    | 0 |   
+     | 7 | 7 | seven | 0 |    | 5 | -5
+     | 7 | 7 | seven | 0 |    | 5 | -5
+     | 7 | 7 | seven | 0 |    | 2 |  2
+     | 7 | 7 | seven | 0 |    | 3 | -3
+     | 7 | 7 | seven | 0 |    | 2 |  4
+     | 7 | 7 | seven | 0 |    |   |   
+     | 7 | 7 | seven | 0 |    |   |  0
+     | 8 | 8 | eight | 0 |    | 1 | -1
+     | 8 | 8 | eight | 0 |    | 0 |   
+     | 8 | 8 | eight | 0 |    | 5 | -5
+     | 8 | 8 | eight | 0 |    | 5 | -5
+     | 8 | 8 | eight | 0 |    | 2 |  2
+     | 8 | 8 | eight | 0 |    | 3 | -3
+     | 8 | 8 | eight | 0 |    | 2 |  4
+     | 8 | 8 | eight | 0 |    |   |   
+     | 8 | 8 | eight | 0 |    |   |  0
+     |   |   | null  | 0 |    | 1 | -1
+     |   |   | null  | 0 |    | 0 |   
+     |   |   | null  | 0 |    | 5 | -5
+     |   |   | null  | 0 |    | 5 | -5
+     |   |   | null  | 0 |    | 2 |  2
+     |   |   | null  | 0 |    | 3 | -3
+     |   |   | null  | 0 |    | 2 |  4
+     |   |   | null  | 0 |    |   |   
+     |   |   | null  | 0 |    |   |  0
+     |   | 0 | zero  | 0 |    | 1 | -1
+     |   | 0 | zero  | 0 |    | 0 |   
+     |   | 0 | zero  | 0 |    | 5 | -5
+     |   | 0 | zero  | 0 |    | 5 | -5
+     |   | 0 | zero  | 0 |    | 2 |  2
+     |   | 0 | zero  | 0 |    | 3 | -3
+     |   | 0 | zero  | 0 |    | 2 |  4
+     |   | 0 | zero  | 0 |    |   |   
+     |   | 0 | zero  | 0 |    |   |  0
+     | 2 | 3 | two   | 5 | -5 | 1 | -1
+     | 2 | 3 | two   | 5 | -5 | 0 |   
+     | 2 | 3 | two   | 5 | -5 | 5 | -5
+     | 2 | 3 | two   | 5 | -5 | 5 | -5
+     | 2 | 3 | two   | 5 | -5 | 2 |  2
+     | 2 | 3 | two   | 5 | -5 | 3 | -3
+     | 2 | 3 | two   | 5 | -5 | 2 |  4
+     | 2 | 3 | two   | 5 | -5 |   |   
+     | 2 | 3 | two   | 5 | -5 |   |  0
+     | 3 | 2 | three | 5 | -5 | 1 | -1
+     | 3 | 2 | three | 5 | -5 | 0 |   
+     | 3 | 2 | three | 5 | -5 | 5 | -5
+     | 3 | 2 | three | 5 | -5 | 5 | -5
+     | 3 | 2 | three | 5 | -5 | 2 |  2
+     | 3 | 2 | three | 5 | -5 | 3 | -3
+     | 3 | 2 | three | 5 | -5 | 2 |  4
+     | 3 | 2 | three | 5 | -5 |   |   
+     | 3 | 2 | three | 5 | -5 |   |  0
+     | 4 | 1 | four  | 5 | -5 | 1 | -1
+     | 4 | 1 | four  | 5 | -5 | 0 |   
+     | 4 | 1 | four  | 5 | -5 | 5 | -5
+     | 4 | 1 | four  | 5 | -5 | 5 | -5
+     | 4 | 1 | four  | 5 | -5 | 2 |  2
+     | 4 | 1 | four  | 5 | -5 | 3 | -3
+     | 4 | 1 | four  | 5 | -5 | 2 |  4
+     | 4 | 1 | four  | 5 | -5 |   |   
+     | 4 | 1 | four  | 5 | -5 |   |  0
+     | 7 | 7 | seven | 5 | -5 | 1 | -1
+     | 7 | 7 | seven | 5 | -5 | 0 |   
+     | 7 | 7 | seven | 5 | -5 | 5 | -5
+     | 7 | 7 | seven | 5 | -5 | 5 | -5
+     | 7 | 7 | seven | 5 | -5 | 2 |  2
+     | 7 | 7 | seven | 5 | -5 | 3 | -3
+     | 7 | 7 | seven | 5 | -5 | 2 |  4
+     | 7 | 7 | seven | 5 | -5 |   |   
+     | 7 | 7 | seven | 5 | -5 |   |  0
+     | 8 | 8 | eight | 5 | -5 | 1 | -1
+     | 8 | 8 | eight | 5 | -5 | 0 |   
+     | 8 | 8 | eight | 5 | -5 | 5 | -5
+     | 8 | 8 | eight | 5 | -5 | 5 | -5
+     | 8 | 8 | eight | 5 | -5 | 2 |  2
+     | 8 | 8 | eight | 5 | -5 | 3 | -3
+     | 8 | 8 | eight | 5 | -5 | 2 |  4
+     | 8 | 8 | eight | 5 | -5 |   |   
+     | 8 | 8 | eight | 5 | -5 |   |  0
+     |   |   | null  | 5 | -5 | 1 | -1
+     |   |   | null  | 5 | -5 | 0 |   
+     |   |   | null  | 5 | -5 | 5 | -5
+     |   |   | null  | 5 | -5 | 5 | -5
+     |   |   | null  | 5 | -5 | 2 |  2
+     |   |   | null  | 5 | -5 | 3 | -3
+     |   |   | null  | 5 | -5 | 2 |  4
+     |   |   | null  | 5 | -5 |   |   
+     |   |   | null  | 5 | -5 |   |  0
+     |   | 0 | zero  | 5 | -5 | 1 | -1
+     |   | 0 | zero  | 5 | -5 | 0 |   
+     |   | 0 | zero  | 5 | -5 | 5 | -5
+     |   | 0 | zero  | 5 | -5 | 5 | -5
+     |   | 0 | zero  | 5 | -5 | 2 |  2
+     |   | 0 | zero  | 5 | -5 | 3 | -3
+     |   | 0 | zero  | 5 | -5 | 2 |  4
+     |   | 0 | zero  | 5 | -5 |   |   
+     |   | 0 | zero  | 5 | -5 |   |  0
+     | 2 | 3 | two   | 5 | -5 | 1 | -1
+     | 2 | 3 | two   | 5 | -5 | 0 |   
+     | 2 | 3 | two   | 5 | -5 | 5 | -5
+     | 2 | 3 | two   | 5 | -5 | 5 | -5
+     | 2 | 3 | two   | 5 | -5 | 2 |  2
+     | 2 | 3 | two   | 5 | -5 | 3 | -3
+     | 2 | 3 | two   | 5 | -5 | 2 |  4
+     | 2 | 3 | two   | 5 | -5 |   |   
+     | 2 | 3 | two   | 5 | -5 |   |  0
+     | 3 | 2 | three | 5 | -5 | 1 | -1
+     | 3 | 2 | three | 5 | -5 | 0 |   
+     | 3 | 2 | three | 5 | -5 | 5 | -5
+     | 3 | 2 | three | 5 | -5 | 5 | -5
+     | 3 | 2 | three | 5 | -5 | 2 |  2
+     | 3 | 2 | three | 5 | -5 | 3 | -3
+     | 3 | 2 | three | 5 | -5 | 2 |  4
+     | 3 | 2 | three | 5 | -5 |   |   
+     | 3 | 2 | three | 5 | -5 |   |  0
+     | 4 | 1 | four  | 5 | -5 | 1 | -1
+     | 4 | 1 | four  | 5 | -5 | 0 |   
+     | 4 | 1 | four  | 5 | -5 | 5 | -5
+     | 4 | 1 | four  | 5 | -5 | 5 | -5
+     | 4 | 1 | four  | 5 | -5 | 2 |  2
+     | 4 | 1 | four  | 5 | -5 | 3 | -3
+     | 4 | 1 | four  | 5 | -5 | 2 |  4
+     | 4 | 1 | four  | 5 | -5 |   |   
+     | 4 | 1 | four  | 5 | -5 |   |  0
+     | 7 | 7 | seven | 5 | -5 | 1 | -1
+     | 7 | 7 | seven | 5 | -5 | 0 |   
+     | 7 | 7 | seven | 5 | -5 | 5 | -5
+     | 7 | 7 | seven | 5 | -5 | 5 | -5
+     | 7 | 7 | seven | 5 | -5 | 2 |  2
+     | 7 | 7 | seven | 5 | -5 | 3 | -3
+     | 7 | 7 | seven | 5 | -5 | 2 |  4
+     | 7 | 7 | seven | 5 | -5 |   |   
+     | 7 | 7 | seven | 5 | -5 |   |  0
+     | 8 | 8 | eight | 5 | -5 | 1 | -1
+     | 8 | 8 | eight | 5 | -5 | 0 |   
+     | 8 | 8 | eight | 5 | -5 | 5 | -5
+     | 8 | 8 | eight | 5 | -5 | 5 | -5
+     | 8 | 8 | eight | 5 | -5 | 2 |  2
+     | 8 | 8 | eight | 5 | -5 | 3 | -3
+     | 8 | 8 | eight | 5 | -5 | 2 |  4
+     | 8 | 8 | eight | 5 | -5 |   |   
+     | 8 | 8 | eight | 5 | -5 |   |  0
+     |   |   | null  | 5 | -5 | 1 | -1
+     |   |   | null  | 5 | -5 | 0 |   
+     |   |   | null  | 5 | -5 | 5 | -5
+     |   |   | null  | 5 | -5 | 5 | -5
+     |   |   | null  | 5 | -5 | 2 |  2
+     |   |   | null  | 5 | -5 | 3 | -3
+     |   |   | null  | 5 | -5 | 2 |  4
+     |   |   | null  | 5 | -5 |   |   
+     |   |   | null  | 5 | -5 |   |  0
+     |   | 0 | zero  | 5 | -5 | 1 | -1
+     |   | 0 | zero  | 5 | -5 | 0 |   
+     |   | 0 | zero  | 5 | -5 | 5 | -5
+     |   | 0 | zero  | 5 | -5 | 5 | -5
+     |   | 0 | zero  | 5 | -5 | 2 |  2
+     |   | 0 | zero  | 5 | -5 | 3 | -3
+     |   | 0 | zero  | 5 | -5 | 2 |  4
+     |   | 0 | zero  | 5 | -5 |   |   
+     |   | 0 | zero  | 5 | -5 |   |  0
 (891 rows)
 
 --
@@ -1569,13 +1573,13 @@ SELECT '' AS "xxx", *
   FROM J1_TBL INNER JOIN J2_TBL USING (i);
  xxx | i | j |   t   | k  
 -----+---+---+-------+----
-     | 0 |   | zero  |   
-     | 1 | 4 | one   | -1
-     | 2 | 3 | two   |  2
+     | 5 | 0 | five  | -5
+     | 5 | 0 | five  | -5
      | 2 | 3 | two   |  4
+     | 2 | 3 | two   |  2
      | 3 | 2 | three | -3
-     | 5 | 0 | five  | -5
-     | 5 | 0 | five  | -5
+     | 1 | 4 | one   | -1
+     | 0 |   | zero  |   
 (7 rows)
 
 -- Same as above, slightly different syntax
@@ -1583,13 +1587,13 @@ SELECT '' AS "xxx", *
   FROM J1_TBL JOIN J2_TBL USING (i);
  xxx | i | j |   t   | k  
 -----+---+---+-------+----
-     | 0 |   | zero  |   
+     | 5 | 0 | five  | -5
+     | 5 | 0 | five  | -5
      | 1 | 4 | one   | -1
-     | 2 | 3 | two   |  2
+     | 0 |   | zero  |   
      | 2 | 3 | two   |  4
+     | 2 | 3 | two   |  2
      | 3 | 2 | three | -3
-     | 5 | 0 | five  | -5
-     | 5 | 0 | five  | -5
 (7 rows)
 
 SELECT '' AS "xxx", *
@@ -1625,35 +1629,35 @@ SELECT '' AS "xxx", *
   FROM J1_TBL NATURAL JOIN J2_TBL;
  xxx | i | j |   t   | k  
 -----+---+---+-------+----
-     | 0 |   | zero  |   
      | 1 | 4 | one   | -1
-     | 2 | 3 | two   |  2
+     | 0 |   | zero  |   
+     | 5 | 0 | five  | -5
+     | 5 | 0 | five  | -5
      | 2 | 3 | two   |  4
+     | 2 | 3 | two   |  2
      | 3 | 2 | three | -3
-     | 5 | 0 | five  | -5
-     | 5 | 0 | five  | -5
 (7 rows)
 
 SELECT '' AS "xxx", *
   FROM J1_TBL t1 (a, b, c) NATURAL JOIN J2_TBL t2 (a, d);
  xxx | a | b |   c   | d  
 -----+---+---+-------+----
-     | 0 |   | zero  |   
      | 1 | 4 | one   | -1
-     | 2 | 3 | two   |  2
+     | 0 |   | zero  |   
+     | 5 | 0 | five  | -5
+     | 5 | 0 | five  | -5
      | 2 | 3 | two   |  4
+     | 2 | 3 | two   |  2
      | 3 | 2 | three | -3
-     | 5 | 0 | five  | -5
-     | 5 | 0 | five  | -5
 (7 rows)
 
 SELECT '' AS "xxx", *
   FROM J1_TBL t1 (a, b, c) NATURAL JOIN J2_TBL t2 (d, a);
  xxx | a | b |  c   | d 
 -----+---+---+------+---
-     | 0 |   | zero |  
      | 2 | 3 | two  | 2
      | 4 | 1 | four | 2
+     | 0 |   | zero |  
 (3 rows)
 
 -- mismatch number of columns
@@ -1662,13 +1666,13 @@ SELECT '' AS "xxx", *
   FROM J1_TBL t1 (a, b) NATURAL JOIN J2_TBL t2 (a);
  xxx | a | b |   t   | k  
 -----+---+---+-------+----
-     | 0 |   | zero  |   
-     | 1 | 4 | one   | -1
-     | 2 | 3 | two   |  2
      | 2 | 3 | two   |  4
+     | 2 | 3 | two   |  2
      | 3 | 2 | three | -3
      | 5 | 0 | five  | -5
      | 5 | 0 | five  | -5
+     | 1 | 4 | one   | -1
+     | 0 |   | zero  |   
 (7 rows)
 
 --
@@ -1678,22 +1682,22 @@ SELECT '' AS "xxx", *
   FROM J1_TBL JOIN J2_TBL ON (J1_TBL.i = J2_TBL.i);
  xxx | i | j |   t   | i | k  
 -----+---+---+-------+---+----
-     | 0 |   | zero  | 0 |   
-     | 1 | 4 | one   | 1 | -1
-     | 2 | 3 | two   | 2 |  2
      | 2 | 3 | two   | 2 |  4
+     | 2 | 3 | two   | 2 |  2
      | 3 | 2 | three | 3 | -3
      | 5 | 0 | five  | 5 | -5
      | 5 | 0 | five  | 5 | -5
+     | 1 | 4 | one   | 1 | -1
+     | 0 |   | zero  | 0 |   
 (7 rows)
 
 SELECT '' AS "xxx", *
   FROM J1_TBL JOIN J2_TBL ON (J1_TBL.i = J2_TBL.k);
  xxx | i | j |  t   | i | k 
 -----+---+---+------+---+---
-     | 0 |   | zero |   | 0
      | 2 | 3 | two  | 2 | 2
      | 4 | 1 | four | 2 | 4
+     | 0 |   | zero |   | 0
 (3 rows)
 
 --
@@ -1703,13 +1707,13 @@ SELECT '' AS "xxx", *
   FROM J1_TBL JOIN J2_TBL ON (J1_TBL.i <= J2_TBL.k);
  xxx | i | j |   t   | i | k 
 -----+---+---+-------+---+---
-     | 1 | 4 | one   | 2 | 2
      | 2 | 3 | two   | 2 | 2
-     | 0 |   | zero  | 2 | 2
-     | 1 | 4 | one   | 2 | 4
      | 2 | 3 | two   | 2 | 4
      | 3 | 2 | three | 2 | 4
      | 4 | 1 | four  | 2 | 4
+     | 1 | 4 | one   | 2 | 2
+     | 0 |   | zero  | 2 | 2
+     | 1 | 4 | one   | 2 | 4
      | 0 |   | zero  | 2 | 4
      | 0 |   | zero  |   | 0
 (9 rows)
@@ -1762,13 +1766,13 @@ SELECT '' AS "xxx", *
   FROM J1_TBL RIGHT OUTER JOIN J2_TBL USING (i);
  xxx | i | j |   t   | k  
 -----+---+---+-------+----
-     | 0 |   | zero  |   
+     | 5 | 0 | five  | -5
+     | 5 | 0 | five  | -5
      | 1 | 4 | one   | -1
+     | 0 |   | zero  |   
      | 2 | 3 | two   |  2
-     | 2 | 3 | two   |  4
      | 3 | 2 | three | -3
-     | 5 | 0 | five  | -5
-     | 5 | 0 | five  | -5
+     | 2 | 3 | two   |  4
      |   |   |       |   
      |   |   |       |  0
 (9 rows)
@@ -1777,15 +1781,15 @@ SELECT '' AS "xxx", *
   FROM J1_TBL RIGHT JOIN J2_TBL USING (i);
  xxx | i | j |   t   | k  
 -----+---+---+-------+----
-     | 0 |   | zero  |   
      | 1 | 4 | one   | -1
+     | 0 |   | zero  |   
      | 2 | 3 | two   |  2
-     | 2 | 3 | two   |  4
      | 3 | 2 | three | -3
-     | 5 | 0 | five  | -5
-     | 5 | 0 | five  | -5
+     | 2 | 3 | two   |  4
      |   |   |       |   
      |   |   |       |  0
+     | 5 | 0 | five  | -5
+     | 5 | 0 | five  | -5
 (9 rows)
 
 SELECT '' AS "xxx", *
@@ -1852,8 +1856,14 @@ SELECT '' AS "xxx", *
 -- Multiway full join
 --
 CREATE TABLE t1 (name TEXT, n INTEGER);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'name' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TABLE t2 (name TEXT, n INTEGER);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'name' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TABLE t3 (name TEXT, n INTEGER);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'name' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO t1 VALUES ( 'bb', 11 );
 INSERT INTO t2 VALUES ( 'bb', 12 );
 INSERT INTO t2 VALUES ( 'cc', 22 );
@@ -1865,9 +1875,9 @@ SELECT * FROM t1 FULL JOIN t2 USING (name) FULL JOIN t3 USING (name);
  name | n  | n  | n  
 ------+----+----+----
  bb   | 11 | 12 | 13
- cc   |    | 22 | 23
  dd   |    |    | 33
  ee   |    | 42 |   
+ cc   |    | 22 | 23
 (4 rows)
 
 --
@@ -1892,9 +1902,9 @@ LEFT JOIN
 USING (name);
  name | n  | n  
 ------+----+----
- bb   | 12 | 13
- cc   | 22 | 23
  ee   | 42 |   
+ cc   | 22 | 23
+ bb   | 12 | 13
 (3 rows)
 
 SELECT * FROM
@@ -1905,9 +1915,9 @@ USING (name);
  name | n  | n  
 ------+----+----
  bb   | 12 | 13
- cc   | 22 | 23
  dd   |    | 33
  ee   | 42 |   
+ cc   | 22 | 23
 (4 rows)
 
 -- Cases with non-nullable expressions in subquery results;
@@ -1928,9 +1938,9 @@ NATURAL LEFT JOIN
 (SELECT name, n as s3_n, 3 as s3_2 FROM t3) s3;
  name | s2_n | s2_2 | s3_n | s3_2 
 ------+------+------+------+------
- bb   |   12 |    2 |   13 |    3
  cc   |   22 |    2 |   23 |    3
  ee   |   42 |    2 |      |     
+ bb   |   12 |    2 |   13 |    3
 (3 rows)
 
 SELECT * FROM
@@ -1939,8 +1949,8 @@ NATURAL FULL JOIN
 (SELECT name, n as s3_n, 3 as s3_2 FROM t3) s3;
  name | s2_n | s2_2 | s3_n | s3_2 
 ------+------+------+------+------
- bb   |   12 |    2 |   13 |    3
  cc   |   22 |    2 |   23 |    3
+ bb   |   12 |    2 |   13 |    3
  dd   |      |      |   33 |    3
  ee   |   42 |    2 |      |     
 (4 rows)
@@ -1965,9 +1975,9 @@ NATURAL FULL JOIN
  name | s1_n | s1_1 | s2_n | s2_2 | s3_n | s3_2 
 ------+------+------+------+------+------+------
  bb   |   11 |    1 |   12 |    2 |   13 |    3
- cc   |      |      |   22 |    2 |   23 |    3
  dd   |      |      |      |      |   33 |    3
  ee   |      |      |   42 |    2 |      |     
+ cc   |      |      |   22 |    2 |   23 |    3
 (4 rows)
 
 SELECT * FROM
@@ -1981,9 +1991,9 @@ NATURAL FULL JOIN
  name | s1_n | s2_n | s3_n 
 ------+------+------+------
  bb   |   11 |   12 |   13
- cc   |      |   22 |   23
  dd   |      |      |   33
  ee   |      |   42 |     
+ cc   |      |   22 |   23
 (4 rows)
 
 SELECT * FROM
@@ -1996,20 +2006,24 @@ NATURAL FULL JOIN
   ) ss2;
  name | s1_n | s2_n | s2_2 | s3_n 
 ------+------+------+------+------
- bb   |   11 |   12 |    2 |   13
  cc   |      |   22 |    2 |   23
+ bb   |   11 |   12 |    2 |   13
  dd   |      |      |      |   33
  ee   |      |   42 |    2 |     
 (4 rows)
 
 -- Test for propagation of nullability constraints into sub-joins
 create temp table x (x1 int, x2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into x values (1,11);
 insert into x values (2,22);
 insert into x values (3,null);
 insert into x values (4,44);
 insert into x values (5,null);
 create temp table y (y1 int, y2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'y1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into y values (1,111);
 insert into y values (2,222);
 insert into y values (3,333);
@@ -2017,11 +2031,11 @@ insert into y values (4,null);
 select * from x;
  x1 | x2 
 ----+----
-  1 | 11
   2 | 22
   3 |   
   4 | 44
   5 |   
+  1 | 11
 (5 rows)
 
 select * from y;
@@ -2036,20 +2050,20 @@ select * from y;
 select * from x left join y on (x1 = y1 and x2 is not null);
  x1 | x2 | y1 | y2  
 ----+----+----+-----
-  1 | 11 |  1 | 111
   2 | 22 |  2 | 222
   3 |    |    |    
   4 | 44 |  4 |    
   5 |    |    |    
+  1 | 11 |  1 | 111
 (5 rows)
 
 select * from x left join y on (x1 = y1 and y2 is not null);
  x1 | x2 | y1 | y2  
 ----+----+----+-----
-  1 | 11 |  1 | 111
   2 | 22 |  2 | 222
   3 |    |  3 | 333
   4 | 44 |    |    
+  1 | 11 |  1 | 111
   5 |    |    |    
 (5 rows)
 
@@ -2057,43 +2071,43 @@ select * from (x left join y on (x1 = y1)) left join x xx(xx1,xx2)
 on (x1 = xx1);
  x1 | x2 | y1 | y2  | xx1 | xx2 
 ----+----+----+-----+-----+-----
-  1 | 11 |  1 | 111 |   1 |  11
   2 | 22 |  2 | 222 |   2 |  22
   3 |    |  3 | 333 |   3 |    
   4 | 44 |  4 |     |   4 |  44
   5 |    |    |     |   5 |    
+  1 | 11 |  1 | 111 |   1 |  11
 (5 rows)
 
 select * from (x left join y on (x1 = y1)) left join x xx(xx1,xx2)
 on (x1 = xx1 and x2 is not null);
  x1 | x2 | y1 | y2  | xx1 | xx2 
 ----+----+----+-----+-----+-----
-  1 | 11 |  1 | 111 |   1 |  11
   2 | 22 |  2 | 222 |   2 |  22
   3 |    |  3 | 333 |     |    
   4 | 44 |  4 |     |   4 |  44
   5 |    |    |     |     |    
+  1 | 11 |  1 | 111 |   1 |  11
 (5 rows)
 
 select * from (x left join y on (x1 = y1)) left join x xx(xx1,xx2)
 on (x1 = xx1 and y2 is not null);
  x1 | x2 | y1 | y2  | xx1 | xx2 
 ----+----+----+-----+-----+-----
-  1 | 11 |  1 | 111 |   1 |  11
+  5 |    |    |     |     |    
   2 | 22 |  2 | 222 |   2 |  22
   3 |    |  3 | 333 |   3 |    
   4 | 44 |  4 |     |     |    
-  5 |    |    |     |     |    
+  1 | 11 |  1 | 111 |   1 |  11
 (5 rows)
 
 select * from (x left join y on (x1 = y1)) left join x xx(xx1,xx2)
 on (x1 = xx1 and xx2 is not null);
  x1 | x2 | y1 | y2  | xx1 | xx2 
 ----+----+----+-----+-----+-----
-  1 | 11 |  1 | 111 |   1 |  11
   2 | 22 |  2 | 222 |   2 |  22
   3 |    |  3 | 333 |     |    
   4 | 44 |  4 |     |   4 |  44
+  1 | 11 |  1 | 111 |   1 |  11
   5 |    |    |     |     |    
 (5 rows)
 
@@ -2120,9 +2134,9 @@ select * from (x left join y on (x1 = y1)) left join x xx(xx1,xx2)
 on (x1 = xx1) where (xx2 is not null);
  x1 | x2 | y1 | y2  | xx1 | xx2 
 ----+----+----+-----+-----+-----
-  1 | 11 |  1 | 111 |   1 |  11
   2 | 22 |  2 | 222 |   2 |  22
   4 | 44 |  4 |     |   4 |  44
+  1 | 11 |  1 | 111 |   1 |  11
 (3 rows)
 
 --
@@ -2173,8 +2187,8 @@ explain (costs off)
 select aa, bb, unique1, unique1
   from tenk1 right join b on aa = unique1
   where bb < bb and bb is null;
-            QUERY PLAN             
------------------------------------
+             QUERY PLAN              
+-------------------------------------
  Result
    One-Time Filter: false
  Optimizer: Postgres query optimizer
@@ -2277,7 +2291,7 @@ select * from
          ->  Sort
                Sort Key: j2_tbl.i, j2_tbl.k
                ->  Seq Scan on j2_tbl
- Optimizer: Pivotal Optimizer (GPORCA) version 3.44.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (10 rows)
 
 select * from
@@ -2286,25 +2300,25 @@ select * from
   on j1_tbl.i = j2_tbl.i and j1_tbl.i = j2_tbl.k; --order none
  i | j |   t   | i | k  
 ---+---+-------+---+----
- 7 | 7 | seven |   |   
- 5 | 0 | five  |   |   
-   |   | null  |   |   
-   | 0 | zero  |   |   
- 1 | 4 | one   |   |   
    |   |       | 0 |   
-   |   |       | 2 |  4
-   |   |       | 5 | -5
-   |   |       |   |   
- 4 | 1 | four  |   |   
  0 |   | zero  |   |   
- 2 | 3 | two   | 2 |  2
-   |   |       |   |  0
-   |   |       | 3 | -3
- 8 | 8 | eight |   |   
- 6 | 6 | six   |   |   
- 3 | 2 | three |   |   
-   |   |       | 5 | -5
    |   |       | 1 | -1
+ 1 | 4 | one   |   |   
+   |   |       | 5 | -5
+   |   |       | 5 | -5
+ 5 | 0 | five  |   |   
+ 6 | 6 | six   |   |   
+ 2 | 3 | two   | 2 |  2
+   |   |       | 2 |  4
+   |   |       | 3 | -3
+   |   |       |   |  0
+   |   |       |   |   
+ 3 | 2 | three |   |   
+ 4 | 1 | four  |   |   
+ 7 | 7 | seven |   |   
+ 8 | 8 | eight |   |   
+   | 0 | zero  |   |   
+   |   | null  |   |   
 (19 rows)
 
 reset enable_mergejoin;
@@ -2334,7 +2348,7 @@ select count(*) from
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                  Hash Key: tenk1_1.unique2, tenk1_1.hundred, tenk1_1.unique2
                                  ->  Seq Scan on tenk1 tenk1_1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (13 rows)
 
 select count(*) from
@@ -2360,9 +2374,17 @@ DROP TABLE J2_TBL;
 -- Both DELETE and UPDATE allow the specification of additional tables
 -- to "join" against to determine which rows should be modified.
 CREATE TEMP TABLE t1 (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TEMP TABLE t2 (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TEMP TABLE t3 (x int, y int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TEMP TABLE t4 (x int, y int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO t1 VALUES (5, 10);
 INSERT INTO t1 VALUES (15, 20);
 INSERT INTO t1 VALUES (100, 100);
@@ -2377,18 +2399,18 @@ DELETE FROM t3 USING t1 table1 WHERE t3.x = table1.a;
 SELECT * FROM t3;
   x  |  y  
 -----+-----
-   6 |   7
    7 |   8
  500 | 100
+   6 |   7
 (3 rows)
 
 DELETE FROM t4 USING t1 JOIN t2 USING (a) WHERE t4.x > t1.a;
 SELECT * FROM t4;
  x | y  
 ---+----
+ 7 |  8
  5 | 20
  6 |  7
- 7 |  8
 (3 rows)
 
 DELETE FROM t3 USING t3 t3_other WHERE t3.x = t3_other.x AND t3.y = t3_other.y;
@@ -2399,24 +2421,29 @@ SELECT * FROM t3;
 
 -- Test join against inheritance tree
 create temp table t2a () inherits (t2);
+NOTICE:  table has parent, setting distribution columns to match parent table
 insert into t2a values (200, 2001);
 select * from t1 left join t2 on (t1.a = t2.a);
   a  |  b   |  a  |  b   
 -----+------+-----+------
-   5 |   10 |     |     
-  15 |   20 |     |     
- 100 |  100 |     |     
  200 | 1000 | 200 | 2000
  200 | 1000 | 200 | 2001
+ 100 |  100 |     |     
+   5 |   10 |     |     
+  15 |   20 |     |     
 (5 rows)
 
 --
 -- regression test for 8.1 merge right join bug
 --
 CREATE TEMP TABLE tt1 ( tt1_id int4, joincol int4 );
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'tt1_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO tt1 VALUES (1, 11);
 INSERT INTO tt1 VALUES (2, NULL);
 CREATE TEMP TABLE tt2 ( tt2_id int4, joincol int4 );
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'tt2_id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO tt2 VALUES (21, 11);
 INSERT INTO tt2 VALUES (22, 11);
 set enable_hashjoin to off;
@@ -2425,17 +2452,17 @@ set enable_nestloop to off;
 select tt1.*, tt2.* from tt1 left join tt2 on tt1.joincol = tt2.joincol;
  tt1_id | joincol | tt2_id | joincol 
 --------+---------+--------+---------
+      2 |         |        |        
       1 |      11 |     21 |      11
       1 |      11 |     22 |      11
-      2 |         |        |        
 (3 rows)
 
 select tt1.*, tt2.* from tt2 right join tt1 on tt1.joincol = tt2.joincol;
  tt1_id | joincol | tt2_id | joincol 
 --------+---------+--------+---------
-      1 |      11 |     21 |      11
-      1 |      11 |     22 |      11
       2 |         |        |        
+      1 |      11 |     22 |      11
+      1 |      11 |     21 |      11
 (3 rows)
 
 reset enable_hashjoin;
@@ -2444,10 +2471,14 @@ reset enable_nestloop;
 -- regression test for 8.2 bug with improper re-ordering of left joins
 --
 create temp table tt3(f1 int, f2 text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into tt3 select x, repeat('xyzzy', 100) from generate_series(1,10000) x;
 create index tt3i on tt3(f1);
 analyze tt3;
 create temp table tt4(f1 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into tt4 values (0),(1),(9999);
 analyze tt4;
 SELECT a.f1
@@ -2460,9 +2491,9 @@ LEFT JOIN (
 WHERE d.f1 IS NULL;
   f1  
 ------
+ 9999
     0
     1
- 9999
 (3 rows)
 
 --
@@ -2481,55 +2512,44 @@ where not exists (
               ) a1 on t3.c2 = a1.c1
   where t1.c1 = t2.c2
 );
-                                                                   QUERY PLAN                                                                   
-------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice7; segments: 3)
-   ->  Result
-         Filter: (COALESCE((count((count()))), '0'::bigint) = '0'::bigint)
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Hash Anti Join
+   Hash Cond: (tt4x.c1 = tt4x_1.c2)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on tt4x
+   ->  Hash
          ->  Result
                ->  Hash Left Join
-                     Hash Cond: (tt4x.c1 = tt4x_1.c2)
-                     ->  Seq Scan on tt4x
+                     Hash Cond: (tt4x_2.c2 = tt4x_4.c1)
+                     ->  Gather Motion 3:1  (slice3; segments: 3)
+                           ->  Hash Left Join
+                                 Hash Cond: (tt4x_1.c3 = tt4x_2.c1)
+                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                       Hash Key: tt4x_1.c3
+                                       ->  Seq Scan on tt4x tt4x_1
+                                 ->  Hash
+                                       ->  Seq Scan on tt4x tt4x_2
                      ->  Hash
-                           ->  Result
-                                 ->  GroupAggregate
-                                       Group Key: tt4x_1.c2
-                                       ->  Sort
-                                             Sort Key: tt4x_1.c2
-                                             ->  Redistribute Motion 3:3  (slice6; segments: 3)
-                                                   Hash Key: tt4x_1.c2
-                                                   ->  Result
-                                                         ->  GroupAggregate
-                                                               Group Key: tt4x_1.c2
-                                                               ->  Sort
-                                                                     Sort Key: tt4x_1.c2
-                                                                     ->  Redistribute Motion 1:3  (slice5)
-                                                                           ->  Hash Left Join
-                                                                                 Hash Cond: (tt4x_2.c2 = tt4x_4.c1)
-                                                                                 ->  Gather Motion 3:1  (slice2; segments: 3)
-                                                                                       ->  Hash Left Join
-                                                                                             Hash Cond: (tt4x_1.c3 = tt4x_2.c1)
-                                                                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                                                                                   Hash Key: tt4x_1.c3
-                                                                                                   ->  Seq Scan on tt4x tt4x_1
-                                                                                             ->  Hash
-                                                                                                   ->  Seq Scan on tt4x tt4x_2
-                                                                                 ->  Hash
-                                                                                       ->  Hash Left Join
-                                                                                             Hash Cond: (tt4x_3.c2 = tt4x_4.c1)
-                                                                                             ->  Gather Motion 3:1  (slice3; segments: 3)
-                                                                                                   ->  Seq Scan on tt4x tt4x_3
-                                                                                             ->  Hash
-                                                                                                   ->  Gather Motion 3:1  (slice4; segments: 3)
-                                                                                                         ->  Seq Scan on tt4x tt4x_4
+                           ->  Hash Left Join
+                                 Hash Cond: (tt4x_3.c2 = tt4x_4.c1)
+                                 ->  Gather Motion 3:1  (slice4; segments: 3)
+                                       ->  Seq Scan on tt4x tt4x_3
+                                 ->  Hash
+                                       ->  Gather Motion 3:1  (slice5; segments: 3)
+                                             ->  Seq Scan on tt4x tt4x_4
  Optimizer: Pivotal Optimizer (GPORCA)
-(40 rows)
+(25 rows)
 
 --
 -- regression test for problems of the sort depicted in bug #3494
 --
 create temp table tt5(f1 int, f2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create temp table tt6(f1 int, f2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'f1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into tt5 values(1, 10);
 insert into tt5 values(1, 11);
 insert into tt6 values(1, 9);
@@ -2545,7 +2565,11 @@ select * from tt5,tt6 where tt5.f1 = tt6.f1 and tt5.f1 = tt5.f2 - tt6.f2;
 -- regression test for problems of the sort depicted in bug #3588
 --
 create temp table xx (pkxx int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'pkxx' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create temp table yy (pkyy int, pkxx int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'pkyy' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into xx values (1);
 insert into xx values (2);
 insert into xx values (3);
@@ -2561,8 +2585,8 @@ from yy
  yy_pkyy | yy_pkxx | yya_pkyy | xxa_pkxx | xxb_pkxx 
 ---------+---------+----------+----------+----------
      101 |       1 |      101 |        1 |        1
-     201 |       2 |          |          |        1
      301 |         |          |          |        1
+     201 |       2 |          |          |        1
 (3 rows)
 
 --
@@ -2632,7 +2656,11 @@ set enable_mergejoin = 1;
 set enable_hashjoin = 0;
 set enable_nestloop = 0;
 create temp table a (i integer);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create temp table b (x integer, y integer);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 select * from a left join b on i = x and i = y and x = i;
  i | x | y 
 ---+---+---
@@ -2658,7 +2686,7 @@ select a.idv, b.idv from tidv a, tidv b where a.idv = b.idv;
                ->  Seq Scan on tidv
          ->  Index Scan using tidv_idv_idx on tidv tidv_1
                Index Cond: (idv = tidv.idv)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (8 rows)
 
 set enable_mergejoin = 0;
@@ -2674,7 +2702,7 @@ select a.idv, b.idv from tidv a, tidv b where a.idv = b.idv;
                ->  Seq Scan on tidv
          ->  Index Scan using tidv_idv_idx on tidv tidv_1
                Index Cond: (idv = tidv.idv)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.19.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (8 rows)
 
 rollback;
@@ -2825,8 +2853,8 @@ SELECT qq, unique1
   ( SELECT COALESCE(q2, -1) AS qq FROM int8_tbl b ) AS ss2
   USING (qq)
   INNER JOIN tenk1 c ON qq = unique2;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)
    ->  Result
          ->  Nested Loop
@@ -2850,7 +2878,7 @@ SELECT qq, unique1
                                                          ->  Seq Scan on int8_tbl int8_tbl_1
                ->  Index Scan using tenk1_unique2 on tenk1
                      Index Cond: (unique2 = (COALESCE((COALESCE(int8_tbl.q1, '0'::bigint)), (COALESCE(int8_tbl_1.q2, '-1'::bigint)))))
- Optimizer: Pivotal Optimizer (GPORCA) version 3.44.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (24 rows)
 
 SELECT qq, unique1
@@ -2862,9 +2890,9 @@ SELECT qq, unique1
   INNER JOIN tenk1 c ON qq = unique2;
  qq  | unique1 
 -----+---------
- 123 |    4596
- 123 |    4596
  456 |    7318
+ 123 |    4596
+ 123 |    4596
 (3 rows)
 
 --
@@ -2882,12 +2910,14 @@ create temp table nt2 (
   b2 boolean,
   foreign key (nt1_id) references nt1(id)
 );
+WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 create temp table nt3 (
   id int primary key,
   nt2_id int,
   c1 boolean,
   foreign key (nt2_id) references nt2(id)
 );
+WARNING:  referential integrity (FOREIGN KEY) constraints are not supported in Greenplum Database, will not be enforced
 insert into nt1 values (1,true,true);
 insert into nt1 values (2,true,false);
 insert into nt1 values (3,false,false);
@@ -3015,46 +3045,46 @@ order by 1,2;
 select * from int4_tbl a full join int4_tbl b on true;
      f1      |     f1      
 -------------+-------------
-           0 |           0
            0 |      123456
            0 |     -123456
+           0 |           0
            0 |  2147483647
            0 | -2147483647
-      123456 |           0
-      123456 |      123456
-      123456 |     -123456
-      123456 |  2147483647
-      123456 | -2147483647
-     -123456 |           0
-     -123456 |      123456
-     -123456 |     -123456
-     -123456 |  2147483647
-     -123456 | -2147483647
-  2147483647 |           0
   2147483647 |      123456
   2147483647 |     -123456
+  2147483647 |           0
   2147483647 |  2147483647
   2147483647 | -2147483647
- -2147483647 |           0
  -2147483647 |      123456
  -2147483647 |     -123456
+ -2147483647 |           0
  -2147483647 |  2147483647
  -2147483647 | -2147483647
+      123456 |      123456
+      123456 |     -123456
+      123456 |           0
+      123456 |  2147483647
+      123456 | -2147483647
+     -123456 |      123456
+     -123456 |     -123456
+     -123456 |           0
+     -123456 |  2147483647
+     -123456 | -2147483647
 (25 rows)
 
 select * from int4_tbl a full join int4_tbl b on false;
      f1      |     f1      
 -------------+-------------
              |           0
-             |      123456
-             |     -123456
              |  2147483647
              | -2147483647
+             |      123456
+             |     -123456
            0 |            
-      123456 |            
-     -123456 |            
   2147483647 |            
  -2147483647 |            
+      123456 |            
+     -123456 |            
 (10 rows)
 
 --
@@ -3109,7 +3139,7 @@ where q1 = thousand or q2 = thousand;
                ->  Broadcast Motion 3:3  (slice1; segments: 3)
                      ->  Seq Scan on int4_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
-(22 rows)
+(23 rows)
 
 explain (costs off)
 select * from
@@ -3137,7 +3167,7 @@ where thousand = (q1 + q2);
                ->  Broadcast Motion 3:3  (slice1; segments: 3)
                      ->  Seq Scan on int4_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(18 rows)
 
 --
 -- test ability to generate a suitable plan for a star-schema query
@@ -3291,7 +3321,7 @@ select * from tenk1 a join tenk1 b on
                                  Index Cond: (unique1 = 2)
                            ->  Bitmap Index Scan on tenk1_hundred
                                  Index Cond: (hundred = 4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.82.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (26 rows)
 
 explain (costs off)
@@ -3319,7 +3349,7 @@ select * from tenk1 a join tenk1 b on
                                  Index Cond: (unique1 = 1)
                            ->  Bitmap Index Scan on tenk1_unique2
                                  Index Cond: (unique2 = 3)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.82.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (21 rows)
 
 explain (costs off)
@@ -3354,7 +3384,7 @@ select * from tenk1 a join tenk1 b on
                                        Index Cond: (unique2 = 3)
                            ->  Bitmap Index Scan on tenk1_unique2
                                  Index Cond: (unique2 = 7)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.82.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (27 rows)
 
 --
@@ -3528,8 +3558,8 @@ select * from
 ) ss
 where fault = 122
 order by fault;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)
    Merge Key: ((COALESCE(tenk1.unique1, '-1'::integer) + int8_tbl.q1))
    ->  Sort
@@ -3729,7 +3759,7 @@ using (join_key);
                                  ->  Seq Scan on public.int4_tbl
                                        Output: int4_tbl.f1
  Optimizer: Pivotal Optimizer (GPORCA)
- Settings: enable_seqscan=on, optimizer=on
+ Settings: optimizer=on
 (27 rows)
 
 select foo1.join_key as foo1_id, foo3.join_key AS foo3_id, bug_field from
@@ -3813,7 +3843,7 @@ select t1.* from
                      ->  Seq Scan on public.int4_tbl
                            Output: int4_tbl.f1
  Optimizer: Pivotal Optimizer (GPORCA)
- Settings: enable_seqscan=on, optimizer=on
+ Settings: optimizer=on
 (48 rows)
 
 select t1.* from
@@ -3898,7 +3928,7 @@ select t1.* from
                      ->  Seq Scan on public.int4_tbl int4_tbl_1
                            Output: int4_tbl_1.f1
  Optimizer: Pivotal Optimizer (GPORCA)
- Settings: enable_seqscan=on, optimizer=on
+ Settings: optimizer=on
 (54 rows)
 
 select t1.* from
@@ -3989,7 +4019,7 @@ select t1.* from
                      ->  Seq Scan on public.int4_tbl int4_tbl_1
                            Output: int4_tbl_1.f1
  Optimizer: Pivotal Optimizer (GPORCA)
- Settings: enable_seqscan=on, optimizer=on
+ Settings: optimizer=on
 (59 rows)
 
 select t1.* from
@@ -4005,8 +4035,8 @@ select t1.* from
   on (i8.q2 = i4.f1);
         f1         
 -------------------
- doh!
  hi de ho neighbor
+ doh!
 (2 rows)
 
 explain (verbose, costs off)
@@ -4053,7 +4083,7 @@ select * from
                      Output: int4_tbl.f1
                      ->  Seq Scan on public.int4_tbl
                            Output: int4_tbl.f1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA)
  Settings: optimizer=on
 (35 rows)
 
@@ -4191,7 +4221,7 @@ where ss1.c2 = 0;
                                  ->  Seq Scan on public.text_tbl
                                        Output: text_tbl.f1
  Optimizer: Postgres query optimizer
- Settings: enable_seqscan=on, optimizer=on
+ Settings: optimizer=on
 (44 rows)
 
 --end_ignore
@@ -4288,7 +4318,7 @@ explain (costs off)
                                  ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                        Hash Key: tenk1_1.unique2
                                        ->  Seq Scan on tenk1 tenk1_1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.44.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (18 rows)
 
 --
@@ -4303,8 +4333,8 @@ explain (verbose, costs off)
   select a.q2, b.q1
     from int8_tbl a left join int8_tbl b on a.q2 = coalesce(b.q1, 1)
     where coalesce(b.q1, 1) > 0;
-                               QUERY PLAN                                
--------------------------------------------------------------------------
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
  Result
    Output: int8_tbl.q2, int8_tbl_1.q1
    Filter: (COALESCE(int8_tbl_1.q1, '1'::bigint) > 0)
@@ -4321,8 +4351,8 @@ explain (verbose, costs off)
                      Output: int8_tbl_1.q1
                      ->  Seq Scan on public.int8_tbl int8_tbl_1
                            Output: int8_tbl_1.q1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
- Settings: enable_hashjoin=off, enable_mergejoin=on, enable_nestloop=off
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_hashjoin=off, enable_mergejoin=on, enable_nestloop=off, optimizer=on
 (18 rows)
 
 select a.q2, b.q1
@@ -4330,16 +4360,16 @@ select a.q2, b.q1
   where coalesce(b.q1, 1) > 0;
         q2         |        q1        
 -------------------+------------------
-               456 |                 
+               123 |              123
+               123 |              123
   4567890123456789 | 4567890123456789
   4567890123456789 | 4567890123456789
   4567890123456789 | 4567890123456789
  -4567890123456789 |                 
+               456 |                 
   4567890123456789 | 4567890123456789
   4567890123456789 | 4567890123456789
   4567890123456789 | 4567890123456789
-               123 |              123
-               123 |              123
 (10 rows)
 
 reset enable_hashjoin;
@@ -4367,7 +4397,7 @@ explain (costs off) SELECT a.* FROM a LEFT JOIN b ON a.b_id = b.id;
                ->  Seq Scan on a
          ->  Index Scan using b_pkey on b
                Index Cond: (id = a.b_id)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (9 rows)
 
 explain (costs off) SELECT b.* FROM b LEFT JOIN c ON b.c_id = c.id;
@@ -4381,7 +4411,7 @@ explain (costs off) SELECT b.* FROM b LEFT JOIN c ON b.c_id = c.id;
                ->  Seq Scan on b
          ->  Index Scan using c_pkey on c
                Index Cond: (id = b.c_id)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (9 rows)
 
 explain (costs off)
@@ -4405,7 +4435,7 @@ explain (costs off)
                                  ->  Seq Scan on b
                            ->  Index Scan using c_pkey on c
                                  Index Cond: (id = b.c_id)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (17 rows)
 
 -- check optimization of outer join within another special join
@@ -4413,8 +4443,8 @@ explain (costs off)
 select id from a where id in (
 	select b.id from b left join c on b.id = c.id
 );
-                  QUERY PLAN                   
------------------------------------------------
+                      QUERY PLAN                      
+------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Hash Semi Join
          Hash Cond: (a.id = b.id)
@@ -4425,7 +4455,7 @@ select id from a where id in (
                      ->  Seq Scan on b
                      ->  Index Scan using c_pkey on c
                            Index Cond: (id = b.id)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (11 rows)
 
 rollback;
@@ -4444,15 +4474,15 @@ select p.* from parent p left join child c on (p.k = c.k);
 
 explain (costs off)
   select p.* from parent p left join child c on (p.k = c.k);
-                QUERY PLAN                
-------------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop Left Join
          Join Filter: true
          ->  Seq Scan on parent
          ->  Index Scan using child_k_key on child
                Index Cond: (k = parent.k)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 
 -- this case is not
@@ -4494,12 +4524,12 @@ explain (costs off)
 select p.* from
   parent p left join child c on (p.k = c.k)
   where p.k = 1 and p.k = 2;
-           QUERY PLAN           
---------------------------------
+              QUERY PLAN               
+---------------------------------------
  Result
    ->  Result
          One-Time Filter: false
- Optimizer: Pivotal Optimizer (GPORCA) version 2.54.2
+ Optimizer: Pivotal Optimizer (GPORCA)
 (4 rows)
 
 select p.* from
@@ -4513,12 +4543,12 @@ explain (costs off)
 select p.* from
   (parent p left join child c on (p.k = c.k)) join parent x on p.k = x.k
   where p.k = 1 and p.k = 2;
-           QUERY PLAN           
---------------------------------
+              QUERY PLAN               
+---------------------------------------
  Result
    ->  Result
          One-Time Filter: false
- Optimizer: Pivotal Optimizer (GPORCA) version 2.54.2
+ Optimizer: Pivotal Optimizer (GPORCA)
 (4 rows)
 
 -- bug 5255: this is not optimizable by join removal
@@ -4554,9 +4584,9 @@ SELECT * FROM
 ---+------------------+-------------------+------------------
  1 |              123 |               456 |              123
  1 |              123 |  4567890123456789 |              123
- 1 | 4567890123456789 |               123 |               42
  1 | 4567890123456789 |  4567890123456789 | 4567890123456789
  1 | 4567890123456789 | -4567890123456789 | 4567890123456789
+ 1 | 4567890123456789 |               123 |               42
 (5 rows)
 
 rollback;
@@ -4624,7 +4654,7 @@ where ss.stringu2 !~* ss.case1;
                                        Index Cond: (f1 = (tenk1.string4)::text)
          ->  Hash
                ->  Seq Scan on text_tbl
- Optimizer: Pivotal Optimizer (GPORCA) version 3.9.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (23 rows)
 
 select t0.*
@@ -4725,11 +4755,11 @@ select unique2, x.*
 from int4_tbl x left join lateral (select unique1, unique2 from tenk1 where f1 = unique1) ss on true;
  unique2 |     f1      
 ---------+-------------
-    9998 |           0
          |      123456
          |     -123456
-         |  2147483647
+    9998 |           0
          | -2147483647
+         |  2147483647
 (5 rows)
 
 explain (costs off)
@@ -4751,21 +4781,21 @@ explain (costs off)
 select *, (select r from (select q1 as q2) x, (select q2 as r) y) from int8_tbl;
         q1        |        q2         |         r         
 ------------------+-------------------+-------------------
-              123 |               456 |               456
-              123 |  4567890123456789 |  4567890123456789
  4567890123456789 |               123 |               123
  4567890123456789 |  4567890123456789 |  4567890123456789
  4567890123456789 | -4567890123456789 | -4567890123456789
+              123 |               456 |               456
+              123 |  4567890123456789 |  4567890123456789
 (5 rows)
 
 select *, (select r from (select q1 as q2) x, lateral (select q2 as r) y) from int8_tbl;
         q1        |        q2         |        r         
 ------------------+-------------------+------------------
-              123 |               456 |              123
-              123 |  4567890123456789 |              123
  4567890123456789 |               123 | 4567890123456789
  4567890123456789 |  4567890123456789 | 4567890123456789
  4567890123456789 | -4567890123456789 | 4567890123456789
+              123 |               456 |              123
+              123 |  4567890123456789 |              123
 (5 rows)
 
 -- lateral with function in FROM
@@ -4881,85 +4911,16 @@ select count(*) from tenk1 a,
 -- these will get fixed once we catch up to those. Or if not, at least it will be
 -- nicer to work on the code, knowing that there aren't going to be a dozen commits
 -- coming up, touching the same area.
+-- FAIL with ERROR:  could not devise a query plan for the given query (pathnode.c:416)
 explain (costs off)
   select * from int8_tbl a,
     int8_tbl x left join lateral (select a.q1 from int4_tbl y) ss(z)
       on x.q2 = ss.z;
-                QUERY PLAN                
-------------------------------------------
- Nested Loop
-   ->  Seq Scan on int8_tbl a
-   ->  Hash Left Join
-         Hash Cond: (x.q2 = (a.q1))
-         ->  Seq Scan on int8_tbl x
-         ->  Hash
-               ->  Seq Scan on int4_tbl y
-(7 rows)
-
+ERROR:  could not devise a query plan for the given query (pathnode.c:422)
 select * from int8_tbl a,
   int8_tbl x left join lateral (select a.q1 from int4_tbl y) ss(z)
     on x.q2 = ss.z;
-        q1        |        q2         |        q1        |        q2         |        z         
-------------------+-------------------+------------------+-------------------+------------------
-              123 |               456 |              123 |               456 |                 
-              123 |               456 |              123 |  4567890123456789 |                 
-              123 |               456 | 4567890123456789 |               123 |              123
-              123 |               456 | 4567890123456789 |               123 |              123
-              123 |               456 | 4567890123456789 |               123 |              123
-              123 |               456 | 4567890123456789 |               123 |              123
-              123 |               456 | 4567890123456789 |               123 |              123
-              123 |               456 | 4567890123456789 |  4567890123456789 |                 
-              123 |               456 | 4567890123456789 | -4567890123456789 |                 
-              123 |  4567890123456789 |              123 |               456 |                 
-              123 |  4567890123456789 |              123 |  4567890123456789 |                 
-              123 |  4567890123456789 | 4567890123456789 |               123 |              123
-              123 |  4567890123456789 | 4567890123456789 |               123 |              123
-              123 |  4567890123456789 | 4567890123456789 |               123 |              123
-              123 |  4567890123456789 | 4567890123456789 |               123 |              123
-              123 |  4567890123456789 | 4567890123456789 |               123 |              123
-              123 |  4567890123456789 | 4567890123456789 |  4567890123456789 |                 
-              123 |  4567890123456789 | 4567890123456789 | -4567890123456789 |                 
- 4567890123456789 |               123 |              123 |               456 |                 
- 4567890123456789 |               123 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 |               123 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 |               123 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 |               123 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 |               123 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 |               123 | 4567890123456789 |               123 |                 
- 4567890123456789 |               123 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 |               123 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 |               123 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 |               123 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 |               123 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 |               123 | 4567890123456789 | -4567890123456789 |                 
- 4567890123456789 |  4567890123456789 |              123 |               456 |                 
- 4567890123456789 |  4567890123456789 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 | 4567890123456789 |               123 |                 
- 4567890123456789 |  4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 | 4567890123456789 | -4567890123456789 |                 
- 4567890123456789 | -4567890123456789 |              123 |               456 |                 
- 4567890123456789 | -4567890123456789 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 | -4567890123456789 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 | -4567890123456789 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 | -4567890123456789 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 | -4567890123456789 |              123 |  4567890123456789 | 4567890123456789
- 4567890123456789 | -4567890123456789 | 4567890123456789 |               123 |                 
- 4567890123456789 | -4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 | -4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 | -4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 | -4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 | -4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 | -4567890123456789 | 4567890123456789 | -4567890123456789 |                 
-(57 rows)
-
+ERROR:  could not devise a query plan for the given query (pathnode.c:422)
 --end_ignore
 -- lateral reference to a join alias variable
 select * from (select f1/2 as x from int4_tbl) ss1 join int4_tbl i4 on x = f1,
@@ -4974,10 +4935,10 @@ select * from (select f1 as x from int4_tbl) ss1 join int4_tbl i4 on x = f1,
       x      |     f1      |      y      
 -------------+-------------+-------------
            0 |           0 |           0
-      123456 |      123456 |      123456
-     -123456 |     -123456 |     -123456
   2147483647 |  2147483647 |  2147483647
  -2147483647 | -2147483647 | -2147483647
+      123456 |      123456 |      123456
+     -123456 |     -123456 |     -123456
 (5 rows)
 
 select * from ((select f1/2 as x from int4_tbl) ss1 join int4_tbl i4 on x = f1) j,
@@ -5007,16 +4968,6 @@ select * from (select f1/1000000000 from int4_tbl) x(lb),
   0 |  2
   0 |  3
   0 |  4
-  0 |  0
-  0 |  1
-  0 |  2
-  0 |  3
-  0 |  4
-  0 |  0
-  0 |  1
-  0 |  2
-  0 |  3
-  0 |  4
   2 |  2
   2 |  3
   2 |  4
@@ -5027,6 +4978,16 @@ select * from (select f1/1000000000 from int4_tbl) x(lb),
  -2 |  2
  -2 |  3
  -2 |  4
+  0 |  0
+  0 |  1
+  0 |  2
+  0 |  3
+  0 |  4
+  0 |  0
+  0 |  1
+  0 |  2
+  0 |  3
+  0 |  4
 (25 rows)
 
 select * from (values(1)) x(lb),
@@ -5052,16 +5013,16 @@ select * from
   lateral (values(x.q1,y.q1,y.q2)) v(xq1,yq1,yq2);
         q1        |        q2         |        q1        |        q2         |       xq1        |       yq1        |        yq2        
 ------------------+-------------------+------------------+-------------------+------------------+------------------+-------------------
+ 4567890123456789 |  4567890123456789 | 4567890123456789 | -4567890123456789 | 4567890123456789 | 4567890123456789 | -4567890123456789
+ 4567890123456789 |  4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789 | 4567890123456789 |  4567890123456789
+ 4567890123456789 |  4567890123456789 | 4567890123456789 |               123 | 4567890123456789 | 4567890123456789 |               123
+ 4567890123456789 | -4567890123456789 |                  |                   | 4567890123456789 |                  |                  
               123 |               456 |                  |                   |              123 |                  |                  
               123 |  4567890123456789 | 4567890123456789 | -4567890123456789 |              123 | 4567890123456789 | -4567890123456789
               123 |  4567890123456789 | 4567890123456789 |  4567890123456789 |              123 | 4567890123456789 |  4567890123456789
               123 |  4567890123456789 | 4567890123456789 |               123 |              123 | 4567890123456789 |               123
  4567890123456789 |               123 |              123 |  4567890123456789 | 4567890123456789 |              123 |  4567890123456789
  4567890123456789 |               123 |              123 |               456 | 4567890123456789 |              123 |               456
- 4567890123456789 |  4567890123456789 | 4567890123456789 | -4567890123456789 | 4567890123456789 | 4567890123456789 | -4567890123456789
- 4567890123456789 |  4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789 | 4567890123456789 |  4567890123456789
- 4567890123456789 |  4567890123456789 | 4567890123456789 |               123 | 4567890123456789 | 4567890123456789 |               123
- 4567890123456789 | -4567890123456789 |                  |                   | 4567890123456789 |                  |                  
 (10 rows)
 
 select * from
@@ -5069,16 +5030,16 @@ select * from
   lateral (select x.q1,y.q1,y.q2) v(xq1,yq1,yq2);
         q1        |        q2         |        q1        |        q2         |       xq1        |       yq1        |        yq2        
 ------------------+-------------------+------------------+-------------------+------------------+------------------+-------------------
+ 4567890123456789 |  4567890123456789 | 4567890123456789 | -4567890123456789 | 4567890123456789 | 4567890123456789 | -4567890123456789
+ 4567890123456789 |  4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789 | 4567890123456789 |  4567890123456789
+ 4567890123456789 |  4567890123456789 | 4567890123456789 |               123 | 4567890123456789 | 4567890123456789 |               123
+ 4567890123456789 | -4567890123456789 |                  |                   | 4567890123456789 |                  |                  
               123 |               456 |                  |                   |              123 |                  |                  
               123 |  4567890123456789 | 4567890123456789 | -4567890123456789 |              123 | 4567890123456789 | -4567890123456789
               123 |  4567890123456789 | 4567890123456789 |  4567890123456789 |              123 | 4567890123456789 |  4567890123456789
               123 |  4567890123456789 | 4567890123456789 |               123 |              123 | 4567890123456789 |               123
  4567890123456789 |               123 |              123 |  4567890123456789 | 4567890123456789 |              123 |  4567890123456789
  4567890123456789 |               123 |              123 |               456 | 4567890123456789 |              123 |               456
- 4567890123456789 |  4567890123456789 | 4567890123456789 | -4567890123456789 | 4567890123456789 | 4567890123456789 | -4567890123456789
- 4567890123456789 |  4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789 | 4567890123456789 |  4567890123456789
- 4567890123456789 |  4567890123456789 | 4567890123456789 |               123 | 4567890123456789 | 4567890123456789 |               123
- 4567890123456789 | -4567890123456789 |                  |                   | 4567890123456789 |                  |                  
 (10 rows)
 
 select x.* from
@@ -5086,16 +5047,16 @@ select x.* from
   lateral (select x.q1,y.q1,y.q2) v(xq1,yq1,yq2);
         q1        |        q2         
 ------------------+-------------------
+ 4567890123456789 |  4567890123456789
+ 4567890123456789 |  4567890123456789
+ 4567890123456789 |  4567890123456789
+ 4567890123456789 | -4567890123456789
               123 |               456
               123 |  4567890123456789
               123 |  4567890123456789
               123 |  4567890123456789
  4567890123456789 |               123
  4567890123456789 |               123
- 4567890123456789 |  4567890123456789
- 4567890123456789 |  4567890123456789
- 4567890123456789 |  4567890123456789
- 4567890123456789 | -4567890123456789
 (10 rows)
 
 select v.* from
@@ -5104,6 +5065,10 @@ select v.* from
   lateral (select x.q1,y.q1 union all select x.q2,y.q2) v(vx,vy);
         vx         |        vy         
 -------------------+-------------------
+  4567890123456789 |               123
+               123 |  4567890123456789
+  4567890123456789 |               123
+               123 |               456
                123 |                  
                456 |                  
                123 |  4567890123456789
@@ -5112,10 +5077,6 @@ select v.* from
   4567890123456789 |  4567890123456789
                123 |  4567890123456789
   4567890123456789 |               123
-  4567890123456789 |               123
-               123 |  4567890123456789
-  4567890123456789 |               123
-               123 |               456
   4567890123456789 |  4567890123456789
   4567890123456789 | -4567890123456789
   4567890123456789 |  4567890123456789
@@ -5132,6 +5093,14 @@ select v.* from
   lateral (select x.q1,y.q1 union all select x.q2,y.q2) v(vx,vy);
         vx         |        vy         
 -------------------+-------------------
+  4567890123456789 |  4567890123456789
+  4567890123456789 | -4567890123456789
+  4567890123456789 |  4567890123456789
+  4567890123456789 |  4567890123456789
+  4567890123456789 |  4567890123456789
+  4567890123456789 |               123
+  4567890123456789 |                  
+ -4567890123456789 |                  
                123 |                  
                456 |                  
                123 |  4567890123456789
@@ -5144,17 +5113,11 @@ select v.* from
                123 |  4567890123456789
   4567890123456789 |               123
                123 |               456
-  4567890123456789 |  4567890123456789
-  4567890123456789 | -4567890123456789
-  4567890123456789 |  4567890123456789
-  4567890123456789 |  4567890123456789
-  4567890123456789 |  4567890123456789
-  4567890123456789 |               123
-  4567890123456789 |                  
- -4567890123456789 |                  
 (20 rows)
 
 create temp table dual();
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
 insert into dual default values;
 analyze dual;
 select v.* from
@@ -5163,14 +5126,6 @@ select v.* from
   lateral (select x.q1,y.q1 from dual union all select x.q2,y.q2 from dual) v(vx,vy);
         vx         |        vy         
 -------------------+-------------------
-               123 |                  
-               456 |                  
-               123 |  4567890123456789
-  4567890123456789 | -4567890123456789
-               123 |  4567890123456789
-  4567890123456789 |  4567890123456789
-               123 |  4567890123456789
-  4567890123456789 |               123
   4567890123456789 |               123
                123 |  4567890123456789
   4567890123456789 |               123
@@ -5183,6 +5138,14 @@ select v.* from
   4567890123456789 |               123
   4567890123456789 |                  
  -4567890123456789 |                  
+               123 |                  
+               456 |                  
+               123 |  4567890123456789
+  4567890123456789 | -4567890123456789
+               123 |  4567890123456789
+  4567890123456789 |  4567890123456789
+               123 |  4567890123456789
+  4567890123456789 |               123
 (20 rows)
 
 explain (verbose, costs off)
@@ -5204,7 +5167,7 @@ select * from
                Output: b.q1, b.q2, a.q2
                Filter: (a.q2 = b.q1)
  Optimizer: Postgres query optimizer
- Settings: optimizer=off
+ Settings: optimizer=on
 (14 rows)
 
 select * from
@@ -5212,24 +5175,24 @@ select * from
   lateral (select *, a.q2 as x from int8_tbl b) ss on a.q2 = ss.q1;
         q1        |        q2         |        q1        |        q2         |        x         
 ------------------+-------------------+------------------+-------------------+------------------
+ 4567890123456789 |  4567890123456789 | 4567890123456789 |               123 | 4567890123456789
+ 4567890123456789 |  4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789
+ 4567890123456789 |  4567890123456789 | 4567890123456789 | -4567890123456789 | 4567890123456789
+ 4567890123456789 | -4567890123456789 |                  |                   |                 
               123 |               456 |                  |                   |                 
               123 |  4567890123456789 | 4567890123456789 |               123 | 4567890123456789
               123 |  4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789
               123 |  4567890123456789 | 4567890123456789 | -4567890123456789 | 4567890123456789
  4567890123456789 |               123 |              123 |               456 |              123
  4567890123456789 |               123 |              123 |  4567890123456789 |              123
- 4567890123456789 |  4567890123456789 | 4567890123456789 |               123 | 4567890123456789
- 4567890123456789 |  4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 | 4567890123456789 | -4567890123456789 | 4567890123456789
- 4567890123456789 | -4567890123456789 |                  |                   |                 
 (10 rows)
 
 explain (verbose, costs off)
 select * from
   int8_tbl a left join
   lateral (select *, coalesce(a.q2, 42) as x from int8_tbl b) ss on a.q2 = ss.q1;
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    Output: a.q1, a.q2, b.q1, b.q2, (COALESCE(a.q2, '42'::bigint))
    ->  Nested Loop Left Join
@@ -5243,7 +5206,7 @@ select * from
                Output: b.q1, b.q2, COALESCE(a.q2, '42'::bigint)
                Filter: (a.q2 = b.q1)
  Optimizer: Postgres query optimizer
- Settings: optimizer=off
+ Settings: optimizer=on
 (14 rows)
 
 select * from
@@ -5255,12 +5218,12 @@ select * from
               123 |  4567890123456789 | 4567890123456789 |               123 | 4567890123456789
               123 |  4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789
               123 |  4567890123456789 | 4567890123456789 | -4567890123456789 | 4567890123456789
- 4567890123456789 |               123 |              123 |               456 |              123
- 4567890123456789 |               123 |              123 |  4567890123456789 |              123
  4567890123456789 |  4567890123456789 | 4567890123456789 |               123 | 4567890123456789
  4567890123456789 |  4567890123456789 | 4567890123456789 |  4567890123456789 | 4567890123456789
  4567890123456789 |  4567890123456789 | 4567890123456789 | -4567890123456789 | 4567890123456789
  4567890123456789 | -4567890123456789 |                  |                   |                 
+ 4567890123456789 |               123 |              123 |               456 |              123
+ 4567890123456789 |               123 |              123 |  4567890123456789 |              123
 (10 rows)
 
 -- lateral can result in join conditions appearing below their
@@ -5282,7 +5245,7 @@ select * from int4_tbl i left join
                ->  Seq Scan on public.int2_tbl j
                      Output: j.f1
  Optimizer: Postgres query optimizer
- Settings: optimizer=off
+ Settings: optimizer=on
 (13 rows)
 
 select * from int4_tbl i left join
@@ -5290,10 +5253,10 @@ select * from int4_tbl i left join
      f1      | f1 
 -------------+----
            0 |  0
-      123456 |   
-     -123456 |   
   2147483647 |   
  -2147483647 |   
+      123456 |   
+     -123456 |   
 (5 rows)
 
 explain (verbose, costs off)
@@ -5311,7 +5274,7 @@ select * from int4_tbl i left join
                Output: j.f1, COALESCE(i.*)
                Filter: (i.f1 = j.f1)
  Optimizer: Postgres query optimizer
- Settings: optimizer=off
+ Settings: optimizer=on
 (11 rows)
 
 select * from int4_tbl i left join
@@ -5319,10 +5282,10 @@ select * from int4_tbl i left join
      f1      | coalesce 
 -------------+----------
            0 | (0)
-      123456 | 
-     -123456 | 
   2147483647 | 
  -2147483647 | 
+      123456 | 
+     -123456 | 
 (5 rows)
 
 explain (verbose, costs off)
@@ -5353,7 +5316,7 @@ select * from int4_tbl a,
                            ->  Seq Scan on public.int4_tbl b
                                  Output: b.f1
  Optimizer: Postgres query optimizer
- Settings: optimizer=off
+ Settings: optimizer=on
 (22 rows)
 
 select * from int4_tbl a,
@@ -5362,31 +5325,31 @@ select * from int4_tbl a,
   ) ss;
      f1      |     f1      | q1 | q2 
 -------------+-------------+----+----
-           0 |           0 |    |   
-           0 |      123456 |    |   
-           0 |     -123456 |    |   
-           0 |  2147483647 |    |   
            0 | -2147483647 |    |   
-      123456 |           0 |    |   
-      123456 |      123456 |    |   
-      123456 |     -123456 |    |   
-      123456 |  2147483647 |    |   
-      123456 | -2147483647 |    |   
-     -123456 |           0 |    |   
-     -123456 |      123456 |    |   
-     -123456 |     -123456 |    |   
-     -123456 |  2147483647 |    |   
-     -123456 | -2147483647 |    |   
-  2147483647 |           0 |    |   
-  2147483647 |      123456 |    |   
-  2147483647 |     -123456 |    |   
-  2147483647 |  2147483647 |    |   
+           0 |           0 |    |   
+           0 |  2147483647 |    |   
   2147483647 | -2147483647 |    |   
- -2147483647 |           0 |    |   
- -2147483647 |      123456 |    |   
- -2147483647 |     -123456 |    |   
- -2147483647 |  2147483647 |    |   
+  2147483647 |           0 |    |   
+  2147483647 |  2147483647 |    |   
  -2147483647 | -2147483647 |    |   
+ -2147483647 |           0 |    |   
+ -2147483647 |  2147483647 |    |   
+      123456 | -2147483647 |    |   
+      123456 |           0 |    |   
+      123456 |  2147483647 |    |   
+     -123456 | -2147483647 |    |   
+     -123456 |           0 |    |   
+     -123456 |  2147483647 |    |   
+           0 |     -123456 |    |   
+           0 |      123456 |    |   
+  2147483647 |     -123456 |    |   
+  2147483647 |      123456 |    |   
+ -2147483647 |     -123456 |    |   
+ -2147483647 |      123456 |    |   
+      123456 |     -123456 |    |   
+      123456 |      123456 |    |   
+     -123456 |     -123456 |    |   
+     -123456 |      123456 |    |   
 (25 rows)
 
 -- lateral reference in a PlaceHolderVar evaluated at join level
@@ -5400,85 +5363,13 @@ select * from
   (select b.q1 as bq1, c.q1 as cq1, least(a.q1,b.q1,c.q1) from
    int8_tbl b cross join int8_tbl c) ss
   on a.q2 = ss.bq1;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)
-   Output: a.q1, a.q2, b.q1, c.q1, (LEAST(a.q1, b.q1, c.q1))
-   ->  Nested Loop Left Join
-         Output: a.q1, a.q2, b.q1, c.q1, (LEAST(a.q1, b.q1, c.q1))
-         ->  Redistribute Motion 3:3  (slice1; segments: 3)
-               Output: a.q1, a.q2
-               Hash Key: a.q2
-               ->  Seq Scan on public.int8_tbl a
-                     Output: a.q1, a.q2
-         ->  Materialize
-               Output: b.q1, c.q1, (LEAST(a.q1, b.q1, c.q1))
-               ->  Nested Loop
-                     Output: b.q1, c.q1, LEAST(a.q1, b.q1, c.q1)
-                     Join Filter: (a.q2 = b.q1)
-                     ->  Seq Scan on public.int8_tbl b
-                           Output: b.q1, b.q2
-                     ->  Materialize
-                           Output: c.q1
-                           ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                                 Output: c.q1
-                                 ->  Seq Scan on public.int8_tbl c
-                                       Output: c.q1
- Optimizer: Postgres query optimizer
- Settings: optimizer=off
-(24 rows)
-
+ERROR:  could not devise a query plan for the given query (pathnode.c:422)
 select * from
   int8_tbl a left join lateral
   (select b.q1 as bq1, c.q1 as cq1, least(a.q1,b.q1,c.q1) from
    int8_tbl b cross join int8_tbl c) ss
   on a.q2 = ss.bq1;
-        q1        |        q2         |       bq1        |       cq1        |      least       
-------------------+-------------------+------------------+------------------+------------------
-              123 |               456 |                  |                  |                 
-              123 |  4567890123456789 | 4567890123456789 |              123 |              123
-              123 |  4567890123456789 | 4567890123456789 |              123 |              123
-              123 |  4567890123456789 | 4567890123456789 | 4567890123456789 |              123
-              123 |  4567890123456789 | 4567890123456789 | 4567890123456789 |              123
-              123 |  4567890123456789 | 4567890123456789 | 4567890123456789 |              123
-              123 |  4567890123456789 | 4567890123456789 |              123 |              123
-              123 |  4567890123456789 | 4567890123456789 |              123 |              123
-              123 |  4567890123456789 | 4567890123456789 | 4567890123456789 |              123
-              123 |  4567890123456789 | 4567890123456789 | 4567890123456789 |              123
-              123 |  4567890123456789 | 4567890123456789 | 4567890123456789 |              123
-              123 |  4567890123456789 | 4567890123456789 |              123 |              123
-              123 |  4567890123456789 | 4567890123456789 |              123 |              123
-              123 |  4567890123456789 | 4567890123456789 | 4567890123456789 |              123
-              123 |  4567890123456789 | 4567890123456789 | 4567890123456789 |              123
-              123 |  4567890123456789 | 4567890123456789 | 4567890123456789 |              123
- 4567890123456789 |               123 |              123 |              123 |              123
- 4567890123456789 |               123 |              123 |              123 |              123
- 4567890123456789 |               123 |              123 | 4567890123456789 |              123
- 4567890123456789 |               123 |              123 | 4567890123456789 |              123
- 4567890123456789 |               123 |              123 | 4567890123456789 |              123
- 4567890123456789 |               123 |              123 |              123 |              123
- 4567890123456789 |               123 |              123 |              123 |              123
- 4567890123456789 |               123 |              123 | 4567890123456789 |              123
- 4567890123456789 |               123 |              123 | 4567890123456789 |              123
- 4567890123456789 |               123 |              123 | 4567890123456789 |              123
- 4567890123456789 |  4567890123456789 | 4567890123456789 |              123 |              123
- 4567890123456789 |  4567890123456789 | 4567890123456789 |              123 |              123
- 4567890123456789 |  4567890123456789 | 4567890123456789 | 4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 | 4567890123456789 | 4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 | 4567890123456789 | 4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 | 4567890123456789 |              123 |              123
- 4567890123456789 |  4567890123456789 | 4567890123456789 |              123 |              123
- 4567890123456789 |  4567890123456789 | 4567890123456789 | 4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 | 4567890123456789 | 4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 | 4567890123456789 | 4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 | 4567890123456789 |              123 |              123
- 4567890123456789 |  4567890123456789 | 4567890123456789 |              123 |              123
- 4567890123456789 |  4567890123456789 | 4567890123456789 | 4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 | 4567890123456789 | 4567890123456789 | 4567890123456789
- 4567890123456789 |  4567890123456789 | 4567890123456789 | 4567890123456789 | 4567890123456789
- 4567890123456789 | -4567890123456789 |                  |                  |                 
-(42 rows)
-
+ERROR:  could not devise a query plan for the given query (pathnode.c:422)
 --end_ignore
 -- case requiring nested PlaceHolderVars
 explain (verbose, costs off)
@@ -5490,8 +5381,8 @@ select * from
     lateral (select q1, coalesce(ss1.x,q2) as y from int8_tbl d) ss2
   ) on c.q2 = ss2.q1,
   lateral (select ss2.y) ss3;
-                                                                                     QUERY PLAN                                                                                     
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                        QUERY PLAN                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)
    Output: c.q1, c.q2, a.q1, a.q2, b.q1, (COALESCE(b.q2, '42'::bigint)), d.q1, (COALESCE((COALESCE(b.q2, '42'::bigint)), d.q2)), ((COALESCE((COALESCE(b.q2, '42'::bigint)), d.q2)))
    ->  Nested Loop
@@ -5529,7 +5420,8 @@ select * from
                ->  Result
                      Output: (COALESCE((COALESCE(b.q2, '42'::bigint)), d.q2))
  Optimizer: Postgres query optimizer
-(37 rows)
+ Settings: optimizer=on
+(38 rows)
 
 -- case that breaks the old ph_may_need optimization
 explain (verbose, costs off)
@@ -5594,7 +5486,8 @@ select c.*,a.*,ss1.q1,ss2.q1,ss3.* from
                      ->  Seq Scan on public.int4_tbl i
                            Output: i.f1
  Optimizer: Postgres query optimizer
-(49 rows)
+ Settings: optimizer=on
+(50 rows)
 
 -- check processing of postponed quals (bug #9041)
 explain (verbose, costs off)
@@ -5715,7 +5608,8 @@ select * from
                              ->  Seq Scan on public.tenk1
                                    Output: tenk1.unique1, tenk1.unique2
  Optimizer: Postgres query optimizer
-(22 rows)
+ Settings: optimizer=on
+(23 rows)
 
 select * from
   (values (0,9998), (1,1000)) v(id,x),
@@ -5773,6 +5667,7 @@ LINE 1: select 1 from tenk1 a, lateral (select max(a.unique1) from i...
                                                ^
 -- check behavior of LATERAL in UPDATE/DELETE
 create temp table xx1 as select f1 as x1, -f1 as x2 from int4_tbl;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 -- error, can't do this:
 update xx1 set x2 = f1 from (select * from int4_tbl where f1 = x1) ss;
 ERROR:  column "x1" does not exist

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1,3 +1,7 @@
+-- start_ignore
+create schema subselect_gp;
+set search_path to subselect_gp, public;
+-- end_ignore
 set optimizer_enable_master_only_queries = on;
 set optimizer_segments = 3;
 set optimizer_nestloop_factor = 1.0;
@@ -86,8 +90,8 @@ NOTICE:  CREATE TABLE will create partition "csq_t2_1_prt_4" for table "csq_t2"
 insert into csq_t1 select * from csq_t1_base;
 insert into csq_t2 select * from csq_t2_base;
 explain select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 where csq_t2.y=csq_t1.y) order by 1;
-                                                                                                                                                                          QUERY PLAN                                                                                                                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..1293.00 rows=1 width=8)
    Filter: (SubPlan 1)
    ->  Sort  (cost=0.00..431.00 rows=1 width=8)
@@ -100,20 +104,20 @@ explain select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 wh
    SubPlan 1  (slice0)
      ->  Result  (cost=0.00..431.00 rows=1 width=1)
            ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                 Filter: (CASE WHEN (sum((CASE WHEN csq_t1.x <= csq_t2.x THEN 1 ELSE 0 END))) IS NULL THEN true WHEN (sum((CASE WHEN csq_t2.x IS NULL THEN 1 ELSE 0 END))) > 0::bigint THEN NULL::boolean WHEN csq_t1.x IS NULL THEN NULL::boolean WHEN (sum((CASE WHEN csq_t1.x <= csq_t2.x THEN 1 ELSE 0 END))) = 0::bigint THEN true ELSE false END) = true
+                 Filter: ((CASE WHEN ((sum((CASE WHEN (csq_t1.x <= csq_t2.x) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN (csq_t2.x IS NULL) THEN 1 ELSE 0 END))) > '0'::bigint) THEN NULL::boolean WHEN (csq_t1.x IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (csq_t1.x <= csq_t2.x) THEN 1 ELSE 0 END))) = '0'::bigint) THEN true ELSE false END) = true)
                  ->  Result  (cost=0.00..431.00 rows=1 width=1)
                        ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
                              ->  Result  (cost=0.00..431.00 rows=1 width=8)
                                    ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                                         Filter: csq_t2.y = csq_t1.y
+                                         Filter: (csq_t2.y = csq_t1.y)
                                          ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
                                                ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                                                      ->  Sequence  (cost=0.00..431.00 rows=1 width=8)
                                                            ->  Partition Selector for csq_t2 (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
                                                                  Partitions selected: 4 (out of 4)
                                                            ->  Dynamic Seq Scan on csq_t2 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
-(26 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(25 rows)
 
 select * from csq_t1 where csq_t1.x >ALL (select csq_t2.x from csq_t2 where csq_t2.y=csq_t1.y) order by 1; -- expected (4,2)
  x | y 
@@ -144,8 +148,8 @@ explain select * from mrs_t1 where exists (select x from mrs_t1 where x < -1);
                      ->  Limit  (cost=0.00..431.00 rows=1 width=1)
                            ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
                                  ->  Seq Scan on mrs_t1  (cost=0.00..431.00 rows=1 width=1)
-                                       Filter: x < (-1)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+                                       Filter: (x < '-1'::integer)
+ Optimizer: Pivotal Optimizer (GPORCA)
 (11 rows)
 
 select * from mrs_t1 where exists (select x from mrs_t1 where x < -1) order by 1;
@@ -163,10 +167,10 @@ explain select * from mrs_t1 where exists (select x from mrs_t1 where x = 1);
          ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
                ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=1)
                      ->  Limit  (cost=0.00..431.00 rows=1 width=1)
-                           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=1)
+                           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
                                  ->  Seq Scan on mrs_t1  (cost=0.00..431.00 rows=1 width=1)
-                                       Filter: x = 1
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+                                       Filter: (x = 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
 (11 rows)
 
 select * from mrs_t1 where exists (select x from mrs_t1 where x = 1) order by 1;
@@ -195,11 +199,11 @@ select * from mrs_t1 where exists (select x from mrs_t1 where x = 1) order by 1;
 (20 rows)
 
 explain select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5;
-                                                                                                                                 QUERY PLAN                                                                                                                                 
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                  QUERY PLAN                                                                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.02 rows=20 width=4)
    ->  Result  (cost=0.00..1293.02 rows=7 width=4)
-         Filter: (CASE WHEN ((count("inner".ColRef_0017)) > 0::bigint) THEN CASE WHEN ((sum((CASE WHEN ((mrs_t1_1.x = ((mrs_t1.x - 95))) IS NULL) THEN 1 ELSE 0 END))) = (count("inner".ColRef_0017))) THEN NULL::boolean ELSE true END ELSE false END OR (mrs_t1_1.x < 5))
+         Filter: (CASE WHEN ((count("outer".ColRef_0017)) > '0'::bigint) THEN CASE WHEN ((sum((CASE WHEN ((mrs_t1_1.x = ((mrs_t1.x - 95))) IS NULL) THEN 1 ELSE 0 END))) = (count("outer".ColRef_0017))) THEN NULL::boolean ELSE true END ELSE false END OR (mrs_t1_1.x < 5))
          ->  GroupAggregate  (cost=0.00..1293.02 rows=7 width=20)
                Group Key: mrs_t1_1.x, mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
                ->  Result  (cost=0.00..1293.02 rows=56 width=19)
@@ -212,7 +216,7 @@ explain select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5;
                                  ->  Result  (cost=0.00..431.00 rows=20 width=5)
                                        ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=20 width=4)
                                              ->  Seq Scan on mrs_t1  (cost=0.00..431.00 rows=7 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (16 rows)
 
 select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5 order by 1;
@@ -256,6 +260,7 @@ drop table if exists csq_m1;
 NOTICE:  table "csq_m1" does not exist, skipping
 create table csq_m1();
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
 set allow_system_table_mods=true;
 delete from gp_distribution_policy where localoid='csq_m1'::regclass;
 reset allow_system_table_mods;
@@ -268,9 +273,9 @@ insert into csq_d1 select * from csq_m1;
 explain select array(select x from csq_m1); -- no initplan
                           QUERY PLAN                          
 --------------------------------------------------------------
- Result  (cost=1.00..1.01 rows=1 width=0)
+ Result  (cost=1.01..1.02 rows=1 width=0)
    InitPlan 1 (returns $0)
-     ->  Seq Scan on csq_m1  (cost=0.00..1.00 rows=1 width=4)
+     ->  Seq Scan on csq_m1  (cost=0.00..1.01 rows=1 width=4)
  Optimizer: Postgres query optimizer
 (4 rows)
 
@@ -287,9 +292,8 @@ explain select array(select x from csq_d1); -- initplan
    InitPlan 1 (returns $0)  (slice2)
      ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=4)
            ->  Seq Scan on csq_d1  (cost=0.00..1.01 rows=1 width=4)
- Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: Postgres query optimizer
-(6 rows)
+ Optimizer: Postgres query optimizer
+(5 rows)
 
 select array(select x from csq_d1); -- {1}
  array 
@@ -338,6 +342,7 @@ ORDER BY a.attnum
 drop table if exists csq_m1;
 create table csq_m1();
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+WARNING:  creating a table with no columns.
 set allow_system_table_mods=true;
 delete from gp_distribution_policy where localoid='csq_m1'::regclass;
 reset allow_system_table_mods;
@@ -358,20 +363,20 @@ select * from csq_m1;
 select * from csq_d1;
  x 
 ---
- 1
  2
  4
+ 1
 (3 rows)
 
 --
 -- outer plan node is master-only and CSQ has distributed relation
 --
 explain select * from csq_m1 where x not in (select x from csq_d1) or x < -100; -- gather motion
-                                                                                                                                               QUERY PLAN                                                                                                                                               
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                    QUERY PLAN                                                                                                                                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1293.00 rows=3 width=4)
    ->  Result  (cost=0.00..1293.00 rows=1 width=4)
-         Filter: (CASE WHEN ((count((count("inner".ColRef_0016)))) > 0::bigint) THEN CASE WHEN ((pg_catalog.sum((sum((CASE WHEN ((csq_m1.x = csq_d1.x) IS NULL) THEN 1 ELSE 0 END))))) = (count((count("inner".ColRef_0016))))) THEN NULL::boolean ELSE false END ELSE true END OR (csq_m1.x < (-100)))
+         Filter: (CASE WHEN ((count((count("outer".ColRef_0016)))) > '0'::bigint) THEN CASE WHEN ((pg_catalog.sum((sum((CASE WHEN ((csq_m1.x = csq_d1.x) IS NULL) THEN 1 ELSE 0 END))))) = (count((count("outer".ColRef_0016))))) THEN NULL::boolean ELSE false END ELSE true END OR (csq_m1.x < '-100'::integer))
          ->  GroupAggregate  (cost=0.00..1293.00 rows=1 width=20)
                Group Key: csq_m1.x, csq_m1.ctid, csq_m1.gp_segment_id
                ->  Sort  (cost=0.00..1293.00 rows=1 width=30)
@@ -392,7 +397,7 @@ explain select * from csq_m1 where x not in (select x from csq_d1) or x < -100; 
                                                                      ->  Result  (cost=0.00..431.00 rows=1 width=5)
                                                                            ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
                                                                                  ->  Seq Scan on csq_d1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.27.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (24 rows)
 
 select * from csq_m1 where x not in (select x from csq_d1) or x < -100; -- (3)
@@ -405,11 +410,11 @@ select * from csq_m1 where x not in (select x from csq_d1) or x < -100; -- (3)
 -- outer plan node is master-only and CSQ has distributed relation
 --
 explain select * from csq_d1 where x not in (select x from csq_m1) or x < -100; -- broadcast motion
-                                                                                                                             QUERY PLAN                                                                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                  QUERY PLAN                                                                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.00 rows=2 width=4)
    ->  Result  (cost=0.00..1293.00 rows=1 width=4)
-         Filter: (CASE WHEN ((count("inner".ColRef_0016)) > 0::bigint) THEN CASE WHEN ((sum((CASE WHEN ((csq_d1.x = csq_m1.x) IS NULL) THEN 1 ELSE 0 END))) = (count("inner".ColRef_0016))) THEN NULL::boolean ELSE false END ELSE true END OR (csq_d1.x < (-100)))
+         Filter: (CASE WHEN ((count("outer".ColRef_0016)) > '0'::bigint) THEN CASE WHEN ((sum((CASE WHEN ((csq_d1.x = csq_m1.x) IS NULL) THEN 1 ELSE 0 END))) = (count("outer".ColRef_0016))) THEN NULL::boolean ELSE false END ELSE true END OR (csq_d1.x < '-100'::integer))
          ->  GroupAggregate  (cost=0.00..1293.00 rows=1 width=20)
                Group Key: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
                ->  Result  (cost=0.00..1293.00 rows=2 width=19)
@@ -422,7 +427,7 @@ explain select * from csq_d1 where x not in (select x from csq_m1) or x < -100; 
                                  ->  Result  (cost=0.00..431.00 rows=3 width=5)
                                        ->  Broadcast Motion 1:3  (slice1)  (cost=0.00..431.00 rows=9 width=4)
                                              ->  Seq Scan on csq_m1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (16 rows)
 
 select * from csq_d1 where x not in (select x from csq_m1) or x < -100; -- (4)
@@ -468,11 +473,11 @@ explain SELECT * FROM csq_r WHERE a IN (SELECT * FROM csq_f(csq_r.a));
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Seq Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
-         Filter: a = ((SubPlan 1))
+         Filter: (a = (SubPlan 1))
          SubPlan 1  (slice1; segments: 3)
            ->  Result  (cost=0.00..0.00 rows=1 width=4)
                  ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 
 SELECT * FROM csq_r WHERE a IN (SELECT * FROM csq_f(csq_r.a));
@@ -487,11 +492,11 @@ explain SELECT * FROM csq_r WHERE a not IN (SELECT * FROM csq_f(csq_r.a));
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Seq Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
-         Filter: a <> ((SubPlan 1))
+         Filter: (a <> (SubPlan 1))
          SubPlan 1  (slice1; segments: 3)
            ->  Result  (cost=0.00..0.00 rows=1 width=4)
                  ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 
 SELECT * FROM csq_r WHERE a not IN (SELECT * FROM csq_f(csq_r.a));
@@ -510,7 +515,7 @@ explain SELECT * FROM csq_r WHERE exists (SELECT * FROM csq_f(csq_r.a));
            ->  Result  (cost=0.00..0.00 rows=1 width=1)
                  ->  Result  (cost=0.00..0.00 rows=1 width=1)
                        ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA)
 (8 rows)
 
 SELECT * FROM csq_r WHERE exists (SELECT * FROM csq_f(csq_r.a));
@@ -530,7 +535,7 @@ explain SELECT * FROM csq_r WHERE not exists (SELECT * FROM csq_f(csq_r.a));
            ->  Result  (cost=0.00..0.00 rows=1 width=1)
                  ->  Result  (cost=0.00..0.00 rows=1 width=1)
                        ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA)
 (8 rows)
 
 SELECT * FROM csq_r WHERE not exists (SELECT * FROM csq_f(csq_r.a));
@@ -544,12 +549,12 @@ explain SELECT * FROM csq_r WHERE a > (SELECT csq_f FROM csq_f(csq_r.a) limit 1)
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Seq Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
-         Filter: a > ((SubPlan 1))
+         Filter: (a > (SubPlan 1))
          SubPlan 1  (slice1; segments: 3)
            ->  Limit  (cost=0.00..0.00 rows=1 width=4)
                  ->  Result  (cost=0.00..0.00 rows=1 width=4)
                        ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.55.21
+ Optimizer: Pivotal Optimizer (GPORCA)
 (8 rows)
 
 SELECT * FROM csq_r WHERE a > (SELECT csq_f FROM csq_f(csq_r.a) limit 1);
@@ -563,13 +568,12 @@ explain SELECT * FROM csq_r WHERE a < ANY (SELECT csq_f FROM csq_f(csq_r.a));
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Seq Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
-         Filter: a < ((SubPlan 1))
+         Filter: (a < (SubPlan 1))
          SubPlan 1  (slice1; segments: 3)
            ->  Result  (cost=0.00..0.00 rows=1 width=4)
                  ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: Pivotal Optimizer (GPORCA) version 1.621
-(8 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 SELECT * FROM csq_r WHERE a < ANY (SELECT csq_f FROM csq_f(csq_r.a));
  a 
@@ -582,13 +586,12 @@ explain SELECT * FROM csq_r WHERE a <= ALL (SELECT csq_f FROM csq_f(csq_r.a));
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Seq Scan on csq_r  (cost=0.00..862.00 rows=1 width=4)
-         Filter: a <= ((SubPlan 1))
+         Filter: (a <= (SubPlan 1))
          SubPlan 1  (slice1; segments: 3)
            ->  Result  (cost=0.00..0.00 rows=1 width=4)
                  ->  Result  (cost=0.00..0.00 rows=1 width=1)
- Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: Pivotal Optimizer (GPORCA) version 1.621
-(8 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 SELECT * FROM csq_r WHERE a <= ALL (SELECT csq_f FROM csq_f(csq_r.a));
  a 
@@ -611,7 +614,7 @@ explain SELECT * FROM csq_r WHERE a IN (SELECT csq_f FROM csq_f(csq_r.a),csq_r);
                  ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
                        ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
                              ->  Seq Scan on csq_r csq_r_1  (cost=0.00..431.00 rows=1 width=1)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (12 rows)
 
 SELECT * FROM csq_r WHERE a IN (SELECT csq_f FROM csq_f(csq_r.a),csq_r);
@@ -639,96 +642,84 @@ insert into csq_pullup values ('def',3, 1, 'abc');
 -- text, text
 --
 explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t);
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=17)
-   ->  Result  (cost=0.00..862.00 rows=1 width=17)
-         Filter: 1 = COALESCE((count()), 0::bigint)
-         ->  Result  (cost=0.00..862.00 rows=1 width=36)
-               ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
-                     Hash Cond: csq_pullup.t = csq_pullup_1.t
-                     ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=12)
-                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
-                                 Group Key: csq_pullup_1.t
-                                 ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                       Sort Key: csq_pullup_1.t
-                                       ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(14 rows)
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..5172.20 rows=1 width=17)
+   ->  Result  (cost=0.00..5172.20 rows=1 width=17)
+         Filter: (1 = (SubPlan 1))
+         ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                 ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                       Filter: (csq_pullup.t = csq_pullup_1.t)
+                       ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                   ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t);
   t  | n | i |  v  
 -----+---+---+-----
+ abc | 1 | 2 | xyz
  xyz | 2 | 3 | def
  def | 3 | 1 | abc
- abc | 1 | 2 | xyz
 (3 rows)
 
 --
 -- text, varchar
 --
 explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.v);
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=17)
-   ->  Result  (cost=0.00..862.00 rows=1 width=17)
-         Filter: (1 = COALESCE((count()), 0::bigint))
-         ->  Result  (cost=0.00..862.00 rows=1 width=36)
-               ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
-                     Hash Cond: (csq_pullup.t = (csq_pullup_1.v)::text)
-                     ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=12)
-                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
-                                 Group Key: csq_pullup_1.v
-                                 ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                       Sort Key: csq_pullup_1.v
-                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                             Hash Key: csq_pullup_1.v
-                                             ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(16 rows)
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..5172.20 rows=1 width=17)
+   ->  Result  (cost=0.00..5172.20 rows=1 width=17)
+         Filter: (1 = (SubPlan 1))
+         ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                 ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                       Filter: (csq_pullup.t = (csq_pullup_1.v)::text)
+                       ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                   ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.v);
   t  | n | i |  v  
 -----+---+---+-----
+ abc | 1 | 2 | xyz
  xyz | 2 | 3 | def
  def | 3 | 1 | abc
- abc | 1 | 2 | xyz
 (3 rows)
 
 --
 -- numeric, numeric
 --
 explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n=t1.n);
-                                                             QUERY PLAN                                                             
-------------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..862.00 rows=1 width=17)
-   Filter: (1 = COALESCE((count()), 0::bigint))
-   ->  Result  (cost=0.00..862.00 rows=1 width=36)
-         ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
-               Hash Cond: (csq_pullup.n = csq_pullup_1.n)
-               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=17)
-                     ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
-               ->  Hash  (cost=431.00..431.00 rows=1 width=13)
-                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=13)
-                           ->  Result  (cost=0.00..431.00 rows=1 width=13)
-                                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=13)
-                                       Group Key: csq_pullup_1.n
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=5)
-                                             Sort Key: csq_pullup_1.n
-                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
-                                                   Hash Key: csq_pullup_1.n
-                                                   ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=5)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(18 rows)
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..5172.20 rows=1 width=17)
+   ->  Result  (cost=0.00..5172.20 rows=1 width=17)
+         Filter: (1 = (SubPlan 1))
+         ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                 ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                       Filter: (csq_pullup.n = csq_pullup_1.n)
+                       ->  Materialize  (cost=0.00..431.00 rows=1 width=5)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+                                   ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=5)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n=t1.n);
   t  | n | i |  v  
 -----+---+---+-----
+ abc | 1 | 2 | xyz
  xyz | 2 | 3 | def
  def | 3 | 1 | abc
- abc | 1 | 2 | xyz
 (3 rows)
 
 --
@@ -739,24 +730,24 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
 -----------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..5172.20 rows=1 width=17)
    ->  Result  (cost=0.00..5172.20 rows=1 width=17)
-         Filter: 1 = ((SubPlan 1))
+         Filter: (1 = (SubPlan 1))
          ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
          SubPlan 1  (slice2; segments: 3)
            ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
                  ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                       Filter: (csq_pullup.n + 1::numeric) = (csq_pullup_1.n + 1::numeric)
+                       Filter: ((csq_pullup.n + '1'::numeric) = (csq_pullup_1.n + '1'::numeric))
                        ->  Materialize  (cost=0.00..431.00 rows=1 width=5)
                              ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
                                    ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=5)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (12 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + 1=t1.n + 1);
   t  | n | i |  v  
 -----+---+---+-----
+ def | 3 | 1 | abc
  abc | 1 | 2 | xyz
  xyz | 2 | 3 | def
- def | 3 | 1 | abc
 (3 rows)
 
 --
@@ -767,24 +758,24 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
 -----------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..5172.20 rows=1 width=17)
    ->  Result  (cost=0.00..5172.20 rows=1 width=17)
-         Filter: 1 = ((SubPlan 1))
+         Filter: (1 = (SubPlan 1))
          ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
          SubPlan 1  (slice2; segments: 3)
            ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
                  ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                       Filter: (csq_pullup.n + 1::numeric) = (csq_pullup_1.i + 1)::numeric
+                       Filter: ((csq_pullup.n + '1'::numeric) = ((csq_pullup_1.i + 1))::numeric)
                        ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
                              ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                    ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (12 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + 1=t1.i + 1);
   t  | n | i |  v  
 -----+---+---+-----
+ def | 3 | 1 | abc
  abc | 1 | 2 | xyz
  xyz | 2 | 3 | def
- def | 3 | 1 | abc
 (3 rows)
 
 --
@@ -798,7 +789,7 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
    ->  Result  (cost=0.00..5172.20 rows=1 width=17)
          Filter: (1 = (SubPlan 1))
          ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
-         SubPlan 1
+         SubPlan 1  (slice2; segments: 3)
            ->  Limit  (cost=0.00..431.00 rows=1 width=8)
                  ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
                        ->  Result  (cost=0.00..431.00 rows=1 width=1)
@@ -806,63 +797,61 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
                              ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
                                    ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                          ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (13 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t LIMIT 1);
   t  | n | i |  v  
 -----+---+---+-----
- xyz | 2 | 3 | def
  def | 3 | 1 | abc
  abc | 1 | 2 | xyz
+ xyz | 2 | 3 | def
 (3 rows)
 
 -- subquery contains a HAVING clause
 explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t HAVING count(*) < 10);
-                                                       QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=17)
-   ->  Result  (cost=0.00..862.00 rows=1 width=17)
-         Filter: (1 = COALESCE((count()), '0'::bigint))
-         ->  Result  (cost=0.00..862.00 rows=1 width=36)
-               ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
-                     Hash Cond: (csq_pullup.t = csq_pullup_1.t)
-                     ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=12)
-                           ->  Result  (cost=0.00..431.00 rows=1 width=12)
-                                 Filter: ((count()) < 10)
-                                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=20)
-                                       Group Key: csq_pullup_1.t
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                             Sort Key: csq_pullup_1.t
-                                             ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(16 rows)
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..6465.25 rows=1 width=17)
+   ->  Result  (cost=0.00..6465.25 rows=1 width=17)
+         Filter: (1 = (SubPlan 1))
+         ->  Seq Scan on csq_pullup  (cost=0.00..6465.24 rows=334 width=36)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                 Filter: ((count()) < 10)
+                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                       ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                             Filter: (csq_pullup.t = csq_pullup_1.t)
+                             ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                         ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(14 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.t HAVING count(*) < 10);
   t  | n | i |  v  
 -----+---+---+-----
+ abc | 1 | 2 | xyz
  xyz | 2 | 3 | def
  def | 3 | 1 | abc
- abc | 1 | 2 | xyz
 (3 rows)
 
 -- subquery contains quals of form 'function(outervar, innervar1) = innvervar2'
 explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + t1.n =t1.i);
                                                    QUERY PLAN                                                    
 -----------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..5172.20 rows=1 width=17)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..5172.20 rows=1 width=17)
    ->  Result  (cost=0.00..5172.20 rows=1 width=17)
          Filter: (1 = (SubPlan 1))
          ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
-         SubPlan 1
+         SubPlan 1  (slice2; segments: 3)
            ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
                  ->  Result  (cost=0.00..431.00 rows=1 width=1)
                        Filter: ((csq_pullup.n + csq_pullup_1.n) = (csq_pullup_1.i)::numeric)
                        ->  Materialize  (cost=0.00..431.00 rows=1 width=9)
-                             ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=9)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=9)
                                    ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=9)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.93.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (12 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n + t1.n =t1.i);
@@ -881,13 +870,13 @@ explain select * from csq_pullup t0 where not exists (select 1 from csq_pullup t
 -------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=17)
    ->  Hash Anti Join  (cost=0.00..862.00 rows=1 width=17)
-         Hash Cond: csq_pullup.t = csq_pullup_1.t
+         Hash Cond: (csq_pullup.t = csq_pullup_1.t)
          ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Result  (cost=0.00..431.00 rows=1 width=4)
                      ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
-                           Filter: i = 1
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+                           Filter: (i = 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
 (9 rows)
 
 select * from csq_pullup t0 where not exists (select 1 from csq_pullup t1 where t0.t=t1.t and t1.i = 1);
@@ -905,14 +894,14 @@ explain select * from csq_pullup t0 where not exists (select 1 from csq_pullup t
 -------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=17)
    ->  Hash Anti Join  (cost=0.00..862.00 rows=1 width=17)
-         Hash Cond: csq_pullup.i = (csq_pullup_1.i + 1)
+         Hash Cond: (csq_pullup.i = (csq_pullup_1.i + 1))
          ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                      ->  Result  (cost=0.00..431.00 rows=1 width=4)
                            ->  Result  (cost=0.00..431.00 rows=1 width=4)
                                  ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (10 rows)
 
 select * from csq_pullup t0 where not exists (select 1 from csq_pullup t1 where t0.i=t1.i + 1);
@@ -925,9 +914,7 @@ select * from csq_pullup t0 where not exists (select 1 from csq_pullup t1 where 
 -- wrong results bug MPP-16477
 --
 drop table if exists subselect_t1;
-NOTICE:  table "subselect_t1" does not exist, skipping
 drop table if exists subselect_t2;
-NOTICE:  table "subselect_t2" does not exist, skipping
 create table subselect_t1(x int) distributed by (x);
 insert into subselect_t1 values(1),(2);
 create table subselect_t2(y int) distributed by (y);
@@ -939,26 +926,26 @@ explain select * from subselect_t1 where x in (select y from subselect_t2);
 --------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=4)
    ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=4)
-         Hash Cond: subselect_t1.x = subselect_t2.y
+         Hash Cond: (subselect_t1.x = subselect_t2.y)
          ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Seq Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.64.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 
 select * from subselect_t1 where x in (select y from subselect_t2);
  x 
 ---
- 1
  2
+ 1
 (2 rows)
 
 -- start_ignore
 -- Known_opt_diff: MPP-21351
 -- end_ignore
 explain select * from subselect_t1 where x in (select y from subselect_t2 union all select y from subselect_t2);
-                                                QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=2 width=4)
    ->  Hash Join  (cost=0.00..1293.00 rows=1 width=4)
          Hash Cond: (subselect_t1.x = subselect_t2.y)
@@ -977,8 +964,8 @@ explain select * from subselect_t1 where x in (select y from subselect_t2 union 
 select * from subselect_t1 where x in (select y from subselect_t2 union all select y from subselect_t2);
  x 
 ---
- 1
  2
+ 1
 (2 rows)
 
 explain select count(*) from subselect_t1 where x in (select y from subselect_t2);
@@ -991,7 +978,7 @@ explain select count(*) from subselect_t1 where x in (select y from subselect_t2
                ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
                ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                      ->  Seq Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (8 rows)
 
 select count(*) from subselect_t1 where x in (select y from subselect_t2);
@@ -1004,8 +991,8 @@ select count(*) from subselect_t1 where x in (select y from subselect_t2);
 -- Known_opt_diff: MPP-21351
 -- end_ignore
 explain select count(*) from subselect_t1 where x in (select y from subselect_t2 union all select y from subselect_t2);
-                                                   QUERY PLAN                                                    
------------------------------------------------------------------------------------------------------------------
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=0.00..1293.00 rows=1 width=8)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=2 width=1)
          ->  Hash Join  (cost=0.00..1293.00 rows=1 width=1)
@@ -1099,9 +1086,8 @@ explain select * from t1 where a=1 and a=2 and a > (select t2.b from t2);
  Result  (cost=0.00..0.00 rows=0 width=4)
    ->  Result  (cost=0.00..0.00 rows=0 width=4)
          One-Time Filter: false
- Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: Pivotal Optimizer (GPORCA) version 1.621
-(5 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
 
 explain select * from t1 where a=1 and a=2 and a > (select t2.b from t2)
 union all
@@ -1110,9 +1096,8 @@ select * from t1 where a=1 and a=2 and a > (select t2.b from t2);
 ------------------------------------------
  Result  (cost=0.00..0.00 rows=0 width=4)
    One-Time Filter: false
- Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: Pivotal Optimizer (GPORCA) version 1.621
-(4 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(3 rows)
 
 select * from t1 where a=1 and a=2 and a > (select t2.b from t2)
 union all
@@ -1129,9 +1114,8 @@ where t1.a = foo.a;
  Result  (cost=0.00..0.00 rows=0 width=8)
    ->  Result  (cost=0.00..0.00 rows=0 width=8)
          One-Time Filter: false
- Settings:  optimizer=on; optimizer_segments=3
- Optimizer status: Pivotal Optimizer (GPORCA) version 1.621
-(5 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
 
 select * from t1,
 (select * from t1 where a=1 and a=2 and a > (select t2.b from t2)) foo
@@ -1153,6 +1137,7 @@ explain select 1 from t1 where a in (select b from t2 where a = 1 limit 1);
          Filter: (SubPlan 1)
          ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
+                     Filter: (a = 1)
          SubPlan 1  (slice0)
            ->  Limit  (cost=0.00..431.00 rows=1 width=4)
                  ->  Result  (cost=0.00..431.00 rows=1 width=4)
@@ -1160,8 +1145,7 @@ explain select 1 from t1 where a in (select b from t2 where a = 1 limit 1);
                        ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
                              ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                    ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
- Settings:  optimizer=on; optimizer_nestloop_factor=1; optimizer_segments=3
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.44.1
+ Optimizer: Pivotal Optimizer (GPORCA)
 (14 rows)
 
 explain select 1 from t1 where a in (select b from t2 where a = 1 offset 1);
@@ -1172,6 +1156,7 @@ explain select 1 from t1 where a in (select b from t2 where a = 1 offset 1);
          Filter: (SubPlan 1)
          ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
+                     Filter: (a = 1)
          SubPlan 1  (slice0)
            ->  Limit  (cost=0.00..431.00 rows=1 width=4)
                  ->  Result  (cost=0.00..431.00 rows=1 width=4)
@@ -1179,8 +1164,7 @@ explain select 1 from t1 where a in (select b from t2 where a = 1 offset 1);
                        ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
                              ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                    ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
- Settings:  optimizer=on; optimizer_nestloop_factor=1; optimizer_segments=3
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.39.2
+ Optimizer: Pivotal Optimizer (GPORCA)
 (14 rows)
 
 select 1 from t1 where a in (select b from t2 where a = 1 limit 1);
@@ -1251,30 +1235,28 @@ explain select row_number() over (order by seq asc) as id, foo.cnt
 from
 (select seq, (select count(*) from t1_mpp_24563 t1 where t1.id = t2.id) cnt from
 	t2_mpp_24563 t2 where value = 7) foo;
-                                                           QUERY PLAN                                                           
---------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..862.00 rows=1 width=16)
-   ->  WindowAgg  (cost=0.00..862.00 rows=1 width=16)
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..5172.08 rows=1 width=16)
+   ->  WindowAgg  (cost=0.00..5172.08 rows=1 width=16)
          Order By: t2_mpp_24563.seq
-         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=12)
+         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..5172.08 rows=1 width=12)
                Merge Key: t2_mpp_24563.seq
-               ->  Result  (cost=0.00..862.00 rows=1 width=12)
-                     ->  Result  (cost=0.00..862.00 rows=1 width=12)
-                           ->  Result  (cost=0.00..862.00 rows=1 width=12)
-                                 ->  Sort  (cost=0.00..862.00 rows=1 width=12)
-                                       Sort Key: t2_mpp_24563.seq
-                                       ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=12)
-                                             Hash Cond: (t2_mpp_24563.id = t1_mpp_24563.id)
-                                             ->  Seq Scan on t2_mpp_24563  (cost=0.00..431.00 rows=1 width=8)
-                                                   Filter: (value = 7)
-                                             ->  Hash  (cost=431.00..431.00 rows=1 width=12)
-                                                   ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
-                                                         Group Key: t1_mpp_24563.id
-                                                         ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                                               Sort Key: t1_mpp_24563.id
-                                                               ->  Seq Scan on t1_mpp_24563  (cost=0.00..431.00 rows=1 width=4)
+               ->  Result  (cost=0.00..5172.08 rows=1 width=12)
+                     ->  Result  (cost=0.00..5172.08 rows=1 width=12)
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                                 Sort Key: t2_mpp_24563.seq
+                                 ->  Seq Scan on t2_mpp_24563  (cost=0.00..431.00 rows=1 width=8)
+                                       Filter: (value = 7)
+                           SubPlan 1  (slice2; segments: 3)
+                             ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                                   ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                         Filter: (t1_mpp_24563.id = t2_mpp_24563.id)
+                                         ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                                     ->  Seq Scan on t1_mpp_24563  (cost=0.00..431.00 rows=1 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(19 rows)
 
 drop table t1_mpp_24563;
 drop table t2_mpp_24563;
@@ -1304,33 +1286,27 @@ CASE
 	ELSE 'Q2'::text END  AS  cc,  1 AS nn
 FROM t_mpp_20470 b;
 explain SELECT  cc, sum(nn) over() FROM v1_mpp_20470;
-                                                                       QUERY PLAN                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------
- WindowAgg  (cost=0.00..862.00 rows=1 width=16)
-   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=2 width=12)
-         ->  Result  (cost=0.00..862.00 rows=1 width=12)
-               ->  Result  (cost=0.00..862.00 rows=1 width=16)
-                     ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=16)
-                           Hash Cond: ((t_mpp_20470.col_name)::text = (t_mpp_20470_1.col_name)::text)
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                 Hash Key: t_mpp_20470.col_name
-                                 ->  Sequence  (cost=0.00..431.00 rows=1 width=8)
-                                       ->  Partition Selector for t_mpp_20470 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
-                                             Partitions selected: 2 (out of 2)
-                                       ->  Dynamic Seq Scan on t_mpp_20470 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
-                           ->  Hash  (cost=431.00..431.00 rows=1 width=16)
-                                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
-                                       Group Key: t_mpp_20470_1.col_name
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=12)
-                                             Sort Key: t_mpp_20470_1.col_name
-                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
-                                                   Hash Key: t_mpp_20470_1.col_name
-                                                   ->  Sequence  (cost=0.00..431.00 rows=1 width=12)
-                                                         ->  Partition Selector for t_mpp_20470 (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
-                                                               Partitions selected: 2 (out of 2)
-                                                         ->  Dynamic Seq Scan on t_mpp_20470 t_mpp_20470_1 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=12)
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ WindowAgg  (cost=0.00..5172.14 rows=334 width=16)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..5172.14 rows=1000 width=12)
+         ->  Result  (cost=0.00..5172.10 rows=334 width=12)
+               ->  Sequence  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Partition Selector for t_mpp_20470 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                           Partitions selected: 2 (out of 2)
+                     ->  Dynamic Seq Scan on t_mpp_20470 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
+               SubPlan 1  (slice2; segments: 3)
+                 ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                       ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                             Filter: ((t_mpp_20470_1.col_name)::text = (t_mpp_20470.col_name)::text)
+                             ->  Materialize  (cost=0.00..431.00 rows=1 width=12)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                                         ->  Sequence  (cost=0.00..431.00 rows=1 width=12)
+                                               ->  Partition Selector for t_mpp_20470 (dynamic scan id: 2)  (cost=10.00..100.00 rows=34 width=4)
+                                                     Partitions selected: 2 (out of 2)
+                                               ->  Dynamic Seq Scan on t_mpp_20470 t_mpp_20470_1 (dynamic scan id: 2)  (cost=0.00..431.00 rows=1 width=12)
  Optimizer: Pivotal Optimizer (GPORCA)
-(24 rows)
+(18 rows)
 
 drop view v1_mpp_20470;
 drop table t_mpp_20470;
@@ -1490,13 +1466,13 @@ EXPLAIN SELECT '' AS six, f1 AS "Uncorrelated Field" FROM SUBSELECT_TBL
          ->  Sort  (cost=0.00..862.00 rows=3 width=4)
                Sort Key: subselect_tbl.f1
                ->  Hash Semi Join  (cost=0.00..862.00 rows=3 width=4)
-                     Hash Cond: subselect_tbl.f1 = subselect_tbl_1.f2
+                     Hash Cond: (subselect_tbl.f1 = subselect_tbl_1.f2)
                      ->  Seq Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=4)
                      ->  Hash  (cost=431.00..431.00 rows=3 width=4)
                            ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
                                  Hash Key: subselect_tbl_1.f2
                                  ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (13 rows)
 
 EXPLAIN SELECT '' AS six, f1 AS "Uncorrelated Field" FROM SUBSELECT_TBL
@@ -1505,12 +1481,12 @@ EXPLAIN SELECT '' AS six, f1 AS "Uncorrelated Field" FROM SUBSELECT_TBL
                                                              QUERY PLAN                                                              
 -------------------------------------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..1293.00 rows=2 width=12)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.00 rows=5 width=4)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.00 rows=4 width=4)
          Merge Key: subselect_tbl.f1
          ->  Sort  (cost=0.00..1293.00 rows=2 width=4)
                Sort Key: subselect_tbl.f1
                ->  Hash Join  (cost=0.00..1293.00 rows=2 width=4)
-                     Hash Cond: subselect_tbl.f1 = subselect_tbl_1.f2
+                     Hash Cond: (subselect_tbl.f1 = subselect_tbl_1.f2)
                      ->  Seq Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=4)
                      ->  Hash  (cost=862.00..862.00 rows=2 width=4)
                            ->  GroupAggregate  (cost=0.00..862.00 rows=2 width=4)
@@ -1518,32 +1494,32 @@ EXPLAIN SELECT '' AS six, f1 AS "Uncorrelated Field" FROM SUBSELECT_TBL
                                  ->  Sort  (cost=0.00..862.00 rows=3 width=4)
                                        Sort Key: subselect_tbl_1.f2
                                        ->  Hash Semi Join  (cost=0.00..862.00 rows=3 width=4)
-                                             Hash Cond: subselect_tbl_1.f2 = subselect_tbl_2.f1
+                                             Hash Cond: (subselect_tbl_1.f2 = subselect_tbl_2.f1)
                                              ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
                                                    Hash Key: subselect_tbl_1.f2
                                                    ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=4)
                                              ->  Hash  (cost=431.00..431.00 rows=3 width=4)
                                                    ->  Seq Scan on subselect_tbl subselect_tbl_2  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (21 rows)
 
 EXPLAIN SELECT '' AS three, f1, f2
   FROM SUBSELECT_TBL
   WHERE (f1, f2) NOT IN (SELECT f2, CAST(f3 AS int4) FROM SUBSELECT_TBL
                          WHERE f3 IS NOT NULL) ORDER BY 2,3;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000009.64..10000000009.64 rows=4 width=8)
    Merge Key: subselect_tbl.f1, subselect_tbl.f2
    ->  Sort  (cost=10000000009.64..10000000009.64 rows=2 width=8)
          Sort Key: subselect_tbl.f1, subselect_tbl.f2
          ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000000.00..10000000009.61 rows=2 width=8)
-               Join Filter: subselect_tbl.f1 = subselect_tbl_1.f2 AND subselect_tbl.f2 = subselect_tbl_1.f3::integer
+               Join Filter: ((subselect_tbl.f1 = subselect_tbl_1.f2) AND (subselect_tbl.f2 = (subselect_tbl_1.f3)::integer))
                ->  Seq Scan on subselect_tbl  (cost=0.00..3.08 rows=3 width=8)
                ->  Materialize  (cost=0.00..3.47 rows=7 width=12)
                      ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.36 rows=7 width=12)
                            ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..3.08 rows=3 width=12)
-                                 Filter: f3 IS NOT NULL
+                                 Filter: (f3 IS NOT NULL)
  Optimizer: Postgres query optimizer
 (12 rows)
 
@@ -1552,22 +1528,22 @@ EXPLAIN SELECT * FROM tenk1 a, tenk1 b
 WHERE (a.unique1,b.unique2) IN (SELECT unique1,unique2 FROM tenk1 c);
                                                 QUERY PLAN                                                 
 -----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=974.00..1636.00 rows=10000 width=488)
-   ->  Hash Join  (cost=974.00..1636.00 rows=3334 width=488)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=978.00..1642.00 rows=10000 width=488)
+   ->  Hash Join  (cost=978.00..1642.00 rows=3334 width=488)
          Hash Cond: (c.unique2 = b.unique2)
-         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=462.00..986.50 rows=3334 width=248)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=464.00..990.50 rows=3334 width=248)
                Hash Key: c.unique2
-               ->  Hash Join  (cost=462.00..786.50 rows=3334 width=248)
+               ->  Hash Join  (cost=464.00..790.50 rows=3334 width=248)
                      Hash Cond: (a.unique1 = c.unique1)
-                     ->  Seq Scan on tenk1 a  (cost=0.00..187.00 rows=3334 width=244)
-                     ->  Hash  (cost=337.00..337.00 rows=3334 width=8)
-                           ->  HashAggregate  (cost=237.00..337.00 rows=3334 width=8)
+                     ->  Seq Scan on tenk1 a  (cost=0.00..189.00 rows=3334 width=244)
+                     ->  Hash  (cost=339.00..339.00 rows=3334 width=8)
+                           ->  HashAggregate  (cost=239.00..339.00 rows=3334 width=8)
                                  Group Key: c.unique1, c.unique2
-                                 ->  Seq Scan on tenk1 c  (cost=0.00..187.00 rows=3334 width=8)
-         ->  Hash  (cost=387.00..387.00 rows=3334 width=244)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..387.00 rows=3334 width=244)
+                                 ->  Seq Scan on tenk1 c  (cost=0.00..189.00 rows=3334 width=8)
+         ->  Hash  (cost=389.00..389.00 rows=3334 width=244)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..389.00 rows=3334 width=244)
                      Hash Key: b.unique2
-                     ->  Seq Scan on tenk1 b  (cost=0.00..187.00 rows=3334 width=244)
+                     ->  Seq Scan on tenk1 b  (cost=0.00..189.00 rows=3334 width=244)
  Optimizer: Postgres query optimizer
 (17 rows)
 
@@ -1575,40 +1551,41 @@ WHERE (a.unique1,b.unique2) IN (SELECT unique1,unique2 FROM tenk1 c);
 EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
   FROM SUBSELECT_TBL upper
   WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1) ORDER BY 2,3;
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..862.00 rows=3 width=16)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=8 width=8)
          Merge Key: subselect_tbl.f1, subselect_tbl.f2
          ->  Sort  (cost=0.00..862.00 rows=3 width=8)
                Sort Key: subselect_tbl.f1, subselect_tbl.f2
                ->  Hash Semi Join  (cost=0.00..862.00 rows=3 width=8)
-                     Hash Cond: subselect_tbl.f1 = subselect_tbl_1.f1 AND subselect_tbl.f1 = subselect_tbl_1.f2
+                     Hash Cond: ((subselect_tbl.f1 = subselect_tbl_1.f1) AND (subselect_tbl.f1 = subselect_tbl_1.f2))
                      ->  Seq Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=8)
+                           Filter: (NOT (f1 IS NULL))
                      ->  Hash  (cost=431.00..431.00 rows=3 width=8)
                            ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=8)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.75.0
-(11 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
 
 EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f3 AS "Second Field"
   FROM SUBSELECT_TBL upper
   WHERE f1 IN
     (SELECT f2 FROM SUBSELECT_TBL WHERE CAST(upper.f2 AS float) = f3) ORDER BY 2,3;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..862.00 rows=3 width=20)
    ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=8 width=12)
          Merge Key: subselect_tbl.f1, subselect_tbl.f3
          ->  Sort  (cost=0.00..862.00 rows=3 width=12)
                Sort Key: subselect_tbl.f1, subselect_tbl.f3
                ->  Hash Semi Join  (cost=0.00..862.00 rows=3 width=12)
-                     Hash Cond: subselect_tbl.f2::double precision = subselect_tbl_1.f3 AND subselect_tbl.f1 = subselect_tbl_1.f2
+                     Hash Cond: (((subselect_tbl.f2)::double precision = subselect_tbl_1.f3) AND (subselect_tbl.f1 = subselect_tbl_1.f2))
                      ->  Seq Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=16)
                      ->  Hash  (cost=431.00..431.00 rows=3 width=12)
                            ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=12)
                                  Hash Key: subselect_tbl_1.f2
                                  ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=12)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.75.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (13 rows)
 
 EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f3 AS "Second Field"
@@ -1629,28 +1606,28 @@ EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f3 AS "Second Field"
                              ->  Materialize  (cost=0.00..431.00 rows=4 width=4)
                                    ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
                                          ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=2 width=4)
-                                               Filter: f2 = f3::integer
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+                                               Filter: (f2 = int4(f3))
+ Optimizer: Pivotal Optimizer (GPORCA)
 (14 rows)
 
 EXPLAIN SELECT '' AS five, f1 AS "Correlated Field"
   FROM SUBSELECT_TBL
   WHERE (f1, f2) IN (SELECT f2, CAST(f3 AS int4) FROM SUBSELECT_TBL
                      WHERE f3 IS NOT NULL) ORDER BY 2;
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=6.67..6.69 rows=8 width=4)
    Merge Key: subselect_tbl.f1
    ->  Sort  (cost=6.67..6.69 rows=3 width=4)
          Sort Key: subselect_tbl.f1
          ->  Hash Semi Join  (cost=3.33..6.55 rows=3 width=4)
-               Hash Cond: subselect_tbl.f1 = subselect_tbl_1.f2 AND subselect_tbl.f2 = subselect_tbl_1.f3::integer
+               Hash Cond: ((subselect_tbl.f1 = subselect_tbl_1.f2) AND (subselect_tbl.f2 = (subselect_tbl_1.f3)::integer))
                ->  Seq Scan on subselect_tbl  (cost=0.00..3.08 rows=3 width=8)
                ->  Hash  (cost=3.22..3.22 rows=3 width=12)
                      ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.22 rows=3 width=12)
                            Hash Key: subselect_tbl_1.f2
                            ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..3.08 rows=3 width=12)
-                                 Filter: f3 IS NOT NULL
+                                 Filter: (f3 IS NOT NULL)
  Optimizer: Postgres query optimizer
 (13 rows)
 
@@ -1703,20 +1680,21 @@ EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
          ->  Hash Semi Join  (cost=0.00..862.00 rows=3 width=8)
                Hash Cond: ((subselect_tbl.f1 = subselect_tbl_1.f1) AND (subselect_tbl.f1 = subselect_tbl_1.f2))
                ->  Seq Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=8)
+                     Filter: (NOT (f1 IS NULL))
                ->  Hash  (cost=431.00..431.00 rows=3 width=8)
                      ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(8 rows)
+(9 rows)
 
 EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
   FROM SUBSELECT_TBL upper
   WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1  ORDER BY f2 LIMIT 3);
                                                            QUERY PLAN                                                            
 ---------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..1324038.57 rows=3 width=16)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324038.57 rows=8 width=8)
-         ->  Seq Scan on subselect_tbl  (cost=0.00..1324038.57 rows=3 width=8)
-               Filter: (SubPlan 1)
+ Result  (cost=0.00..1324038.66 rows=3 width=16)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324038.66 rows=8 width=8)
+         ->  Seq Scan on subselect_tbl  (cost=0.00..1324038.66 rows=3 width=8)
+               Filter: ((NOT (f1 IS NULL)) AND (SubPlan 1))
                SubPlan 1  (slice2; segments: 3)
                  ->  Limit  (cost=0.00..431.01 rows=1 width=4)
                        ->  Sort  (cost=0.00..431.01 rows=1 width=4)
@@ -1742,7 +1720,7 @@ EXPLAIN select count(*) from
    ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..864.07 rows=1 width=8)
          ->  Aggregate  (cost=0.00..864.07 rows=1 width=8)
                ->  Hash Join  (cost=0.00..864.07 rows=34 width=1)
-                     Hash Cond: tenk1.unique1 = tenk1_1.hundred
+                     Hash Cond: (tenk1.unique1 = tenk1_1.hundred)
                      ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=4)
                      ->  Hash  (cost=431.94..431.94 rows=34 width=4)
                            ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
@@ -1754,7 +1732,7 @@ EXPLAIN select count(*) from
                                              ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
                                                    Group Key: tenk1_1.hundred
                                                    ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.51 rows=3334 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.75.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (17 rows)
 
 EXPLAIN select count(distinct ss.ten) from
@@ -1780,7 +1758,7 @@ EXPLAIN select count(distinct ss.ten) from
                                                    ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
                                                          Group Key: tenk1_1.hundred
                                                          ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.51 rows=3334 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (19 rows)
 
 EXPLAIN select count(*) from
@@ -1792,7 +1770,7 @@ EXPLAIN select count(*) from
    ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..864.07 rows=1 width=8)
          ->  Aggregate  (cost=0.00..864.07 rows=1 width=8)
                ->  Hash Semi Join  (cost=0.00..864.07 rows=34 width=1)
-                     Hash Cond: tenk1.unique1 = tenk1_1.hundred
+                     Hash Cond: (tenk1.unique1 = tenk1_1.hundred)
                      ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=4)
                      ->  Hash  (cost=431.94..431.94 rows=34 width=4)
                            ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
@@ -1804,7 +1782,7 @@ EXPLAIN select count(*) from
                                              ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
                                                    Group Key: tenk1_1.hundred
                                                    ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.51 rows=3334 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.75.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (17 rows)
 
 EXPLAIN select count(distinct ss.ten) from
@@ -1830,7 +1808,7 @@ EXPLAIN select count(distinct ss.ten) from
                                                    ->  HashAggregate  (cost=0.00..431.94 rows=34 width=4)
                                                          Group Key: tenk1_1.hundred
                                                          ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.51 rows=3334 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (19 rows)
 
 --
@@ -1842,17 +1820,17 @@ EXPLAIN select count(distinct ss.ten) from
 EXPLAIN SELECT EXISTS(SELECT * FROM tenk1 WHERE tenk1.unique1 = tenk2.unique1) FROM tenk2 LIMIT 1;
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
- Limit  (cost=0.00..865.44 rows=1 width=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..865.44 rows=1 width=1)
-         ->  Limit  (cost=0.00..865.44 rows=1 width=1)
-               ->  Result  (cost=0.00..865.44 rows=3334 width=1)
-                     ->  Result  (cost=0.00..865.44 rows=3334 width=8)
-                           ->  Hash Left Join  (cost=0.00..865.41 rows=3334 width=8)
+ Limit  (cost=0.00..866.24 rows=1 width=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..866.24 rows=1 width=1)
+         ->  Limit  (cost=0.00..866.24 rows=1 width=1)
+               ->  Result  (cost=0.00..866.24 rows=3334 width=1)
+                     ->  HashAggregate  (cost=0.00..866.24 rows=3334 width=1)
+                           Group Key: tenk2.unique1, tenk2.ctid, tenk2.gp_segment_id, "outer".ColRef_0048
+                           ->  Hash Left Join  (cost=0.00..864.63 rows=3334 width=15)
                                  Hash Cond: (tenk2.unique1 = tenk1.unique1)
-                                 ->  Seq Scan on tenk2  (cost=0.00..431.50 rows=3334 width=4)
-                                 ->  Hash  (cost=431.96..431.96 rows=3334 width=12)
-                                       ->  HashAggregate  (cost=0.00..431.96 rows=3334 width=12)
-                                             Group Key: tenk1.unique1
+                                 ->  Seq Scan on tenk2  (cost=0.00..431.50 rows=3334 width=14)
+                                 ->  Hash  (cost=431.55..431.55 rows=3334 width=5)
+                                       ->  Result  (cost=0.00..431.55 rows=3334 width=5)
                                              ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
 (13 rows)
@@ -1895,13 +1873,13 @@ ANALYZE dedup_test3;
 EXPLAIN SELECT * FROM dedup_test1 INNER JOIN dedup_test2 ON dedup_test1.a= dedup_test2.e WHERE (a) IN (SELECT a FROM dedup_test3);
                                                                               QUERY PLAN                                                                               
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.00 rows=2 width=16)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1293.00 rows=1 width=16)
    ->  Hash Join  (cost=0.00..1293.00 rows=1 width=16)
-         Hash Cond: dedup_test2.e = dedup_test1.a
+         Hash Cond: (dedup_test2.e = dedup_test1.a)
          ->  Seq Scan on dedup_test2  (cost=0.00..431.00 rows=2 width=8)
          ->  Hash  (cost=862.00..862.00 rows=1 width=8)
                ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
-                     Hash Cond: dedup_test1.a = dedup_test3.a
+                     Hash Cond: (dedup_test1.a = dedup_test3.a)
                      ->  Seq Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=8)
                      ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                            ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
@@ -1919,7 +1897,7 @@ EXPLAIN SELECT * FROM dedup_test1 INNER JOIN dedup_test2 ON dedup_test1.a= dedup
                                                                      ->  Partition Selector for dedup_test3 (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
                                                                            Partitions selected: 1 (out of 1)
                                                                      ->  Dynamic Seq Scan on dedup_test3 (dynamic scan id: 1)  (cost=0.00..431.00 rows=4 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.60.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (25 rows)
 
 SELECT * FROM dedup_test1 INNER JOIN dedup_test2 ON dedup_test1.a= dedup_test2.e WHERE (a) IN (SELECT a FROM dedup_test3);
@@ -1947,8 +1925,8 @@ EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND dedup_test3.b IN 
          ->  Hash  (cost=431.00..431.00 rows=4 width=4)
                ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
                      ->  Seq Scan on dedup_test1 dedup_test1_1  (cost=0.00..431.00 rows=2 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
-(19 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(16 rows)
 
 EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND dedup_test3.b IN (SELECT a FROM dedup_test1);
                                                          QUERY PLAN                                                          
@@ -1968,14 +1946,14 @@ EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND dedup_test3.b IN 
          ->  Hash  (cost=431.00..431.00 rows=4 width=4)
                ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
                      ->  Seq Scan on dedup_test1 dedup_test1_1  (cost=0.00..431.00 rows=2 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (16 rows)
 
 EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND EXISTS (SELECT b FROM dedup_test1) AND dedup_test3.b IN (SELECT b FROM dedup_test1);
                                                               QUERY PLAN                                                               
 ---------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..2648064.82 rows=4 width=20)
-   ->  Hash Join  (cost=0.00..2648064.81 rows=2 width=20)
+ Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..2648064.79 rows=4 width=20)
+   ->  Hash Join  (cost=0.00..2648064.79 rows=2 width=20)
          Hash Cond: (dedup_test3.b = dedup_test1_2.b)
          ->  Nested Loop  (cost=0.00..1324032.60 rows=2 width=20)
                Join Filter: true
@@ -1986,9 +1964,9 @@ EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND EXISTS (SELECT b 
                            ->  Dynamic Seq Scan on dedup_test3 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=12)
                                  Filter: (c = 7)
                ->  Seq Scan on dedup_test1  (cost=0.00..431.00 rows=2 width=8)
-         ->  Hash  (cost=1324032.22..1324032.22 rows=4 width=4)
-               ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..1324032.22 rows=4 width=4)
-                     ->  Nested Loop Semi Join  (cost=0.00..1324032.22 rows=2 width=4)
+         ->  Hash  (cost=1324032.20..1324032.20 rows=4 width=4)
+               ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..1324032.20 rows=4 width=4)
+                     ->  Nested Loop Semi Join  (cost=0.00..1324032.20 rows=2 width=4)
                            Join Filter: true
                            ->  GroupAggregate  (cost=0.00..431.00 rows=2 width=4)
                                  Group Key: dedup_test1_2.b
@@ -2003,7 +1981,7 @@ EXPLAIN SELECT * FROM dedup_test3, dedup_test1 WHERE c = 7 AND EXISTS (SELECT b 
                                              ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
                                                    ->  Limit  (cost=0.00..431.00 rows=1 width=1)
                                                          ->  Seq Scan on dedup_test1 dedup_test1_1  (cost=0.00..431.00 rows=2 width=1)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (30 rows)
 
 -- start_ignore
@@ -2031,6 +2009,7 @@ select * from init_main_plan_parallel where exists (select * from pg_class);
 -- hashExpr are in its targetlist, test the motion node above it also updated
 -- its targetlist, otherwise, a wrong answer or a crash happens.
 DROP TABLE IF EXISTS TEST_IN;
+NOTICE:  table "test_in" does not exist, skipping
 CREATE TABLE TEST_IN(
     C01  FLOAT,
     C02  NUMERIC(10,0)
@@ -2074,8 +2053,8 @@ select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where 
                              ->  Materialize
                                    ->  Gather Motion 3:1  (slice2; segments: 3)
                                          ->  Seq Scan on simplify_sub simplify_sub_1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
-(14 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(15 rows)
 
 select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
  i 
@@ -2101,7 +2080,7 @@ select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 wh
                              ->  Materialize
                                    ->  Gather Motion 3:1  (slice2; segments: 3)
                                          ->  Seq Scan on simplify_sub simplify_sub_1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (14 rows)
 
 select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 1);
@@ -2111,8 +2090,8 @@ select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 wh
 
 explain (costs off)
 select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
-                      QUERY PLAN                      
-------------------------------------------------------
+                    QUERY PLAN                    
+--------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop Semi Join
          Join Filter: true
@@ -2122,8 +2101,8 @@ select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where 
                ->  Result
                      ->  Result
                            One-Time Filter: false
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
-(9 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
 
 select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
  i 
@@ -2132,22 +2111,22 @@ select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where 
 
 explain (costs off)
 select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
-                      QUERY PLAN                      
-------------------------------------------------------
+                QUERY PLAN                
+------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop Anti Join
          Join Filter: true
          ->  Seq Scan on simplify_sub
          ->  Result
                One-Time Filter: false
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 
 select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit 0);
  i 
 ---
- 1
  2
+ 1
 (2 rows)
 
 explain (costs off)
@@ -2162,14 +2141,14 @@ select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where 
          ->  Hash
                ->  Result
                      ->  Seq Scan on simplify_sub simplify_sub_1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
-(8 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
 
 select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
  i 
 ---
- 2
  1
+ 2
 (2 rows)
 
 explain (costs off)
@@ -2183,7 +2162,7 @@ select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 wh
          ->  Hash
                ->  Result
                      ->  Seq Scan on simplify_sub simplify_sub_1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (8 rows)
 
 select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit all);
@@ -2203,14 +2182,14 @@ select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where 
          ->  Hash
                ->  Result
                      ->  Seq Scan on simplify_sub simplify_sub_1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
-(8 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
 
 select * from simplify_sub t1 where exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
  i 
 ---
- 2
  1
+ 2
 (2 rows)
 
 explain (costs off)
@@ -2224,7 +2203,7 @@ select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 wh
          ->  Hash
                ->  Result
                      ->  Seq Scan on simplify_sub simplify_sub_1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (8 rows)
 
 select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 where t1.i = t2.i limit NULL);
@@ -2235,11 +2214,11 @@ select * from simplify_sub t1 where not exists (select 1 from simplify_sub t2 wh
 -- aggregates without GROUP BY or HAVING
 explain (costs off)
 select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
-                      QUERY PLAN                      
-------------------------------------------------------
+                QUERY PLAN                
+------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Seq Scan on simplify_sub
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (3 rows)
 
 select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
@@ -2251,12 +2230,12 @@ select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t
 
 explain (costs off)
 select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
-                      QUERY PLAN                      
-------------------------------------------------------
+              QUERY PLAN               
+---------------------------------------
  Result
    ->  Result
          One-Time Filter: false
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (4 rows)
 
 select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i);
@@ -2266,11 +2245,11 @@ select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_s
 
 explain (costs off)
 select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
-                      QUERY PLAN                      
-------------------------------------------------------
+                QUERY PLAN                
+------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Seq Scan on simplify_sub
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (3 rows)
 
 select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
@@ -2282,12 +2261,12 @@ select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t
 
 explain (costs off)
 select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
-                      QUERY PLAN                      
-------------------------------------------------------
+              QUERY PLAN               
+---------------------------------------
  Result
    ->  Result
          One-Time Filter: false
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (4 rows)
 
 select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 0);
@@ -2311,7 +2290,7 @@ select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t
                        ->  Materialize
                              ->  Gather Motion 3:1  (slice2; segments: 3)
                                    ->  Seq Scan on simplify_sub simplify_sub_1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (13 rows)
 
 select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
@@ -2335,7 +2314,7 @@ select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_s
                        ->  Materialize
                              ->  Gather Motion 3:1  (slice2; segments: 3)
                                    ->  Seq Scan on simplify_sub simplify_sub_1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (13 rows)
 
 select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset 1);
@@ -2361,14 +2340,14 @@ select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t
                        ->  Materialize
                              ->  Gather Motion 3:1  (slice2; segments: 3)
                                    ->  Seq Scan on simplify_sub simplify_sub_1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (13 rows)
 
 select * from simplify_sub t1 where exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
  i 
 ---
- 2
  1
+ 2
 (2 rows)
 
 explain (costs off)
@@ -2387,7 +2366,7 @@ select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_s
                        ->  Materialize
                              ->  Gather Motion 3:1  (slice2; segments: 3)
                                    ->  Seq Scan on simplify_sub simplify_sub_1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.55.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (13 rows)
 
 select * from simplify_sub t1 where not exists (select sum(t2.i) from simplify_sub t2 where t1.i = t2.i offset NULL);
@@ -2425,15 +2404,19 @@ LANGUAGE plpgsql NO SQL;
 SELECT a, b FROM foo f WHERE EXISTS (SELECT 1 FROM foo f1 WHERE f.b=f1.b AND f1.c > (SELECT my_lookup('a')));
  a | b 
 ---+---
- 1 | a
  2 | b
+ 1 | a
 (2 rows)
 
 -- When creating a plan with subplan in ParallelizeSubplan, use the top-level flow
 -- for the corresponding slice instead of the containing the plan node's flow.
 -- This related to issue: https://github.com/greenplum-db/gpdb/issues/12371
 create table extra_flow_dist(a int, b int, c date);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table extra_flow_dist1(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into extra_flow_dist select i, i, '1949-10-01'::date from generate_series(1, 10)i;
 insert into extra_flow_dist1 select i, i from generate_series(20, 22)i;
 -- case 1 subplan with general locus (CTE and subquery)
@@ -2446,7 +2429,7 @@ explain (costs off) with run_dt as (
 )
 select * from run_dt, extra_flow_dist1
 where dt < '2010-01-01'::date;
-                                         QUERY PLAN
+                                         QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)
    ->  Nested Loop
@@ -2479,9 +2462,9 @@ select * from run_dt, extra_flow_dist1
 where dt < '2010-01-01'::date;
      dt     | a  | b  
 ------------+----+----
+ 10-01-1949 | 22 | 22
  10-01-1949 | 20 | 20
  10-01-1949 | 21 | 21
- 10-01-1949 | 22 | 22
 (3 rows)
 
 create table extra_flow_rand(a int) distributed replicated;
@@ -2496,8 +2479,8 @@ explain (verbose, costs off) with run_dt as (
 )
 select * from run_dt, extra_flow_dist1
 where dt < '2010-01-01'::date;
-                                         QUERY PLAN
---------------------------------------------------------------------------------------------
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    Output: ((SubPlan 1)), extra_flow_dist1.a, extra_flow_dist1.b
    ->  Nested Loop
@@ -2539,9 +2522,9 @@ select * from run_dt, extra_flow_dist1
 where dt < '2010-01-01'::date;
      dt     | a  | b  
 ------------+----+----
- 10-01-1949 | 22 | 22
  10-01-1949 | 20 | 20
  10-01-1949 | 21 | 21
+ 10-01-1949 | 22 | 22
 (3 rows)
 
 -- case 3 for subplan with entry locus (CTE and subquery)
@@ -2554,7 +2537,7 @@ explain (costs off) with run_dt as (
 )
 select * from run_dt, extra_flow_dist1
 where dt < '2010-01-01'::date;
-                                         QUERY PLAN
+                                         QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)
    ->  Nested Loop
@@ -2603,8 +2586,8 @@ explain (verbose, costs off) with run_dt as (
 )
 select * from run_dt, extra_flow_dist1
 where dt < extra_flow_dist1.a;
-                                         QUERY PLAN
---------------------------------------------------------------------------------------------
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    Output: extra_flow_rand.a, (max(1)), extra_flow_dist1.a, extra_flow_dist1.b
    ->  Nested Loop
@@ -2644,8 +2627,8 @@ explain (costs off) with run_dt as (
 )
 select * from run_dt, extra_flow_dist1
 where dt < extra_flow_dist1.a;
-                                         QUERY PLAN
---------------------------------------------------------------------------------------------
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)
    ->  Nested Loop
          Join Filter: ((max(1)) < extra_flow_dist1.a)
@@ -2683,8 +2666,8 @@ explain (costs off) select * from (
 ) run_dt,
 extra_flow_dist1
 where dt < '2010-01-01'::date;
-                                         QUERY PLAN
---------------------------------------------------------------------------------------------
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice6; segments: 3)
    ->  Nested Loop
          Join Filter: true
@@ -2745,7 +2728,7 @@ explain (costs off) with run_dt as (
 )
 select * from run_dt, extra_flow_dist1
 where dt < '2010-01-01'::date;
-                                         QUERY PLAN
+                                         QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)
    ->  Nested Loop
@@ -2774,7 +2757,7 @@ explain (costs off) select * from (select
    ) dt
    from im() x) run_dt, extra_flow_dist1
 where dt < '2010-01-01'::date;
-                                         QUERY PLAN
+                                         QUERY PLAN                                         
 --------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)
    ->  Nested Loop
@@ -3051,31 +3034,31 @@ set optimizer to off;
 explain select t.* from sublink_outer_table t join (select y ,10*avg(x) s from sublink_inner_table group by y) RR on RR.y = t.b and t.a > rr.s;
                                             QUERY PLAN                                            
 --------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=436.00..1310.77 rows=28700 width=8)
-   ->  Hash Join  (cost=436.00..928.11 rows=9567 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1306.00..13962.25 rows=28700 width=8)
+   ->  Hash Join  (cost=1306.00..13962.25 rows=9567 width=8)
          Hash Cond: (t.b = sublink_inner_table.y)
          Join Filter: ((t.a)::numeric > (('10'::numeric * avg(sublink_inner_table.x))))
-         ->  Seq Scan on sublink_outer_table t  (cost=0.00..321.00 rows=28700 width=8)
-         ->  Hash  (cost=431.83..431.83 rows=333 width=40)
-               ->  HashAggregate  (cost=423.50..428.50 rows=333 width=40)
+         ->  Seq Scan on sublink_outer_table t  (cost=0.00..961.00 rows=28700 width=8)
+         ->  Hash  (cost=1293.50..1293.50 rows=334 width=40)
+               ->  HashAggregate  (cost=1268.50..1283.50 rows=334 width=40)
                      Group Key: sublink_inner_table.y
-                     ->  Seq Scan on sublink_inner_table  (cost=0.00..293.67 rows=25967 width=12)
+                     ->  Seq Scan on sublink_inner_table  (cost=0.00..879.00 rows=25967 width=12)
  Optimizer: Postgres query optimizer
 (10 rows)
 
 explain select * from sublink_outer_table T where a > (select 10*avg(x) from sublink_inner_table R where T.b=R.y);
                                                 QUERY PLAN                                                
 ----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=436.00..1310.77 rows=28700 width=8)
-   ->  Hash Join  (cost=436.00..928.11 rows=9567 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1306.00..13962.25 rows=28700 width=8)
+   ->  Hash Join  (cost=1306.00..13962.25 rows=9567 width=8)
          Hash Cond: (t.b = "Expr_SUBQUERY".csq_c0)
          Join Filter: ((t.a)::numeric > "Expr_SUBQUERY".csq_c1)
-         ->  Seq Scan on sublink_outer_table t  (cost=0.00..321.00 rows=28700 width=8)
-         ->  Hash  (cost=431.83..431.83 rows=333 width=40)
-               ->  Subquery Scan on "Expr_SUBQUERY"  (cost=423.50..431.83 rows=333 width=40)
-                     ->  HashAggregate  (cost=423.50..428.50 rows=333 width=40)
+         ->  Seq Scan on sublink_outer_table t  (cost=0.00..961.00 rows=28700 width=8)
+         ->  Hash  (cost=1293.50..1293.50 rows=334 width=40)
+               ->  Subquery Scan on "Expr_SUBQUERY"  (cost=1268.50..1293.50 rows=334 width=40)
+                     ->  HashAggregate  (cost=1268.50..1283.50 rows=334 width=40)
                            Group Key: r.y
-                           ->  Seq Scan on sublink_inner_table r  (cost=0.00..293.67 rows=25967 width=12)
+                           ->  Seq Scan on sublink_inner_table r  (cost=0.00..879.00 rows=25967 width=12)
  Optimizer: Postgres query optimizer
 (11 rows)
 
@@ -3083,35 +3066,35 @@ set enable_hashagg to off;
 explain select t.* from sublink_outer_table t join (select y ,10*avg(x) s from sublink_inner_table group by y) RR on RR.y = t.b and t.a > rr.s;
                                                QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=2404.84..3279.62 rows=28700 width=8)
-   ->  Hash Join  (cost=2404.84..2896.95 rows=9567 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=7829.87..20486.12 rows=28700 width=8)
+   ->  Hash Join  (cost=7829.87..20486.12 rows=9567 width=8)
          Hash Cond: (t.b = sublink_inner_table.y)
          Join Filter: ((t.a)::numeric > (('10'::numeric * avg(sublink_inner_table.x))))
-         ->  Seq Scan on sublink_outer_table t  (cost=0.00..321.00 rows=28700 width=8)
-         ->  Hash  (cost=2400.67..2400.67 rows=333 width=40)
-               ->  GroupAggregate  (cost=2197.59..2397.34 rows=333 width=40)
+         ->  Seq Scan on sublink_outer_table t  (cost=0.00..961.00 rows=28700 width=8)
+         ->  Hash  (cost=7817.37..7817.37 rows=334 width=40)
+               ->  GroupAggregate  (cost=7208.12..7807.37 rows=334 width=40)
                      Group Key: sublink_inner_table.y
-                     ->  Sort  (cost=2197.59..2262.51 rows=25967 width=12)
+                     ->  Sort  (cost=7208.12..7402.87 rows=25967 width=12)
                            Sort Key: sublink_inner_table.y
-                           ->  Seq Scan on sublink_inner_table  (cost=0.00..293.67 rows=25967 width=12)
+                           ->  Seq Scan on sublink_inner_table  (cost=0.00..879.00 rows=25967 width=12)
  Optimizer: Postgres query optimizer
 (12 rows)
 
 explain select * from sublink_outer_table T where a > (select 10*avg(x) from sublink_inner_table R where T.b=R.y);
                                                    QUERY PLAN                                                   
 ----------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=2404.84..3279.62 rows=28700 width=8)
-   ->  Hash Join  (cost=2404.84..2896.95 rows=9567 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=7829.87..20486.12 rows=28700 width=8)
+   ->  Hash Join  (cost=7829.87..20486.12 rows=9567 width=8)
          Hash Cond: (t.b = "Expr_SUBQUERY".csq_c0)
          Join Filter: ((t.a)::numeric > "Expr_SUBQUERY".csq_c1)
-         ->  Seq Scan on sublink_outer_table t  (cost=0.00..321.00 rows=28700 width=8)
-         ->  Hash  (cost=2400.67..2400.67 rows=333 width=40)
-               ->  Subquery Scan on "Expr_SUBQUERY"  (cost=2197.59..2400.67 rows=333 width=40)
-                     ->  GroupAggregate  (cost=2197.59..2397.34 rows=333 width=40)
+         ->  Seq Scan on sublink_outer_table t  (cost=0.00..961.00 rows=28700 width=8)
+         ->  Hash  (cost=7817.37..7817.37 rows=334 width=40)
+               ->  Subquery Scan on "Expr_SUBQUERY"  (cost=7208.12..7817.37 rows=334 width=40)
+                     ->  GroupAggregate  (cost=7208.12..7807.37 rows=334 width=40)
                            Group Key: r.y
-                           ->  Sort  (cost=2197.59..2262.51 rows=25967 width=12)
+                           ->  Sort  (cost=7208.12..7402.87 rows=25967 width=12)
                                  Sort Key: r.y
-                                 ->  Seq Scan on sublink_inner_table r  (cost=0.00..293.67 rows=25967 width=12)
+                                 ->  Seq Scan on sublink_inner_table r  (cost=0.00..879.00 rows=25967 width=12)
  Optimizer: Postgres query optimizer
 (13 rows)
 
@@ -3524,9 +3507,9 @@ explain (costs off) select least((select 5), greatest(b, NULL, (select 1)), a) f
 select least((select 5), greatest(b, NULL, (select 1)), a) from foo;
  least 
 -------
+     1
      2
      3
-     1
 (3 rows)
 
 drop table foo;


### PR DESCRIPTION
Disable decorrelation for count() with no grouping columns.

In SQL standard, GROUP BY clause can represent two distinct operations: normal GROUP BY with grouping columns, and scalar GROUP BY without grouping columns. Their main difference is that the scalar GROUP BY always outputs exactly one row, even when input relation is empty. This especially matters for COUNT(*) and COUNT(attr) aggregates since in empty input their output is 0, not NULL.

During subquery decorrelation in ORCA, when pulling predicates through GpAgg, new grouping columns are added to it. This is fine for normal GROUP BYs, but for scalar GROUP BY (the case when there were no grouping columns originally), it changes behavior on empty input relations, which produces invalid output. This seems to be a well-known bug in existing database literature, known as the "COUNT bug".

This behavior was noticed previously in ORCA, and a "COALESCE fix" was added, converting NULLs back to 0. However, this fix was added in a previous transformation (CSubqueryHandler), so it was unnecessary in some cases, and also didn't cover all of them. Fixing this properly will require a partial rewrite of CDecorrelator to use better decorrelation algorithms that don't miss these edge cases.

As a temporary solution, this patch disables decorrelation for GpAgg with no grouping columns, if COUNT(*) or COUNT(attr) is present, as well as the COALESCE fix. This unfortunately results in less optimal plans in some cases, but distinguishing correct decorrelation from incorrect ones is complicated and requires big rewrites.

Tests affected by this:
1. Search space size is reduced in 13 minidump tests, plans themselves weren't affected.
2. Unnecessary COALESCE is removed from 7 minidump tests.
3. Swap joins in InferPredicatesFromMultiSubquery.mdp, without affecting performance.
4. Fix ScalarCorrelatedSubqueryCountStar.mdp and ScalarSubqueryCountStarInJoin.mdp, since previously they were fixing incorrect behavior.
5. Change NullIf-With-Subquery.mdp and UnnestSQJoins.mdp to correlated versions (COALESCE fix worked for them before, so they were correct).
6. Change plans of several regression tests in subselect.sql, subselect_gp.sql, subselect_gp_indexes.sql and eagerfree.sql, replacing them with correlated plans. Unfortunately, they were the ones where decorrelation was safe even without COALESCE fix, but there is no easy way to determine that with current architecture (COALESCE fix was applied to them previously regardless).

Ported from greengage #1658.

Co-Authored-By: Maxim Michkov <m.michkov@arenadata.io>
