### PR TITLE
Remove obsolete pgaudit test configuration

### DIFF
--- a/gpcontrib/pgaudit/Makefile
+++ b/gpcontrib/pgaudit/Makefile
@@ -8,7 +8,6 @@ DATA = pgaudit--1.0.9.sql pgaudit--1.0--1.0.6.sql pgaudit--1.0.6--1.0.7.sql pgau
 PGFILEDESC = "pgAudit - An audit logging extension for PostgreSQL"
 
 REGRESS = pgaudit
-REGRESS_OPTS = --temp-config=$(top_srcdir)/contrib/pgaudit/pgaudit.conf
 
 ifdef USE_PGXS
 PG_CONFIG = pg_config

--- a/gpcontrib/pgaudit/pgaudit.conf
+++ b/gpcontrib/pgaudit/pgaudit.conf
@@ -1,1 +1,0 @@
-shared_preload_libraries = pgaudit


### PR DESCRIPTION
The `Makefile` previously referenced a configuration file via `REGRESS_OPTS` with an incorrect path (`contrib/pgaudit/` instead of `gpcontrib/pgaudit/`). 

Despite this broken path, the regression tests continued to pass successfully. This indicates that the custom configuration file was redundant and the tests do not actually require these specific overrides to function correctly. 

Removing this obsolete logic simplifies the build system and eliminates confusion caused by the stale, non-functional path reference.