### PR TITLE
Add extension for AST-based audit logging

### DIFF
--- a/gpcontrib/Makefile
+++ b/gpcontrib/Makefile
@@ -13,6 +13,7 @@ recurse_targets = ""
 
 ifeq "$(enable_debug_extensions)" "yes"
 	recurse_targets = access_log \
+			   ast_log \
                gp_sparse_vector \
                gp_distribution_policy \
                gp_parallel_retrieve_cursor \
@@ -32,6 +33,7 @@ ifeq "$(enable_debug_extensions)" "yes"
                temp_tables_stat
 else
 	recurse_targets = access_log \
+			   ast_log \
                gp_sparse_vector \
                gp_distribution_policy \
                gp_parallel_retrieve_cursor \
@@ -143,6 +145,7 @@ distclean:
 
 installcheck:
 	$(MAKE) -C access_log installcheck
+	$(MAKE) -C ast_log installcheck
 	$(MAKE) -C gp_internal_tools installcheck
 	$(MAKE) -C gp_array_agg installcheck
 	$(MAKE) -C gp_aux_catalog installcheck

--- a/gpcontrib/ast_log/Makefile
+++ b/gpcontrib/ast_log/Makefile
@@ -1,0 +1,17 @@
+# gpcontrib/ast_log/Makefile
+
+MODULE_big = ast_log
+OBJS = ast_log.o
+
+REGRESS = ast_log
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = gpcontrib/ast_log
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/gpcontrib/ast_log/README.md
+++ b/gpcontrib/ast_log/README.md
@@ -1,0 +1,64 @@
+# ast_log
+
+This extension provides detailed logging of Query Abstract Syntax Trees (AST) for Greenplum Database.
+
+Unlike standard statement logging which records the raw SQL text, `ast_log` captures the internal parsed representation of queries as seen by the planner. This provides a structured view of the query logic, including target lists, join trees, and qualifications, which is essential for deep query analysis, optimizer debugging, and automated query understanding.
+
+The `ast_log` module hooks into the planner and utility execution phases to intercept queries and log their AST representation to a dedicated log file. It is designed to be lightweight and compatible with Greenplum 6 (PostgreSQL 9.4).
+
+## Key Features
+
+- **AST Logging**: Logs the internal node structure of `INSERT ... SELECT` statements (plain `INSERT ... VALUES` without a data source is not logged).
+- **CTAS Support**: Specifically handles `CREATE TABLE AS SELECT` (including `SELECT INTO` and `CREATE MATERIALIZED VIEW`) to log the AST of the underlying query separately from the DDL command.
+- **Granular Control**: Each class of statements (CTAS, INSERT) is controlled by its own independent GUC.
+- **Greenplum Aware**: Runs exclusively on the Coordinator (Master) node, avoiding noise on segment nodes.
+- **Dedicated Log File**: Writes audit records to `pg_log/ast.log` with timestamps and session information.
+
+## Log Format
+
+Each line in `pg_log/ast.log` is a CSV record with the following fields:
+
+- Timestamp (`YYYY-MM-DD HH:MM:SS.uuuuuu`)
+- Session ID (`gp_session_id`)
+- Statement class: `CTAS` or `INSERT`
+- Fully-qualified target object name (e.g. `public.mytable`)
+- Serialized query AST with a dictionary of referenced tables/functions
+
+
+## Configuration Parameters
+
+The following parameters can be configured via `SET` command. All settings require superuser privileges.
+
+### ast_log.ctas
+
+Enables logging of the AST for the query part of `CREATE TABLE AS SELECT` (also covers `SELECT INTO` and `CREATE MATERIALIZED VIEW`).
+
+Default: `off`.
+
+### ast_log.insert
+
+Enables logging of the AST for `INSERT ... SELECT` statements.
+
+Default: `off`.
+
+### Example:
+
+```
+SET ast_log.ctas = on;
+SET ast_log.insert = on;
+```
+
+## Installation
+
+Load the extension in the current session:
+
+```
+LOAD '$libdir/ast_log';
+```
+
+Or load automatically at server start (Coordinator only):
+
+```
+gpconfig -c shared_preload_libraries -v '' -m 'ast_log'
+gpstop -ra
+```

--- a/gpcontrib/ast_log/ast_log.c
+++ b/gpcontrib/ast_log/ast_log.c
@@ -1,0 +1,583 @@
+#include "postgres.h"
+
+#include <sys/file.h>
+#include <unistd.h>
+
+#include "access/xact.h"
+#include "catalog/namespace.h"
+#include "catalog/pg_proc.h"
+#include "cdb/cdbvars.h"
+#include "commands/prepare.h"
+#include "funcapi.h"
+#include "optimizer/planner.h"
+#include "parser/parsetree.h"
+#include "rewrite/rewriteHandler.h"
+#include "tcop/utility.h"
+#include "utils/builtins.h"
+#include "utils/lsyscache.h"
+#include "utils/memutils.h"
+#include "utils/syscache.h"
+
+PG_MODULE_MAGIC;
+
+#define LOG_FILE_NAME "pg_log/ast.log"
+
+void _PG_init(void);
+
+static const char *const CLASS_CTAS   = "CTAS";
+static const char *const CLASS_INSERT = "INSERT";
+
+static bool ast_log_ctas = false;
+static bool ast_log_insert = false;
+
+static planner_hook_type next_planner_hook = NULL;
+static ProcessUtility_hook_type next_ProcessUtility_hook = NULL;
+
+typedef struct
+{
+	List *rel_oids;
+	List *func_oids;
+} QueryOids;
+
+static void
+write_to_log(const char *str, size_t len)
+{
+	size_t	off = 0;
+	int		f;
+
+	f = OpenTransientFile(LOG_FILE_NAME, O_WRONLY | O_APPEND | O_CREAT,
+						  S_IRUSR | S_IWUSR);
+	if (f < 0)
+	{
+		ereport(WARNING, (errcode_for_file_access(),
+				errmsg("could not open file " LOG_FILE_NAME ": %m")));
+		return;
+	}
+
+	while (flock(f, LOCK_EX) != 0 && errno == EINTR)
+		;
+
+	while (off < len)
+	{
+		ssize_t rc = write(f, str + off, len - off);
+
+		if (rc < 0)
+		{
+			if (errno == EINTR)
+				continue;
+
+			ereport(WARNING, (errcode_for_file_access(),
+					errmsg("could not write to file " LOG_FILE_NAME ": %m")));
+			break;
+		}
+		off += (size_t) rc;
+	}
+
+	CloseTransientFile(f);
+}
+
+static void
+append_valid_csv(StringInfo buffer, const char *appendStr)
+{
+	if (appendStr == NULL)
+		return;
+
+	if (strpbrk(appendStr, ",\"\n\r") == NULL)
+		appendStringInfoString(buffer, appendStr);
+	else
+	{
+		appendStringInfoCharMacro(buffer, '"');
+
+		for (const char *pChar = appendStr; *pChar; pChar++)
+		{
+			if (*pChar == '"')
+				appendStringInfoCharMacro(buffer, *pChar);
+
+			appendStringInfoCharMacro(buffer, *pChar);
+		}
+
+		appendStringInfoCharMacro(buffer, '"');
+	}
+}
+
+static void
+append_log_time(StringInfo buffer)
+{
+	struct timeval	tv;
+	pg_time_t		stamp_time;
+
+	/*
+	 * 19 ("YYYY-MM-DD HH:MM:SS") + 1 (".") + 6 (microseconds) + 1 ("\0").
+	 */
+	char			buf[19 + 1 + 6 + 1];
+
+	gettimeofday(&tv, NULL);
+	stamp_time = (pg_time_t) tv.tv_sec;
+
+	pg_strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S",
+				pg_localtime(&stamp_time, log_timezone));
+
+	sprintf(buf + 19, ".%06d", (int) tv.tv_usec);
+
+	appendStringInfoString(buffer, buf);
+}
+
+static bool
+walker_rel_and_func(Node *node, QueryOids *oids)
+{
+	if (node == NULL)
+		return false;
+
+	if (IsA(node, Query))
+		return query_tree_walker((Query *) node, walker_rel_and_func, oids,
+								 QTW_EXAMINE_RTES);
+
+	if (IsA(node, RangeTblEntry))
+	{
+		RangeTblEntry *rte = (RangeTblEntry *) node;
+
+		if (rte->rtekind == RTE_RELATION && OidIsValid(rte->relid))
+			oids->rel_oids = list_append_unique_oid(oids->rel_oids, rte->relid);
+
+		return false;
+	}
+
+	if (IsA(node, Aggref))
+		oids->func_oids = list_append_unique_oid(oids->func_oids,
+												 ((Aggref *) node)->aggfnoid);
+
+	if (IsA(node, WindowFunc))
+		oids->func_oids = list_append_unique_oid(oids->func_oids,
+												 ((WindowFunc *) node)->winfnoid);
+
+	if (IsA(node, FuncExpr))
+		oids->func_oids = list_append_unique_oid(oids->func_oids,
+												 ((FuncExpr *) node)->funcid);
+
+	return expression_tree_walker(node, walker_rel_and_func, oids);
+}
+
+static void
+append_attrs(StringInfo str, Oid classOid, int16 natts)
+{
+	for (AttrNumber n = 1; n <= natts; n++)
+	{
+		char *att = get_attname(classOid, n);
+
+		if (n > 1)
+			appendStringInfoChar(str, ',');
+
+		if (att == NULL)
+			continue;
+
+		appendStringInfoString(str, att);
+		pfree(att);
+	}
+}
+
+static void
+append_func_out_args(StringInfo str, HeapTuple htFunc)
+{
+	Form_pg_proc	func = (Form_pg_proc) GETSTRUCT(htFunc);
+	HeapTuple		htType;
+	HeapTuple		htRel;
+	Form_pg_class	rel;
+	Oid				typrelid;
+
+	if (func->prorettype == RECORDOID)
+	{
+		Oid	   *argtypes;
+		char  **argnames;
+		char   *argmodes;
+		int		numargs;
+		bool	printComma = false;
+
+		numargs = get_func_arg_info(htFunc, &argtypes, &argnames, &argmodes);
+		pfree(argtypes);
+
+		if (argmodes != NULL && argnames != NULL)
+		{
+			for (int i = 0; i < numargs; i++)
+			{
+				if (argmodes[i] != PROARGMODE_OUT &&
+					argmodes[i] != PROARGMODE_TABLE)
+					continue;
+
+				if (printComma)
+					appendStringInfoChar(str, ',');
+
+				if (argnames[i] != NULL)
+					appendStringInfoString(str, argnames[i]);
+
+				printComma = true;
+			}
+		}
+
+		if (argnames != NULL)
+		{
+			for (int i = 0; i < numargs; i++)
+				pfree(argnames[i]);
+			pfree(argnames);
+		}
+
+		if (argmodes != NULL)
+			pfree(argmodes);
+
+		return;
+	}
+
+	htType = SearchSysCache1(TYPEOID, ObjectIdGetDatum(func->prorettype));
+	if (!HeapTupleIsValid(htType))
+		return;
+
+	typrelid = ((Form_pg_type) GETSTRUCT(htType))->typrelid;
+	ReleaseSysCache(htType);
+
+	if (!OidIsValid(typrelid))
+		return;
+
+	htRel = SearchSysCache1(RELOID, ObjectIdGetDatum(typrelid));
+	if (!HeapTupleIsValid(htRel))
+		return;
+
+	rel = (Form_pg_class) GETSTRUCT(htRel);
+
+	append_attrs(str, typrelid, rel->relnatts);
+
+	ReleaseSysCache(htRel);
+}
+
+static void
+append_name(StringInfo str, char type, Oid oid, Oid namespaceOid, Name name)
+{
+	char *strNS = get_namespace_name(namespaceOid);
+
+	appendStringInfo(str, "{%c %u ", type, oid);
+
+	if (strNS != NULL)
+	{
+		appendStringInfo(str, "%s.", strNS);
+		pfree(strNS);
+	}
+
+	appendStringInfo(str, "%s {", NameStr(*name));
+}
+
+static char *
+query_to_text(Query *parse)
+{
+	ListCell	   *cell;
+	StringInfoData	str;
+	QueryOids		oids = {NIL, NIL};
+	char		   *parseStr = nodeToString(parse);
+
+	query_tree_walker(parse, walker_rel_and_func, &oids, QTW_EXAMINE_RTES);
+
+	if (oids.rel_oids == NIL && oids.func_oids == NIL)
+		return parseStr;
+
+	initStringInfo(&str);
+	appendStringInfoString(&str, parseStr);
+	pfree(parseStr);
+
+	foreach(cell, oids.rel_oids)
+	{
+		Oid			oid = lfirst_oid(cell);
+		HeapTuple	htRel = SearchSysCache1(RELOID, ObjectIdGetDatum(oid));
+
+		if (HeapTupleIsValid(htRel))
+		{
+			Form_pg_class reltup = (Form_pg_class) GETSTRUCT(htRel);
+
+			append_name(&str, 'r', oid, reltup->relnamespace, &reltup->relname);
+			append_attrs(&str, oid, reltup->relnatts);
+			appendStringInfoString(&str, "}}");
+
+			ReleaseSysCache(htRel);
+		}
+	}
+	list_free(oids.rel_oids);
+
+	foreach(cell, oids.func_oids)
+	{
+		Oid			oid = lfirst_oid(cell);
+		HeapTuple	htFunc = SearchSysCache1(PROCOID, ObjectIdGetDatum(oid));
+
+		if (HeapTupleIsValid(htFunc))
+		{
+			Form_pg_proc func = (Form_pg_proc) GETSTRUCT(htFunc);
+
+			append_name(&str, 'f', oid, func->pronamespace, &func->proname);
+
+			if (func->proretset)
+				append_func_out_args(&str, htFunc);
+
+			appendStringInfoString(&str, "}}");
+
+			ReleaseSysCache(htFunc);
+		}
+	}
+	list_free(oids.func_oids);
+
+	return str.data;
+}
+
+static void
+log_audit_record(const char *className, const char *objName,
+				 const char *astText)
+{
+	StringInfoData	buf;
+
+	initStringInfo(&buf);
+
+	append_log_time(&buf);
+	appendStringInfo(&buf, ",%d,%s,",
+					 gp_session_id, className);
+
+	append_valid_csv(&buf, objName);
+	appendStringInfoChar(&buf, ',');
+	append_valid_csv(&buf, astText);
+	appendStringInfoChar(&buf, '\n');
+
+	write_to_log(buf.data, buf.len);
+
+	pfree(buf.data);
+}
+
+static bool
+ast_log_active(void)
+{
+	if (Gp_role != GP_ROLE_DISPATCH && Gp_role != GP_ROLE_UTILITY)
+		return false;
+
+	if (IsAbortedTransactionBlockState())
+		return false;
+
+	return true;
+}
+
+static void
+log_query_ast(Query *parse, bool rewrite,
+			  const char *className, const char *objName)
+{
+	static MemoryContext	astLogContext = NULL;
+	MemoryContext			oldContext;
+	Query					*finalQuery = parse;
+
+	if (astLogContext == NULL)
+		astLogContext = AllocSetContextCreate(TopMemoryContext,
+											  "ast_log context",
+											  ALLOCSET_DEFAULT_MINSIZE,
+											  ALLOCSET_DEFAULT_INITSIZE,
+											  ALLOCSET_DEFAULT_MAXSIZE);
+
+	oldContext = MemoryContextSwitchTo(astLogContext);
+
+
+	if (rewrite)
+	{
+		List *rewritten = QueryRewrite((Query *) copyObject(parse));
+
+		if (list_length(rewritten) != 1)
+			ereport(ERROR,
+					(errmsg("ast_log: unexpected rewrite result")));
+
+		finalQuery = (Query *) linitial(rewritten);
+	}
+
+	log_audit_record(className, objName, query_to_text(finalQuery));
+
+	MemoryContextSwitchTo(oldContext);
+	MemoryContextReset(astLogContext);
+}
+
+static char *
+result_relation_name(Query *parse)
+{
+	RangeTblEntry *rte;
+
+	rte = rt_fetch(parse->resultRelation, parse->rtable);
+
+	if (rte->rtekind != RTE_RELATION)
+		return NULL;
+
+	return quote_qualified_identifier(
+				get_namespace_name(get_rel_namespace(rte->relid)),
+				get_rel_name(rte->relid));
+}
+
+/*
+ * Over-logging these harmless false positives is preferable to
+ * the extra complexity of ruling them out:
+ * 1) INSERT INTO t SELECT 1
+ * 2) INSERT ... VALUES (...) RETURNING (SELECT ...)
+ */
+static bool
+insert_has_source(Query *parse)
+{
+	ListCell   *cell;
+	int			rtindex = 0;
+
+	if (parse->hasSubLinks)
+		return true;
+
+	foreach(cell, parse->rtable)
+	{
+		RangeTblEntry *rte = (RangeTblEntry *) lfirst(cell);
+
+		if (++rtindex == parse->resultRelation)
+			continue;
+
+		if (rte->rtekind == RTE_VALUES)
+			continue;
+
+		if (rte->rtekind == RTE_RELATION && !rte->inFromCl)
+			continue;
+
+		return true;
+	}
+
+	return false;
+}
+
+static Query *
+resolve_ctas_query(Node *node)
+{
+	Query *query;
+
+	if (node == NULL || !IsA(node, Query))
+		return NULL;
+
+	query = (Query *) node;
+
+	if (query->commandType == CMD_UTILITY &&
+		query->utilityStmt != NULL &&
+		IsA(query->utilityStmt, ExecuteStmt))
+	{
+		ExecuteStmt		   *execStmt = (ExecuteStmt *) query->utilityStmt;
+		PreparedStatement  *entry = FetchPreparedStatement(execStmt->name, false);
+
+		if (entry == NULL || entry->plansource == NULL ||
+			list_length(entry->plansource->query_list) != 1)
+			return NULL;
+
+		return (Query *) linitial(entry->plansource->query_list);
+	}
+
+	return query;
+}
+
+static void
+process_utility_ast(Node *parsetree)
+{
+	CreateTableAsStmt  *ctas;
+	Query			   *query;
+	char			   *tableName = NULL;
+
+	if (!IsA(parsetree, CreateTableAsStmt))
+		return;
+
+	if (!ast_log_ctas || !ast_log_active())
+		return;
+
+	ctas = (CreateTableAsStmt *) parsetree;
+
+	query = resolve_ctas_query(ctas->query);
+	if (query == NULL)
+		return;
+
+	if (ctas->into != NULL && ctas->into->rel != NULL)
+	{
+		RangeVar   *rv = ctas->into->rel;
+		char	   *schemaName = rv->schemaname;
+
+		if (schemaName == NULL)
+			schemaName = get_namespace_name(RangeVarGetCreationNamespace(rv));
+
+		tableName = quote_qualified_identifier(schemaName, rv->relname);
+	}
+
+	log_query_ast(query, true, CLASS_CTAS, tableName);
+
+	if (tableName != NULL)
+		pfree(tableName);
+}
+
+static PlannedStmt *
+ast_log_planner_hook(Query *parse, int cursorOptions, ParamListInfo boundParams)
+{
+	if (parse->commandType == CMD_INSERT &&
+		ast_log_insert && ast_log_active() &&
+		insert_has_source(parse))
+	{
+		char *objName = result_relation_name(parse);
+
+		log_query_ast(parse, false, CLASS_INSERT, objName);
+
+		if (objName != NULL)
+			pfree(objName);
+	}
+
+	if (next_planner_hook)
+		return (*next_planner_hook) (parse, cursorOptions, boundParams);
+	else
+		return standard_planner(parse, cursorOptions, boundParams);
+}
+
+static void
+ast_log_ProcessUtility_hook(Node *parsetree,
+							const char *queryString,
+							ProcessUtilityContext context,
+							ParamListInfo params,
+							DestReceiver *dest,
+							char *completionTag)
+{
+	if (next_ProcessUtility_hook)
+		(*next_ProcessUtility_hook) (parsetree, queryString, context,
+									 params, dest, completionTag);
+	else
+		standard_ProcessUtility(parsetree, queryString, context,
+								params, dest, completionTag);
+
+	process_utility_ast(parsetree);
+}
+
+void
+_PG_init(void)
+{
+	if (Gp_role == GP_ROLE_EXECUTE)
+		return;
+
+	DefineCustomBoolVariable(
+		"ast_log.ctas",
+		"Logs the AST of the underlying query of CREATE TABLE AS SELECT "
+		"(also covers SELECT INTO and CREATE MATERIALIZED VIEW).",
+		NULL,
+		&ast_log_ctas,
+		false,
+		PGC_SUSET,
+		0,
+		NULL,
+		NULL,
+		NULL);
+
+	DefineCustomBoolVariable(
+		"ast_log.insert",
+		"Logs the AST of INSERT ... SELECT statements.",
+		NULL,
+		&ast_log_insert,
+		false,
+		PGC_SUSET,
+		0,
+		NULL,
+		NULL,
+		NULL);
+
+	EmitWarningsOnPlaceholders("ast_log");
+
+	next_planner_hook = planner_hook;
+	planner_hook = ast_log_planner_hook;
+
+	next_ProcessUtility_hook = ProcessUtility_hook;
+	ProcessUtility_hook = ast_log_ProcessUtility_hook;
+}

--- a/gpcontrib/ast_log/expected/ast_log.out
+++ b/gpcontrib/ast_log/expected/ast_log.out
@@ -1,0 +1,294 @@
+-- start_matchsubs
+-- m/\{r \d+ /
+-- s/\{r \d+ /{r XXXX /g
+-- m/\{f \d+ /
+-- s/\{f \d+ /{f XXXX /g
+-- end_matchsubs
+\set VERBOSITY terse
+--------------------------------------------------------------------------------
+-- checking EmitWarningsOnPlaceholders  
+--------------------------------------------------------------------------------
+SET ast_log.unexist = on;
+LOAD '$libdir/ast_log';
+WARNING:  unrecognized configuration parameter "ast_log.unexist"
+DO
+$$
+DECLARE
+  location text;
+BEGIN
+  SELECT 'file://' || hostname || ':' || port || datadir || '/pg_log/ast.log'
+    INTO STRICT location
+    FROM gp_segment_configuration
+   WHERE role = 'p' AND content = -1;
+
+  EXECUTE format(
+    'CREATE EXTERNAL TABLE ast_log_external
+       (logtime timestamp,
+        session_id int, class text, objname text, asttext text)
+     LOCATION (%L) FORMAT ''csv''',
+    location);
+END $$;
+CREATE FUNCTION reset_ast_log() RETURNS void AS $$
+BEGIN
+  PERFORM pg_file_unlink('pg_log/ast.log');
+  PERFORM pg_file_write('pg_log/ast.log', '', false);
+END $$ LANGUAGE plpgsql;
+CREATE FUNCTION show_ast_log()
+  RETURNS TABLE(class text, objname text, asttext text)
+AS $$
+  SELECT class, coalesce(objname, '<null>'),
+    CASE
+      WHEN asttext NOT LIKE '{QUERY %' THEN
+        '<MALFORMED AST>'
+      WHEN position('{r ' IN asttext) > 0 THEN
+        '{QUERY ...}' || substr(asttext, position('{r ' IN asttext))
+      WHEN position('{f ' IN asttext) > 0 THEN
+        '{QUERY ...}' || substr(asttext, position('{f ' IN asttext))
+      ELSE
+        '{QUERY ...}'
+    END
+  FROM ast_log_external
+  WHERE session_id = current_setting('gp_session_id')::integer
+  ORDER BY logtime;
+$$ LANGUAGE sql;
+CREATE TABLE test_src AS SELECT id, data FROM (VALUES (1, 'a'), (2, 'b'), (3, 'c')) AS t(id, data) DISTRIBUTED BY (id);
+CREATE TABLE test_dst (id int, data text) DISTRIBUTED BY (id);
+CREATE TYPE srf_composite_a AS (id int, data text);
+CREATE TYPE srf_composite_b AS (val int, label text);
+CREATE FUNCTION srf_table() RETURNS TABLE(out_id int, out_data text) AS
+  $$ SELECT 1, 'a'::text $$ LANGUAGE sql IMMUTABLE;
+CREATE FUNCTION srf_composite_a() RETURNS SETOF srf_composite_a AS
+  $$ SELECT 1, 'a'::text $$ LANGUAGE sql IMMUTABLE;
+CREATE FUNCTION srf_composite_b() RETURNS SETOF srf_composite_b AS
+  $$ SELECT 2, 'b'::text $$ LANGUAGE sql IMMUTABLE;
+--------------------------------------------------------------------------------
+-- 1. GUC: both off by default, nothing is logged
+--------------------------------------------------------------------------------
+SELECT reset_ast_log();
+ reset_ast_log 
+---------------
+ 
+(1 row)
+
+INSERT INTO test_dst SELECT * FROM test_src;
+CREATE TABLE test_ctas AS SELECT * FROM test_src DISTRIBUTED BY (id);
+SELECT * FROM show_ast_log();
+ class | objname | asttext 
+-------+---------+---------
+(0 rows)
+
+DROP TABLE test_ctas;
+--------------------------------------------------------------------------------
+-- 2. ast_log.insert: negative cases
+--------------------------------------------------------------------------------
+SET ast_log.insert = on;
+SELECT pg_file_unlink('pg_log/ast.log');
+ pg_file_unlink 
+----------------
+ t
+(1 row)
+
+INSERT INTO test_dst SELECT * FROM test_src;
+SELECT * FROM show_ast_log();
+ class  |     objname     |                                      asttext                                      
+--------+-----------------+-----------------------------------------------------------------------------------
+ INSERT | public.test_dst | {QUERY ...}{r 16820 public.test_dst {id,data}}{r 16814 public.test_src {id,data}}
+(1 row)
+
+SELECT reset_ast_log();
+ reset_ast_log 
+---------------
+ 
+(1 row)
+
+INSERT INTO test_dst VALUES (1, 'x');
+SELECT * FROM show_ast_log();
+ class | objname | asttext 
+-------+---------+---------
+(0 rows)
+
+SELECT reset_ast_log();
+ reset_ast_log 
+---------------
+ 
+(1 row)
+
+SELECT count(*) FROM test_src;
+ count 
+-------
+     3
+(1 row)
+
+UPDATE test_dst SET data = 'y' WHERE id = 1;
+DELETE FROM test_dst WHERE id = 1;
+SELECT * FROM show_ast_log();
+ class | objname | asttext 
+-------+---------+---------
+(0 rows)
+
+--------------------------------------------------------------------------------
+-- 3. ast_log.insert: positive cases
+--------------------------------------------------------------------------------
+SELECT reset_ast_log();
+ reset_ast_log 
+---------------
+ 
+(1 row)
+
+INSERT INTO test_dst SELECT * FROM srf_table();
+SELECT * FROM show_ast_log();
+ class  |     objname     |                                          asttext                                           
+--------+-----------------+--------------------------------------------------------------------------------------------
+ INSERT | public.test_dst | {QUERY ...}{r 16820 public.test_dst {id,data}}{f 16832 public.srf_table {out_id,out_data}}
+(1 row)
+
+SELECT reset_ast_log();
+ reset_ast_log 
+---------------
+ 
+(1 row)
+
+INSERT INTO test_dst SELECT id, data FROM srf_composite_a();
+SELECT * FROM show_ast_log();
+ class  |     objname     |                                         asttext                                          
+--------+-----------------+------------------------------------------------------------------------------------------
+ INSERT | public.test_dst | {QUERY ...}{r 16820 public.test_dst {id,data}}{f 16833 public.srf_composite_a {id,data}}
+(1 row)
+
+SELECT reset_ast_log();
+ reset_ast_log 
+---------------
+ 
+(1 row)
+
+INSERT INTO test_dst SELECT a.id, b.label FROM srf_composite_a() a, srf_composite_b() b;
+SELECT * FROM show_ast_log();
+ class  |     objname     |                                                               asttext                                                                
+--------+-----------------+--------------------------------------------------------------------------------------------------------------------------------------
+ INSERT | public.test_dst | {QUERY ...}{r 16820 public.test_dst {id,data}}{f 16833 public.srf_composite_a {id,data}}{f 16834 public.srf_composite_b {val,label}}
+(1 row)
+
+SET ast_log.insert = off;
+--------------------------------------------------------------------------------
+-- 4. ast_log.ctas: positive cases
+--------------------------------------------------------------------------------
+SET ast_log.ctas = on;
+SELECT reset_ast_log();
+ reset_ast_log 
+---------------
+ 
+(1 row)
+
+CREATE TABLE test_ctas AS SELECT * FROM test_src DISTRIBUTED BY (id);
+SELECT * FROM show_ast_log();
+ class |     objname      |                    asttext                     
+-------+------------------+------------------------------------------------
+ CTAS  | public.test_ctas | {QUERY ...}{r 16814 public.test_src {id,data}}
+(1 row)
+
+DROP TABLE test_ctas;
+SELECT reset_ast_log();
+ reset_ast_log 
+---------------
+ 
+(1 row)
+
+CREATE MATERIALIZED VIEW test_matview AS SELECT * FROM test_src DISTRIBUTED BY (id);
+SELECT * FROM show_ast_log();
+ class |       objname       |                    asttext                     
+-------+---------------------+------------------------------------------------
+ CTAS  | public.test_matview | {QUERY ...}{r 16814 public.test_src {id,data}}
+(1 row)
+
+DROP MATERIALIZED VIEW test_matview;
+SELECT reset_ast_log();
+ reset_ast_log 
+---------------
+ 
+(1 row)
+
+CREATE TABLE test_ctas AS SELECT a.id, b.label FROM srf_composite_a() a, srf_composite_b() b DISTRIBUTED BY (id);
+SELECT * FROM show_ast_log();
+ class |     objname      |                                              asttext                                              
+-------+------------------+---------------------------------------------------------------------------------------------------
+ CTAS  | public.test_ctas | {QUERY ...}{f 16833 public.srf_composite_a {id,data}}{f 16834 public.srf_composite_b {val,label}}
+(1 row)
+
+DROP TABLE test_ctas;
+SELECT reset_ast_log();
+ reset_ast_log 
+---------------
+ 
+(1 row)
+
+PREPARE ctas_stmt AS SELECT * FROM test_src;
+CREATE TABLE test_ctas_exec AS EXECUTE ctas_stmt;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+SELECT * FROM show_ast_log();
+ class |        objname        |                    asttext                     
+-------+-----------------------+------------------------------------------------
+ CTAS  | public.test_ctas_exec | {QUERY ...}{r 16814 public.test_src {id,data}}
+(1 row)
+
+DEALLOCATE ctas_stmt;
+DROP TABLE test_ctas_exec;
+SET ast_log.ctas = off;
+--------------------------------------------------------------------------------
+-- 5. Both classes on
+--------------------------------------------------------------------------------
+SET ast_log.ctas = on;
+SET ast_log.insert = on;
+SELECT reset_ast_log();
+ reset_ast_log 
+---------------
+ 
+(1 row)
+
+INSERT INTO test_dst SELECT * FROM test_src;
+CREATE TABLE test_ctas AS SELECT * FROM test_dst DISTRIBUTED BY (id);
+SELECT * FROM show_ast_log();
+ class  |     objname      |                                      asttext                                      
+--------+------------------+-----------------------------------------------------------------------------------
+ CTAS   | public.test_ctas | {QUERY ...}{r 16820 public.test_dst {id,data}}
+ INSERT | public.test_dst  | {QUERY ...}{r 16820 public.test_dst {id,data}}{r 16814 public.test_src {id,data}}
+(2 rows)
+
+DROP TABLE test_ctas;
+SET ast_log.ctas = off;
+SET ast_log.insert = off;
+--------------------------------------------------------------------------------
+-- 6. Both classes off
+--------------------------------------------------------------------------------
+SELECT reset_ast_log();
+ reset_ast_log 
+---------------
+ 
+(1 row)
+
+INSERT INTO test_dst SELECT * FROM test_src;
+CREATE TABLE test_ctas AS SELECT * FROM test_src DISTRIBUTED BY (id);
+SELECT * FROM show_ast_log();
+ class | objname | asttext 
+-------+---------+---------
+(0 rows)
+
+DROP TABLE test_ctas;
+--------------------------------------------------------------------------------
+-- cleanup
+--------------------------------------------------------------------------------
+DROP FUNCTION show_ast_log();
+DROP FUNCTION reset_ast_log();
+DROP FUNCTION srf_table();
+DROP FUNCTION srf_composite_a();
+DROP FUNCTION srf_composite_b();
+DROP TYPE srf_composite_a, srf_composite_b;
+DROP EXTERNAL TABLE ast_log_external;
+DROP TABLE test_dst, test_src;
+RESET ast_log.ctas;
+RESET ast_log.insert;
+SELECT pg_file_unlink('pg_log/ast.log');
+ pg_file_unlink 
+----------------
+ t
+(1 row)
+

--- a/gpcontrib/ast_log/results/ast_log.out
+++ b/gpcontrib/ast_log/results/ast_log.out
@@ -1,0 +1,314 @@
+-- start_matchsubs
+-- m/\{r \d+ /
+-- s/\{r \d+ /{r XXXX /g
+-- m/\{f \d+ /
+-- s/\{f \d+ /{f XXXX /g
+-- end_matchsubs
+\set VERBOSITY terse
+--------------------------------------------------------------------------------
+-- checking EmitWarningsOnPlaceholders  
+--------------------------------------------------------------------------------
+SET ast_log.unexist = on;
+LOAD '$libdir/ast_log';
+WARNING:  unrecognized configuration parameter "ast_log.unexist"
+-- start_ignore
+DROP EXTERNAL TABLE IF EXISTS ast_log_external;
+NOTICE:  table "ast_log_external" does not exist, skipping
+DROP MATERIALIZED VIEW IF EXISTS test_matview;
+NOTICE:  materialized view "test_matview" does not exist, skipping
+DROP TABLE IF EXISTS test_src, test_dst, test_ctas, test_ctas_exec;
+NOTICE:  table "test_src" does not exist, skipping
+NOTICE:  table "test_dst" does not exist, skipping
+NOTICE:  table "test_ctas" does not exist, skipping
+NOTICE:  table "test_ctas_exec" does not exist, skipping
+DROP FUNCTION IF EXISTS srf_table();
+NOTICE:  function srf_table() does not exist, skipping
+DROP FUNCTION IF EXISTS srf_composite_a();
+NOTICE:  function srf_composite_a() does not exist, skipping
+DROP FUNCTION IF EXISTS srf_composite_b();
+NOTICE:  function srf_composite_b() does not exist, skipping
+DROP TYPE IF EXISTS srf_composite_a, srf_composite_b;
+NOTICE:  type "srf_composite_a" does not exist, skipping
+NOTICE:  type "srf_composite_b" does not exist, skipping
+-- end_ignore
+DO
+$$
+DECLARE
+  location text;
+BEGIN
+  SELECT 'file://' || hostname || ':' || port || datadir || '/pg_log/ast.log'
+    INTO STRICT location
+    FROM gp_segment_configuration
+   WHERE role = 'p' AND content = -1;
+
+  EXECUTE format(
+    'CREATE EXTERNAL TABLE ast_log_external
+       (logtime timestamp,
+        session_id int, class text, objname text, asttext text)
+     LOCATION (%L) FORMAT ''csv''',
+    location);
+END $$;
+CREATE FUNCTION reset_ast_log() RETURNS void AS $$
+BEGIN
+  PERFORM pg_file_unlink('pg_log/ast.log');
+  PERFORM pg_file_write('pg_log/ast.log', '', false);
+END $$ LANGUAGE plpgsql;
+CREATE FUNCTION show_ast_log()
+  RETURNS TABLE(class text, objname text, asttext text)
+AS $$
+  SELECT class, coalesce(objname, '<null>'),
+    CASE
+      WHEN asttext NOT LIKE '{QUERY %' THEN
+        '<MALFORMED AST>'
+      WHEN position('{r ' IN asttext) > 0 THEN
+        '{QUERY ...}' || substr(asttext, position('{r ' IN asttext))
+      WHEN position('{f ' IN asttext) > 0 THEN
+        '{QUERY ...}' || substr(asttext, position('{f ' IN asttext))
+      ELSE
+        '{QUERY ...}'
+    END
+  FROM ast_log_external
+  WHERE session_id = current_setting('gp_session_id')::integer
+  ORDER BY logtime;
+$$ LANGUAGE sql;
+CREATE TABLE test_src AS SELECT id, data FROM (VALUES (1, 'a'), (2, 'b'), (3, 'c')) AS t(id, data) DISTRIBUTED BY (id);
+CREATE TABLE test_dst (id int, data text) DISTRIBUTED BY (id);
+CREATE TYPE srf_composite_a AS (id int, data text);
+CREATE TYPE srf_composite_b AS (val int, label text);
+CREATE FUNCTION srf_table() RETURNS TABLE(out_id int, out_data text) AS
+  $$ SELECT 1, 'a'::text $$ LANGUAGE sql IMMUTABLE;
+CREATE FUNCTION srf_composite_a() RETURNS SETOF srf_composite_a AS
+  $$ SELECT 1, 'a'::text $$ LANGUAGE sql IMMUTABLE;
+CREATE FUNCTION srf_composite_b() RETURNS SETOF srf_composite_b AS
+  $$ SELECT 2, 'b'::text $$ LANGUAGE sql IMMUTABLE;
+--------------------------------------------------------------------------------
+-- 1. GUC: both off by default, nothing is logged
+--------------------------------------------------------------------------------
+SELECT reset_ast_log();
+ reset_ast_log 
+---------------
+ 
+(1 row)
+
+INSERT INTO test_dst SELECT * FROM test_src;
+CREATE TABLE test_ctas AS SELECT * FROM test_src DISTRIBUTED BY (id);
+SELECT * FROM show_ast_log();
+ class | objname | asttext 
+-------+---------+---------
+(0 rows)
+
+DROP TABLE test_ctas;
+--------------------------------------------------------------------------------
+-- 2. ast_log.insert: negative cases
+--------------------------------------------------------------------------------
+SET ast_log.insert = on;
+SELECT pg_file_unlink('pg_log/ast.log');
+ pg_file_unlink 
+----------------
+ t
+(1 row)
+
+INSERT INTO test_dst SELECT * FROM test_src;
+SELECT * FROM show_ast_log();
+ class  |     objname     |                                      asttext                                      
+--------+-----------------+-----------------------------------------------------------------------------------
+ INSERT | public.test_dst | {QUERY ...}{r 17450 public.test_dst {id,data}}{r 17444 public.test_src {id,data}}
+(1 row)
+
+SELECT reset_ast_log();
+ reset_ast_log 
+---------------
+ 
+(1 row)
+
+INSERT INTO test_dst VALUES (1, 'x');
+SELECT * FROM show_ast_log();
+ class | objname | asttext 
+-------+---------+---------
+(0 rows)
+
+SELECT reset_ast_log();
+ reset_ast_log 
+---------------
+ 
+(1 row)
+
+SELECT count(*) FROM test_src;
+ count 
+-------
+     3
+(1 row)
+
+UPDATE test_dst SET data = 'y' WHERE id = 1;
+DELETE FROM test_dst WHERE id = 1;
+SELECT * FROM show_ast_log();
+ class | objname | asttext 
+-------+---------+---------
+(0 rows)
+
+--------------------------------------------------------------------------------
+-- 3. ast_log.insert: positive cases
+--------------------------------------------------------------------------------
+SELECT reset_ast_log();
+ reset_ast_log 
+---------------
+ 
+(1 row)
+
+INSERT INTO test_dst SELECT * FROM srf_table();
+SELECT * FROM show_ast_log();
+ class  |     objname     |                                          asttext                                           
+--------+-----------------+--------------------------------------------------------------------------------------------
+ INSERT | public.test_dst | {QUERY ...}{r 17450 public.test_dst {id,data}}{f 17462 public.srf_table {out_id,out_data}}
+(1 row)
+
+SELECT reset_ast_log();
+ reset_ast_log 
+---------------
+ 
+(1 row)
+
+INSERT INTO test_dst SELECT id, data FROM srf_composite_a();
+SELECT * FROM show_ast_log();
+ class  |     objname     |                                         asttext                                          
+--------+-----------------+------------------------------------------------------------------------------------------
+ INSERT | public.test_dst | {QUERY ...}{r 17450 public.test_dst {id,data}}{f 17463 public.srf_composite_a {id,data}}
+(1 row)
+
+SELECT reset_ast_log();
+ reset_ast_log 
+---------------
+ 
+(1 row)
+
+INSERT INTO test_dst SELECT a.id, b.label FROM srf_composite_a() a, srf_composite_b() b;
+SELECT * FROM show_ast_log();
+ class  |     objname     |                                                               asttext                                                                
+--------+-----------------+--------------------------------------------------------------------------------------------------------------------------------------
+ INSERT | public.test_dst | {QUERY ...}{r 17450 public.test_dst {id,data}}{f 17463 public.srf_composite_a {id,data}}{f 17464 public.srf_composite_b {val,label}}
+(1 row)
+
+SET ast_log.insert = off;
+--------------------------------------------------------------------------------
+-- 4. ast_log.ctas: positive cases
+--------------------------------------------------------------------------------
+SET ast_log.ctas = on;
+SELECT reset_ast_log();
+ reset_ast_log 
+---------------
+ 
+(1 row)
+
+CREATE TABLE test_ctas AS SELECT * FROM test_src DISTRIBUTED BY (id);
+SELECT * FROM show_ast_log();
+ class |     objname      |                    asttext                     
+-------+------------------+------------------------------------------------
+ CTAS  | public.test_ctas | {QUERY ...}{r 17444 public.test_src {id,data}}
+(1 row)
+
+DROP TABLE test_ctas;
+SELECT reset_ast_log();
+ reset_ast_log 
+---------------
+ 
+(1 row)
+
+CREATE MATERIALIZED VIEW test_matview AS SELECT * FROM test_src DISTRIBUTED BY (id);
+SELECT * FROM show_ast_log();
+ class |       objname       |                    asttext                     
+-------+---------------------+------------------------------------------------
+ CTAS  | public.test_matview | {QUERY ...}{r 17444 public.test_src {id,data}}
+(1 row)
+
+DROP MATERIALIZED VIEW test_matview;
+SELECT reset_ast_log();
+ reset_ast_log 
+---------------
+ 
+(1 row)
+
+CREATE TABLE test_ctas AS SELECT a.id, b.label FROM srf_composite_a() a, srf_composite_b() b DISTRIBUTED BY (id);
+SELECT * FROM show_ast_log();
+ class |     objname      |                                              asttext                                              
+-------+------------------+---------------------------------------------------------------------------------------------------
+ CTAS  | public.test_ctas | {QUERY ...}{f 17463 public.srf_composite_a {id,data}}{f 17464 public.srf_composite_b {val,label}}
+(1 row)
+
+DROP TABLE test_ctas;
+SELECT reset_ast_log();
+ reset_ast_log 
+---------------
+ 
+(1 row)
+
+PREPARE ctas_stmt AS SELECT * FROM test_src;
+CREATE TABLE test_ctas_exec AS EXECUTE ctas_stmt;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+SELECT * FROM show_ast_log();
+ class |        objname        |                    asttext                     
+-------+-----------------------+------------------------------------------------
+ CTAS  | public.test_ctas_exec | {QUERY ...}{r 17444 public.test_src {id,data}}
+(1 row)
+
+DEALLOCATE ctas_stmt;
+DROP TABLE test_ctas_exec;
+SET ast_log.ctas = off;
+--------------------------------------------------------------------------------
+-- 5. Both classes on
+--------------------------------------------------------------------------------
+SET ast_log.ctas = on;
+SET ast_log.insert = on;
+SELECT reset_ast_log();
+ reset_ast_log 
+---------------
+ 
+(1 row)
+
+INSERT INTO test_dst SELECT * FROM test_src;
+CREATE TABLE test_ctas AS SELECT * FROM test_dst DISTRIBUTED BY (id);
+SELECT * FROM show_ast_log();
+ class  |     objname      |                                      asttext                                      
+--------+------------------+-----------------------------------------------------------------------------------
+ INSERT | public.test_dst  | {QUERY ...}{r 17450 public.test_dst {id,data}}{r 17444 public.test_src {id,data}}
+ CTAS   | public.test_ctas | {QUERY ...}{r 17450 public.test_dst {id,data}}
+(2 rows)
+
+DROP TABLE test_ctas;
+SET ast_log.ctas = off;
+SET ast_log.insert = off;
+--------------------------------------------------------------------------------
+-- 6. Both classes off
+--------------------------------------------------------------------------------
+SELECT reset_ast_log();
+ reset_ast_log 
+---------------
+ 
+(1 row)
+
+INSERT INTO test_dst SELECT * FROM test_src;
+CREATE TABLE test_ctas AS SELECT * FROM test_src DISTRIBUTED BY (id);
+SELECT * FROM show_ast_log();
+ class | objname | asttext 
+-------+---------+---------
+(0 rows)
+
+DROP TABLE test_ctas;
+--------------------------------------------------------------------------------
+-- cleanup
+--------------------------------------------------------------------------------
+DROP FUNCTION show_ast_log();
+DROP FUNCTION reset_ast_log();
+DROP FUNCTION srf_table();
+DROP FUNCTION srf_composite_a();
+DROP FUNCTION srf_composite_b();
+DROP TYPE srf_composite_a, srf_composite_b;
+DROP EXTERNAL TABLE ast_log_external;
+DROP TABLE test_dst, test_src;
+RESET ast_log.ctas;
+RESET ast_log.insert;
+SELECT pg_file_unlink('pg_log/ast.log');
+ pg_file_unlink 
+----------------
+ t
+(1 row)
+

--- a/gpcontrib/ast_log/sql/ast_log.sql
+++ b/gpcontrib/ast_log/sql/ast_log.sql
@@ -1,0 +1,205 @@
+-- start_matchsubs
+-- m/\{r \d+ /
+-- s/\{r \d+ /{r XXXX /g
+-- m/\{f \d+ /
+-- s/\{f \d+ /{f XXXX /g
+-- end_matchsubs
+
+\set VERBOSITY terse
+
+--------------------------------------------------------------------------------
+-- checking EmitWarningsOnPlaceholders  
+--------------------------------------------------------------------------------
+SET ast_log.unexist = on;
+
+LOAD '$libdir/ast_log';
+
+-- start_ignore
+DROP EXTERNAL TABLE IF EXISTS ast_log_external;
+DROP MATERIALIZED VIEW IF EXISTS test_matview;
+DROP TABLE IF EXISTS test_src, test_dst, test_ctas, test_ctas_exec;
+DROP FUNCTION IF EXISTS srf_table();
+DROP FUNCTION IF EXISTS srf_composite_a();
+DROP FUNCTION IF EXISTS srf_composite_b();
+DROP TYPE IF EXISTS srf_composite_a, srf_composite_b;
+-- end_ignore
+
+DO
+$$
+DECLARE
+  location text;
+BEGIN
+  SELECT 'file://' || hostname || ':' || port || datadir || '/pg_log/ast.log'
+    INTO STRICT location
+    FROM gp_segment_configuration
+   WHERE role = 'p' AND content = -1;
+
+  EXECUTE format(
+    'CREATE EXTERNAL TABLE ast_log_external
+       (logtime timestamp,
+        session_id int, class text, objname text, asttext text)
+     LOCATION (%L) FORMAT ''csv''',
+    location);
+END $$;
+
+CREATE FUNCTION reset_ast_log() RETURNS void AS $$
+BEGIN
+  PERFORM pg_file_unlink('pg_log/ast.log');
+  PERFORM pg_file_write('pg_log/ast.log', '', false);
+END $$ LANGUAGE plpgsql;
+
+CREATE FUNCTION show_ast_log()
+  RETURNS TABLE(class text, objname text, asttext text)
+AS $$
+  SELECT class, coalesce(objname, '<null>'),
+    CASE
+      WHEN asttext NOT LIKE '{QUERY %' THEN
+        '<MALFORMED AST>'
+      WHEN position('{r ' IN asttext) > 0 THEN
+        '{QUERY ...}' || substr(asttext, position('{r ' IN asttext))
+      WHEN position('{f ' IN asttext) > 0 THEN
+        '{QUERY ...}' || substr(asttext, position('{f ' IN asttext))
+      ELSE
+        '{QUERY ...}'
+    END
+  FROM ast_log_external
+  WHERE session_id = current_setting('gp_session_id')::integer
+  ORDER BY logtime;
+$$ LANGUAGE sql;
+
+CREATE TABLE test_src AS SELECT id, data FROM (VALUES (1, 'a'), (2, 'b'), (3, 'c')) AS t(id, data) DISTRIBUTED BY (id);
+CREATE TABLE test_dst (id int, data text) DISTRIBUTED BY (id);
+
+CREATE TYPE srf_composite_a AS (id int, data text);
+CREATE TYPE srf_composite_b AS (val int, label text);
+
+CREATE FUNCTION srf_table() RETURNS TABLE(out_id int, out_data text) AS
+  $$ SELECT 1, 'a'::text $$ LANGUAGE sql IMMUTABLE;
+
+CREATE FUNCTION srf_composite_a() RETURNS SETOF srf_composite_a AS
+  $$ SELECT 1, 'a'::text $$ LANGUAGE sql IMMUTABLE;
+
+CREATE FUNCTION srf_composite_b() RETURNS SETOF srf_composite_b AS
+  $$ SELECT 2, 'b'::text $$ LANGUAGE sql IMMUTABLE;
+
+--------------------------------------------------------------------------------
+-- 1. GUC: both off by default, nothing is logged
+--------------------------------------------------------------------------------
+
+SELECT reset_ast_log();
+INSERT INTO test_dst SELECT * FROM test_src;
+CREATE TABLE test_ctas AS SELECT * FROM test_src DISTRIBUTED BY (id);
+SELECT * FROM show_ast_log();
+DROP TABLE test_ctas;
+
+--------------------------------------------------------------------------------
+-- 2. ast_log.insert: negative cases
+--------------------------------------------------------------------------------
+
+SET ast_log.insert = on;
+
+SELECT pg_file_unlink('pg_log/ast.log');
+INSERT INTO test_dst SELECT * FROM test_src;
+SELECT * FROM show_ast_log();
+
+SELECT reset_ast_log();
+INSERT INTO test_dst VALUES (1, 'x');
+SELECT * FROM show_ast_log();
+
+SELECT reset_ast_log();
+SELECT count(*) FROM test_src;
+UPDATE test_dst SET data = 'y' WHERE id = 1;
+DELETE FROM test_dst WHERE id = 1;
+SELECT * FROM show_ast_log();
+
+--------------------------------------------------------------------------------
+-- 3. ast_log.insert: positive cases
+--------------------------------------------------------------------------------
+
+SELECT reset_ast_log();
+INSERT INTO test_dst SELECT * FROM srf_table();
+SELECT * FROM show_ast_log();
+
+SELECT reset_ast_log();
+INSERT INTO test_dst SELECT id, data FROM srf_composite_a();
+SELECT * FROM show_ast_log();
+
+SELECT reset_ast_log();
+INSERT INTO test_dst SELECT a.id, b.label FROM srf_composite_a() a, srf_composite_b() b;
+SELECT * FROM show_ast_log();
+
+SET ast_log.insert = off;
+
+--------------------------------------------------------------------------------
+-- 4. ast_log.ctas: positive cases
+--------------------------------------------------------------------------------
+
+SET ast_log.ctas = on;
+
+SELECT reset_ast_log();
+CREATE TABLE test_ctas AS SELECT * FROM test_src DISTRIBUTED BY (id);
+SELECT * FROM show_ast_log();
+DROP TABLE test_ctas;
+
+SELECT reset_ast_log();
+CREATE MATERIALIZED VIEW test_matview AS SELECT * FROM test_src DISTRIBUTED BY (id);
+SELECT * FROM show_ast_log();
+DROP MATERIALIZED VIEW test_matview;
+
+SELECT reset_ast_log();
+CREATE TABLE test_ctas AS SELECT a.id, b.label FROM srf_composite_a() a, srf_composite_b() b DISTRIBUTED BY (id);
+SELECT * FROM show_ast_log();
+DROP TABLE test_ctas;
+
+SELECT reset_ast_log();
+PREPARE ctas_stmt AS SELECT * FROM test_src;
+CREATE TABLE test_ctas_exec AS EXECUTE ctas_stmt;
+SELECT * FROM show_ast_log();
+DEALLOCATE ctas_stmt;
+DROP TABLE test_ctas_exec;
+
+SET ast_log.ctas = off;
+
+--------------------------------------------------------------------------------
+-- 5. Both classes on
+--------------------------------------------------------------------------------
+
+SET ast_log.ctas = on;
+SET ast_log.insert = on;
+
+SELECT reset_ast_log();
+INSERT INTO test_dst SELECT * FROM test_src;
+CREATE TABLE test_ctas AS SELECT * FROM test_dst DISTRIBUTED BY (id);
+SELECT * FROM show_ast_log();
+DROP TABLE test_ctas;
+
+SET ast_log.ctas = off;
+SET ast_log.insert = off;
+
+--------------------------------------------------------------------------------
+-- 6. Both classes off
+--------------------------------------------------------------------------------
+
+SELECT reset_ast_log();
+INSERT INTO test_dst SELECT * FROM test_src;
+CREATE TABLE test_ctas AS SELECT * FROM test_src DISTRIBUTED BY (id);
+SELECT * FROM show_ast_log();
+DROP TABLE test_ctas;
+
+--------------------------------------------------------------------------------
+-- cleanup
+--------------------------------------------------------------------------------
+
+DROP FUNCTION show_ast_log();
+DROP FUNCTION reset_ast_log();
+DROP FUNCTION srf_table();
+DROP FUNCTION srf_composite_a();
+DROP FUNCTION srf_composite_b();
+DROP TYPE srf_composite_a, srf_composite_b;
+DROP EXTERNAL TABLE ast_log_external;
+DROP TABLE test_dst, test_src;
+
+RESET ast_log.ctas;
+RESET ast_log.insert;
+
+SELECT pg_file_unlink('pg_log/ast.log');


### PR DESCRIPTION
Add `ast_log` extension that logs Query AST (Abstract Syntax Trees) for
`INSERT INTO ... SELECT` and `CREATE TABLE AS SELECT` statements.
Provide `ast_log.ctas` and `ast_log.insert` GUCs to enable logging for
each class of statements independently.

Co-Authored-By: andr-sokolov <sokolov.andrey.yurevich@gmail.com>